### PR TITLE
Add basic project skeleton, with trivial interpreter in place

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+
+namespace Perlang
+{
+    public abstract class Expr
+    {
+        public interface IVisitor<TR>
+        {
+            TR VisitAssignExpr(Assign expr);
+            TR VisitBinaryExpr(Binary expr);
+            TR VisitCallExpr(Call expr);
+            TR VisitGroupingExpr(Grouping expr);
+            TR VisitLiteralExpr(Literal expr);
+            TR VisitLogicalExpr(Logical expr);
+            TR VisitUnaryExpr(Unary expr);
+            TR VisitVariableExpr(Variable expr);
+        }
+
+        public class Assign : Expr
+        {
+            public Token Name { get; }
+            public Expr Value { get; }
+
+            public Assign(Token name, Expr value) {
+                Name = name;
+                Value = value;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitAssignExpr(this);
+            }
+        }
+
+        public class Binary : Expr
+        {
+            public Expr Left { get; }
+            public Token Operator { get; }
+            public Expr Right { get; }
+
+            public Binary(Expr left, Token _operator, Expr right) {
+                Left = left;
+                Operator = _operator;
+                Right = right;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitBinaryExpr(this);
+            }
+        }
+
+        public class Call : Expr
+        {
+            public Expr Callee { get; }
+            public Token Paren { get; }
+            public List<Expr> Arguments { get; }
+
+            public Call(Expr callee, Token paren, List<Expr> arguments) {
+                Callee = callee;
+                Paren = paren;
+                Arguments = arguments;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitCallExpr(this);
+            }
+        }
+
+        public class Grouping : Expr
+        {
+            public Expr Expression { get; }
+
+            public Grouping(Expr expression) {
+                Expression = expression;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitGroupingExpr(this);
+            }
+        }
+
+        public class Literal : Expr
+        {
+            public object Value { get; }
+
+            public Literal(object value) {
+                Value = value;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitLiteralExpr(this);
+            }
+        }
+
+        public class Logical : Expr
+        {
+            public Expr Left { get; }
+            public Token Operator { get; }
+            public Expr Right { get; }
+
+            public Logical(Expr left, Token _operator, Expr right) {
+                Left = left;
+                Operator = _operator;
+                Right = right;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitLogicalExpr(this);
+            }
+        }
+
+        public class Unary : Expr
+        {
+            public Token Operator { get; }
+            public Expr Right { get; }
+
+            public Unary(Token _operator, Expr right) {
+                Operator = _operator;
+                Right = right;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitUnaryExpr(this);
+            }
+        }
+
+        public class Variable : Expr
+        {
+            public Token Name { get; }
+
+            public Variable(Token name) {
+                Name = name;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitVariableExpr(this);
+            }
+        }
+
+        public abstract TR Accept<TR>(IVisitor<TR> visitor);
+    }
+}

--- a/Perlang.Common/Perlang.Common.csproj
+++ b/Perlang.Common/Perlang.Common.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <RootNamespace>Perlang</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/Perlang.Common/Stmt.cs
+++ b/Perlang.Common/Stmt.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+
+namespace Perlang
+{
+    public abstract class Stmt
+    {
+        public interface IVisitor<TR>
+        {
+            TR VisitBlockStmt(Block stmt);
+            TR VisitExpressionStmt(ExpressionStmt stmt);
+            TR VisitFunctionStmt(Function stmt);
+            TR VisitIfStmt(If stmt);
+            TR VisitPrintStmt(Print stmt);
+            TR VisitReturnStmt(Return stmt);
+            TR VisitVarStmt(Var stmt);
+            TR VisitWhileStmt(While stmt);
+        }
+
+        public class Block : Stmt
+        {
+            public List<Stmt> Statements { get; }
+
+            public Block(List<Stmt> statements) {
+                Statements = statements;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitBlockStmt(this);
+            }
+        }
+
+        public class ExpressionStmt : Stmt
+        {
+            public Expr Expression { get; }
+
+            public ExpressionStmt(Expr expression) {
+                Expression = expression;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitExpressionStmt(this);
+            }
+        }
+
+        public class Function : Stmt
+        {
+            public Token Name { get; }
+            public List<Token> Params { get; }
+            public List<Stmt> Body { get; }
+
+            public Function(Token name, List<Token> _params, List<Stmt> body) {
+                Name = name;
+                Params = _params;
+                Body = body;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitFunctionStmt(this);
+            }
+        }
+
+        public class If : Stmt
+        {
+            public Expr Condition { get; }
+            public Stmt ThenBranch { get; }
+            public Stmt ElseBranch { get; }
+
+            public If(Expr condition, Stmt thenBranch, Stmt elseBranch) {
+                Condition = condition;
+                ThenBranch = thenBranch;
+                ElseBranch = elseBranch;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitIfStmt(this);
+            }
+        }
+
+        public class Print : Stmt
+        {
+            public Expr Expression { get; }
+
+            public Print(Expr expression) {
+                Expression = expression;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitPrintStmt(this);
+            }
+        }
+
+        public class Return : Stmt
+        {
+            public Token Keyword { get; }
+            public Expr Value { get; }
+
+            public Return(Token keyword, Expr value) {
+                Keyword = keyword;
+                Value = value;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitReturnStmt(this);
+            }
+        }
+
+        public class Var : Stmt
+        {
+            public Token Name { get; }
+            public Expr Initializer { get; }
+
+            public Var(Token name, Expr initializer) {
+                Name = name;
+                Initializer = initializer;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitVarStmt(this);
+            }
+        }
+
+        public class While : Stmt
+        {
+            public Expr Condition { get; }
+            public Stmt Body { get; }
+
+            public While(Expr condition, Stmt body) {
+                Condition = condition;
+                Body = body;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitWhileStmt(this);
+            }
+        }
+
+        public abstract TR Accept<TR>(IVisitor<TR> visitor);
+    }
+}

--- a/Perlang.Common/Token.cs
+++ b/Perlang.Common/Token.cs
@@ -1,0 +1,23 @@
+namespace Perlang
+{
+    public class Token
+    {
+        public TokenType Type { get; }
+        public string Lexeme { get; }
+        public object Literal { get; }
+        public int Line { get; }
+
+        public Token(TokenType type, string lexeme, object literal, int line)
+        {
+            Type = type;
+            Lexeme = lexeme;
+            Literal = literal;
+            Line = line;
+        }
+
+        public override string ToString()
+        {
+            return $"{Type} {Lexeme} {Literal}";
+        }
+    }
+}

--- a/Perlang.Common/TokenType.cs
+++ b/Perlang.Common/TokenType.cs
@@ -1,0 +1,24 @@
+namespace Perlang
+{
+    public enum TokenType
+    {
+        // Single-character tokens.
+        LEFT_PAREN, RIGHT_PAREN, LEFT_BRACE, RIGHT_BRACE,
+        COMMA, DOT, MINUS, PLUS, SEMICOLON, SLASH, STAR,
+
+        // One or two character tokens.
+        BANG, BANG_EQUAL,
+        EQUAL, EQUAL_EQUAL,
+        GREATER, GREATER_EQUAL,
+        LESS, LESS_EQUAL,
+
+        // Literals.
+        IDENTIFIER, STRING, NUMBER,
+
+        // Keywords.
+        AND, CLASS, ELSE, FALSE, FUN, FOR, IF, NIL, OR,
+        PRINT, RETURN, SUPER, THIS, TRUE, VAR, WHILE,
+
+        EOF
+    }
+}

--- a/Perlang.Interpreter/ICallable.cs
+++ b/Perlang.Interpreter/ICallable.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Perlang.Interpreter
+{
+    internal interface ICallable
+    {
+        object Call(IInterpreter interpreter, List<object> arguments);
+        int Arity();
+    }
+}

--- a/Perlang.Interpreter/IInterpreter.cs
+++ b/Perlang.Interpreter/IInterpreter.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Perlang.Interpreter
+{
+    public interface IInterpreter
+    {
+        void ExecuteBlock(IEnumerable<Stmt> statements, PerlangEnvironment blockEnvironment);
+        void Resolve(Expr expr, int depth);
+    }
+}

--- a/Perlang.Interpreter/IResolveErrorHandler.cs
+++ b/Perlang.Interpreter/IResolveErrorHandler.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Interpreter
+{
+    internal interface IResolveErrorHandler
+    {
+        void ResolveError(Token name, string message);
+    }
+}

--- a/Perlang.Interpreter/IRuntimeErrorHandler.cs
+++ b/Perlang.Interpreter/IRuntimeErrorHandler.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Interpreter
+{
+    internal interface IRuntimeErrorHandler
+    {
+        void RuntimeError(RuntimeError error);
+    }
+}

--- a/Perlang.Interpreter/Perlang.Interpreter.csproj
+++ b/Perlang.Interpreter/Perlang.Interpreter.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Perlang.Common\Perlang.Common.csproj" />
+      <ProjectReference Include="..\Perlang.Parser\Perlang.Parser.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Perlang.Interpreter/PerlangEnvironment.cs
+++ b/Perlang.Interpreter/PerlangEnvironment.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+namespace Perlang.Interpreter
+{
+    /// <summary>
+    /// Holds information about the context for a static scope (functions and variable name bindings).
+    /// </summary>
+    public class PerlangEnvironment
+    {
+        private readonly PerlangEnvironment enclosing;
+
+        private readonly Dictionary<string, object> values = new Dictionary<string, object>();
+
+        public PerlangEnvironment(PerlangEnvironment enclosing = null)
+        {
+            this.enclosing = enclosing;
+        }
+
+        internal void Define(string name, object value)
+        {
+            values[name] = value;
+        }
+
+        internal object GetAt(int distance, string name)
+        {
+            return Ancestor(distance).values[name];
+        }
+
+        internal void AssignAt(int distance, Token name, object value)
+        {
+            Ancestor(distance).values[name.Lexeme] = value;
+        }
+
+        private PerlangEnvironment Ancestor(int distance)
+        {
+            PerlangEnvironment environment = this;
+
+            for (int i = 0; i < distance; i++)
+            {
+                environment = environment.enclosing;
+            }
+
+            return environment;
+        }
+
+        internal object Get(Token name)
+        {
+            if (values.ContainsKey(name.Lexeme))
+            {
+                return values[name.Lexeme];
+            }
+
+            // Fall-back to the enclosing scope if the variable isn't found in the current scope.
+            if (enclosing != null)
+            {
+                return enclosing.Get(name);
+            }
+
+            throw new RuntimeError(name, "Undefined variable '" + name.Lexeme + "'.");
+        }
+
+        internal void Assign(Token name, object value)
+        {
+            if (values.ContainsKey(name.Lexeme))
+            {
+                values[name.Lexeme] = value;
+                return;
+            }
+
+            if (enclosing != null)
+            {
+                enclosing.Assign(name, value);
+                return;
+            }
+
+            throw new RuntimeError(name, "Undefined variable '" + name.Lexeme + "'.");
+        }
+    }
+}

--- a/Perlang.Interpreter/PerlangFunction.cs
+++ b/Perlang.Interpreter/PerlangFunction.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace Perlang.Interpreter
+{
+    class PerlangFunction : ICallable
+    {
+        private readonly Stmt.Function declaration;
+        private readonly PerlangEnvironment closure;
+
+        internal PerlangFunction(Stmt.Function declaration, PerlangEnvironment closure)
+        {
+            this.declaration = declaration;
+            this.closure = closure;
+        }
+
+        public object Call(IInterpreter interpreter, List<object> arguments)
+        {
+            var environment = new PerlangEnvironment(closure);
+
+            for (int i = 0; i < declaration.Params.Count; i++)
+            {
+                environment.Define(declaration.Params[i].Lexeme, arguments[i]);
+            }
+
+            try
+            {
+                interpreter.ExecuteBlock(declaration.Body, environment);
+                return null;
+            }
+            catch (Return returnValue)
+            {
+                return returnValue.Value;
+            }
+        }
+
+        public int Arity()
+        {
+            return declaration.Params.Count;
+        }
+
+        public override string ToString()
+        {
+            return "<fn " + declaration.Name.Lexeme + ">";
+        }
+    }
+}

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Generic;
+using Perlang.Parser;
+using static Perlang.TokenType;
+
+namespace Perlang.Interpreter
+{
+    internal class PerlangInterpreter : IInterpreter, Expr.IVisitor<object>, Stmt.IVisitor<VoidObject>
+    {
+        private readonly IRuntimeErrorHandler runtimeErrorHandler;
+        private readonly PerlangEnvironment globals = new PerlangEnvironment();
+        private readonly IDictionary<Expr, int> locals = new Dictionary<Expr, int>();
+
+        private PerlangEnvironment perlangEnvironment;
+
+        public PerlangInterpreter(IRuntimeErrorHandler runtimeErrorHandler)
+        {
+            this.runtimeErrorHandler = runtimeErrorHandler;
+            
+            perlangEnvironment = globals;
+
+            globals.Define("clock", new ClockCallable());
+        }
+
+        internal void Interpret(IEnumerable<Stmt> statements)
+        {
+            try
+            {
+                foreach (Stmt statement in statements)
+                {
+                    Execute(statement);
+                }
+            }
+            catch (RuntimeError error)
+            {
+                runtimeErrorHandler.RuntimeError(error);
+            }
+        }
+
+        public object VisitLiteralExpr(Expr.Literal expr)
+        {
+            return expr.Value;
+        }
+
+        private class ClockCallable : ICallable
+        {
+            public int Arity()
+            {
+                return 0;
+            }
+
+            public object Call(IInterpreter interpreter, List<object> arguments)
+            {
+                return new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds() / 1000.0;
+            }
+
+            public override string ToString()
+            {
+                return "<native fn>";
+            }
+        }
+
+        public object VisitLogicalExpr(Expr.Logical expr)
+        {
+            object left = Evaluate(expr.Left);
+
+            if (expr.Operator.Type == OR)
+            {
+                if (IsTruthy(left)) return left;
+            }
+            else if (expr.Operator.Type == AND)
+            {
+                if (!IsTruthy(left)) return left;
+            }
+            else
+            {
+                throw new RuntimeError(expr.Operator, $"Unsupported logical operator: {expr.Operator.Type}");
+            }
+
+            return Evaluate(expr.Right);
+        }
+
+        public object VisitUnaryExpr(Expr.Unary expr)
+        {
+            object right = Evaluate(expr.Right);
+
+            switch (expr.Operator.Type)
+            {
+                case BANG:
+                    return !IsTruthy(right);
+
+                case MINUS:
+                    CheckNumberOperand(expr.Operator, right);
+                    return -(double) right;
+            }
+
+            // Unreachable.
+            return null;
+        }
+
+        public object VisitVariableExpr(Expr.Variable expr)
+        {
+            return LookUpVariable(expr.Name, expr);
+        }
+
+        private object LookUpVariable(Token name, Expr expr)
+        {
+            if (locals.TryGetValue(expr, out int distance))
+            {
+                return perlangEnvironment.GetAt(distance, name.Lexeme);
+            }
+            else
+            {
+                return globals.Get(name);
+            }
+        }
+
+        private static void CheckNumberOperand(Token _operator, object operand)
+        {
+            if (operand is double)
+            {
+                return;
+            }
+
+            throw new RuntimeError(_operator, "Operand must be a number.");
+        }
+
+        private static void CheckNumberOperands(Token _operator, object left, object right)
+        {
+            if (left is double && right is double)
+            {
+                return;
+            }
+
+            throw new RuntimeError(_operator, "Operands must be numbers.");
+        }
+
+        private static bool IsTruthy(object _object)
+        {
+            if (_object == null)
+            {
+                return false;
+            }
+
+            if (_object is bool b)
+            {
+                return b;
+            }
+
+            return true;
+        }
+
+        private static bool IsEqual(object a, object b)
+        {
+            // nil is only equal to nil.
+            if (a == null && b == null)
+            {
+                return true;
+            }
+
+            if (a == null)
+            {
+                return false;
+            }
+
+            return a.Equals(b);
+        }
+
+        private static string Stringify(object _object)
+        {
+            if (_object == null)
+            {
+                return "nil";
+            }
+
+            return _object.ToString();
+        }
+
+        public object VisitGroupingExpr(Expr.Grouping expr)
+        {
+            return Evaluate(expr.Expression);
+        }
+
+        internal object Evaluate(Expr expr)
+        {
+            return expr.Accept(this);
+        }
+
+        private void Execute(Stmt stmt)
+        {
+            stmt.Accept(this);
+        }
+
+        public void Resolve(Expr expr, int depth)
+        {
+            locals[expr] = depth;
+        }
+
+        public void ExecuteBlock(IEnumerable<Stmt> statements, PerlangEnvironment blockEnvironment)
+        {
+            PerlangEnvironment previous = perlangEnvironment;
+
+            try
+            {
+                perlangEnvironment = blockEnvironment;
+
+                foreach (Stmt statement in statements)
+                {
+                    Execute(statement);
+                }
+            }
+            finally
+            {
+                perlangEnvironment = previous;
+            }
+        }
+
+        public VoidObject VisitBlockStmt(Stmt.Block stmt)
+        {
+            ExecuteBlock(stmt.Statements, new PerlangEnvironment(perlangEnvironment));
+            return null;
+        }
+
+        public VoidObject VisitExpressionStmt(Stmt.ExpressionStmt stmt)
+        {
+            Evaluate(stmt.Expression);
+            return null;
+        }
+
+        public VoidObject VisitFunctionStmt(Stmt.Function stmt)
+        {
+            var function = new PerlangFunction(stmt, perlangEnvironment);
+            perlangEnvironment.Define(stmt.Name.Lexeme, function);
+            return null;
+        }
+
+        public VoidObject VisitIfStmt(Stmt.If stmt)
+        {
+            if (IsTruthy(Evaluate(stmt.Condition)))
+            {
+                Execute(stmt.ThenBranch);
+            }
+            else if (stmt.ElseBranch != null)
+            {
+                Execute(stmt.ElseBranch);
+            }
+
+            return null;
+        }
+
+        public VoidObject VisitPrintStmt(Stmt.Print stmt)
+        {
+            object value = Evaluate(stmt.Expression);
+            Console.WriteLine(Stringify(value));
+            return null;
+        }
+
+        public VoidObject VisitReturnStmt(Stmt.Return stmt)
+        {
+            object value = null;
+            if (stmt.Value != null) value = Evaluate(stmt.Value);
+
+            throw new Return(value);
+        }
+
+        public VoidObject VisitVarStmt(Stmt.Var stmt)
+        {
+            object value = null;
+            
+            if (stmt.Initializer != null)
+            {
+                value = Evaluate(stmt.Initializer);
+            }
+
+            perlangEnvironment.Define(stmt.Name.Lexeme, value);
+            return null;
+        }
+
+        public VoidObject VisitWhileStmt(Stmt.While stmt)
+        {
+            while (IsTruthy(Evaluate(stmt.Condition)))
+            {
+                Execute(stmt.Body);
+            }
+
+            return null;
+        }
+
+        public object VisitAssignExpr(Expr.Assign expr)
+        {
+            object value = Evaluate(expr.Value);
+
+            if (locals.TryGetValue(expr, out int distance))
+            {
+                perlangEnvironment.AssignAt(distance, expr.Name, value);
+            }
+            else
+            {
+                globals.Assign(expr.Name, value);
+            }
+
+            return value;
+        }
+
+        public object VisitBinaryExpr(Expr.Binary expr)
+        {
+            object left = Evaluate(expr.Left);
+            object right = Evaluate(expr.Right);
+
+            switch (expr.Operator.Type)
+            {
+                case GREATER:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left > (double) right;
+                case GREATER_EQUAL:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left >= (double) right;
+                case LESS:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left < (double) right;
+                case LESS_EQUAL:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left <= (double) right;
+                case MINUS:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left - (double) right;
+                case PLUS:
+                    if (left is double d1 && right is double d2)
+                    {
+                        return d1 + d2;
+                    }
+
+                    if (left is string s1 && right is string s2)
+                    {
+                        return s1 + s2;
+                    }
+
+                    throw new RuntimeError(expr.Operator, "Operands must be two numbers or two strings.");
+                case SLASH:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left / (double) right;
+                case STAR:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return (double) left * (double) right;
+                case BANG_EQUAL:
+                    return !IsEqual(left, right);
+                case EQUAL_EQUAL:
+                    return IsEqual(left, right);
+            }
+
+            // Unreachable.
+            return null;
+        }
+
+        public object VisitCallExpr(Expr.Call expr)
+        {
+            object callee = Evaluate(expr.Callee);
+
+            var arguments = new List<object>();
+
+            foreach (Expr argument in expr.Arguments)
+            {
+                arguments.Add(Evaluate(argument));
+            }
+
+            if (!(callee is ICallable))
+            {
+                throw new RuntimeError(expr.Paren, "Can only call functions and classes.");
+            }
+
+            var function = (ICallable) callee;
+
+            if (arguments.Count != function.Arity())
+            {
+                throw new RuntimeError(expr.Paren, "Expected " + function.Arity() + " arguments but got " +
+                                                   arguments.Count + ".");
+            }
+
+            return function.Call(this, arguments);
+        }
+    }
+}

--- a/Perlang.Interpreter/Program.cs
+++ b/Perlang.Interpreter/Program.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Perlang.Parser;
+
+namespace Perlang.Interpreter
+{
+    public class Program : IScannerErrorHandler, IResolveErrorHandler, IParseErrorHandler, IRuntimeErrorHandler
+    {
+        private readonly PerlangInterpreter interpreter;
+
+        private static bool hadError;
+        private static bool hadRuntimeError;
+
+        public static void Main(string[] args)
+        {
+            if (args.Length > 1)
+            {
+                Console.WriteLine("Usage: perlang [script]");
+                Environment.Exit(64);
+            }
+            else if (args.Length == 1)
+            {
+                new Program().RunFile(args[0]);
+            }
+            else
+            {
+                new Program().RunPrompt();
+            }
+        }
+
+        private Program()
+        {
+            interpreter = new PerlangInterpreter(this);
+        }
+
+        private void RunFile(string path)
+        {
+            var bytes = File.ReadAllBytes(path);
+            Run(Encoding.UTF8.GetString(bytes));
+
+            // Indicate an error in the exit code.
+            if (hadError)
+            {
+                Environment.Exit(65);
+            }
+
+            if (hadRuntimeError)
+            {
+                Environment.Exit(70);
+            }
+        }
+        
+        private void RunPrompt()
+        {
+            for (;;)
+            {
+                Console.Write("> ");
+                Run(Console.ReadLine());
+                hadError = false;
+            }
+        }
+        
+        private void Run(string source)
+        {
+            if (String.IsNullOrWhiteSpace(source))
+            {
+                return;
+            }
+
+            var scanner = new Scanner(source, this);
+
+            var tokens = scanner.ScanTokens();
+
+            // For now, just print the tokens.
+            var parser = new PerlangParser(tokens, this);
+            var statements = parser.ParseStatements();
+
+            // Stop if there was a syntax error.
+            if (!hadError)
+            {
+                var resolver = new Resolver(interpreter, this);
+                resolver.Resolve(statements);
+
+                // Stop if there was a resolution error.
+                if (hadError) return;
+
+                interpreter.Interpret(statements);
+            }
+            else
+            {
+                // This was not a valid set of statements. But is it perhaps a valid expression? The parser is now
+                // at EOF and since we don't currently have any form of "rewind" functionality, the easiest approach
+                // is to just create a new parser at this point.
+                parser = new PerlangParser(tokens, this);
+                Expr expression = parser.ParseExpression();
+
+                if (expression == null)
+                {
+                    // Likely not a valid expression. Errors are presumed to have been handled at this point, so we
+                    // can just return.
+                    return;
+                }
+
+                // TODO: we don't run the resolver in this case, which essentially means that we will be unable to
+                // TODO: refer to local variables.
+                object result = interpreter.Evaluate(expression);
+
+                if (result != null)
+                {
+                    Console.WriteLine(result);
+                }
+            }
+        }
+
+        public void ScannerError(int line, string message)
+        {
+            Report(line, "", message);
+        }
+
+        public void RuntimeError(RuntimeError error)
+        {
+            Console.WriteLine($"{error.Message}\n" +
+                              $"[line {error.Token.Line}]");
+            hadRuntimeError = true;
+        }
+
+        private static void Report(int line, string where, string message)
+        {
+            Console.Error.WriteLine($"[line {line}] Error{where}: {message}");
+            hadError = true;
+        }
+
+        private static void Error(Token token, string message)
+        {
+            if (token.Type == TokenType.EOF)
+            {
+                Report(token.Line, " at end", message);
+            }
+            else
+            {
+                Report(token.Line, " at '" + token.Lexeme + "'", message);
+            }
+        }
+
+        public void ParseError(Token token, string message, ParseErrorType? parseErrorType)
+        {
+            if (parseErrorType == ParseErrorType.MISSING_TRAILING_SEMICOLON)
+            {
+                // These errors are ignored; we will get them all them when we try to parse expressions as
+                // statements.
+                hadError = true;
+                return;
+            }
+
+            Error(token, message);
+        }
+
+        public void ResolveError(Token token, string message)
+        {
+            Error(token, message);
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -1,0 +1,267 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Perlang.Parser;
+
+namespace Perlang.Interpreter
+{
+    class Resolver : Expr.IVisitor<VoidObject>, Stmt.IVisitor<VoidObject>
+    {
+        private readonly Stack<IDictionary<string, bool>> scopes = new Stack<IDictionary<string, bool>>();
+        private FunctionType currentFunction = FunctionType.None;
+
+        private readonly IInterpreter interpreter;
+        private readonly IResolveErrorHandler resolveErrorHandler;
+
+        internal Resolver(IInterpreter interpreter, IResolveErrorHandler resolveErrorHandler)
+        {
+            this.interpreter = interpreter;
+            this.resolveErrorHandler = resolveErrorHandler;
+        }
+
+        internal void Resolve(IEnumerable<Stmt> statements)
+        {
+            foreach (Stmt statement in statements)
+            {
+                Resolve(statement);
+            }
+        }
+
+        private void BeginScope()
+        {
+            scopes.Push(new Dictionary<string, bool>());
+        }
+
+        private void EndScope()
+        {
+            scopes.Pop();
+        }
+
+        private void Declare(Token name)
+        {
+            if (IsEmpty(scopes)) return;
+
+            // This adds the variable to the innermost scope so that it shadows any outer one and so that we know the
+            // variable exists. We mark it as “not ready yet” by binding its name to false in the scope map. Each value
+            // in the scope map means “is finished being initialized”.
+            var scope = scopes.Peek();
+
+            if (scope.ContainsKey(name.Lexeme))
+            {
+                resolveErrorHandler.ResolveError(name, "Variable with this name already declared in this scope.");
+            }
+
+            scope[name.Lexeme] = false;
+        }
+
+        private static bool IsEmpty(ICollection stack)
+        {
+            return stack.Count == 0;
+        }
+
+        private void Define(Token name)
+        {
+            if (IsEmpty(scopes)) return;
+
+            // We set the variable’s value in the scope map to true to mark it as fully initialized and available for
+            // use. It’s alive!
+            scopes.Peek()[name.Lexeme] = true;
+        }
+
+        private void ResolveLocal(Expr expr, Token name)
+        {
+            for (int i = scopes.Count - 1; i >= 0; i--)
+            {
+                // TODO: rewrite this for performance, since scopes.ElementAt() is much more inefficient on .NET
+                // TODO: than the Java counterpart.
+                if (scopes.ElementAt(i).ContainsKey(name.Lexeme))
+                {
+                    interpreter.Resolve(expr, scopes.Count - 1 - i);
+                    return;
+                }
+            }
+
+            // Not found. Assume it is global.                   
+        }
+
+        public VoidObject VisitAssignExpr(Expr.Assign expr)
+        {
+            Resolve(expr.Value);
+            ResolveLocal(expr, expr.Name);
+            return null;
+        }
+
+        public VoidObject VisitBinaryExpr(Expr.Binary expr)
+        {
+            Resolve(expr.Left);
+            Resolve(expr.Right);
+            return null;
+        }
+
+        public VoidObject VisitCallExpr(Expr.Call expr)
+        {
+            Resolve(expr.Callee);
+
+            foreach (Expr argument in expr.Arguments)
+            {
+                Resolve(argument);
+            }
+
+            return null;
+        }
+
+        public VoidObject VisitGroupingExpr(Expr.Grouping expr)
+        {
+            Resolve(expr.Expression);
+            return null;
+        }
+
+        public VoidObject VisitLiteralExpr(Expr.Literal expr)
+        {
+            return null;
+        }
+
+        public VoidObject VisitLogicalExpr(Expr.Logical expr)
+        {
+            Resolve(expr.Left);
+            Resolve(expr.Right);
+            
+            return null;
+        }
+
+        public VoidObject VisitUnaryExpr(Expr.Unary expr)
+        {
+            Resolve(expr.Right);
+            
+            return null;
+        }
+
+        public VoidObject VisitVariableExpr(Expr.Variable expr)
+        {
+            if (!IsEmpty(scopes) &&
+                scopes.Peek()[expr.Name.Lexeme] == false)
+            {
+                resolveErrorHandler.ResolveError(expr.Name,
+                    "Cannot read local variable in its own initializer.");
+            }
+
+            ResolveLocal(expr, expr.Name);
+            return null;
+        }
+
+        public VoidObject VisitBlockStmt(Stmt.Block stmt)
+        {
+            BeginScope();
+            Resolve(stmt.Statements);
+            EndScope();
+            return null;
+        }
+
+        private void Resolve(Stmt stmt)
+        {
+            stmt.Accept(this);
+        }
+
+        private void Resolve(Expr expr)
+        {
+            expr.Accept(this);
+        }
+
+        public VoidObject VisitExpressionStmt(Stmt.ExpressionStmt stmt)
+        {
+            Resolve(stmt.Expression);
+            return null;
+        }
+
+        public VoidObject VisitFunctionStmt(Stmt.Function stmt)
+        {
+            Declare(stmt.Name);
+            Define(stmt.Name);
+
+            ResolveFunction(stmt, FunctionType.Function);
+            return null;
+        }
+
+        private void ResolveFunction(Stmt.Function function, FunctionType type)
+        {
+            FunctionType enclosingFunction = currentFunction;
+            currentFunction = type;
+
+            BeginScope();
+
+            foreach (Token param in function.Params)
+            {
+                Declare(param);
+                Define(param);
+            }
+
+            Resolve(function.Body);
+            EndScope();
+
+            currentFunction = enclosingFunction;
+        }
+
+        public VoidObject VisitIfStmt(Stmt.If stmt)
+        {
+            Resolve(stmt.Condition);
+            Resolve(stmt.ThenBranch);
+            
+            if (stmt.ElseBranch != null)
+            {
+                Resolve(stmt.ElseBranch);
+            }
+
+            return null;
+        }
+
+        public VoidObject VisitPrintStmt(Stmt.Print stmt)
+        {
+            Resolve(stmt.Expression);
+            
+            return null;
+        }
+
+        public VoidObject VisitReturnStmt(Stmt.Return stmt)
+        {
+            if (currentFunction == FunctionType.None)
+            {
+                resolveErrorHandler.ResolveError(stmt.Keyword, "Cannot return from top-level code.");
+            }
+
+            if (stmt.Value != null)
+            {
+                Resolve(stmt.Value);
+            }
+
+            return null;
+        }
+
+        public VoidObject VisitVarStmt(Stmt.Var stmt)
+        {
+            Declare(stmt.Name);
+            
+            if (stmt.Initializer != null)
+            {
+                Resolve(stmt.Initializer);
+            }
+
+            Define(stmt.Name);
+            
+            return null;
+        }
+
+        public VoidObject VisitWhileStmt(Stmt.While stmt)
+        {
+            Resolve(stmt.Condition);
+            Resolve(stmt.Body);
+            
+            return null;
+        }
+
+        private enum FunctionType
+        {
+            None,
+            Function
+        }
+    }
+}

--- a/Perlang.Interpreter/Return.cs
+++ b/Perlang.Interpreter/Return.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Perlang.Interpreter
+{
+    internal class Return : Exception
+    {
+        internal object Value { get; }
+
+        internal Return(object value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/Perlang.Interpreter/RuntimeError.cs
+++ b/Perlang.Interpreter/RuntimeError.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Perlang.Interpreter
+{
+    public class RuntimeError : Exception
+    {
+        internal Token Token { get; }
+
+        internal RuntimeError(Token token, string message)
+            : base(message)
+        {
+            Token = token;
+        }
+    }
+}

--- a/Perlang.Parser/IParseErrorHandler.cs
+++ b/Perlang.Parser/IParseErrorHandler.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Parser
+{
+    public interface IParseErrorHandler
+    {
+        void ParseError(Token token, string message, ParseErrorType? parseErrorType);
+    }
+}

--- a/Perlang.Parser/IScannerErrorHandler.cs
+++ b/Perlang.Parser/IScannerErrorHandler.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Parser
+{
+    public interface IScannerErrorHandler
+    {
+        void ScannerError(int line, string unexpectedCharacter);
+    }
+}

--- a/Perlang.Parser/ParseErrorType.cs
+++ b/Perlang.Parser/ParseErrorType.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Parser
+{
+    public enum ParseErrorType
+    {
+        MISSING_TRAILING_SEMICOLON
+    }
+}

--- a/Perlang.Parser/Perlang.Parser.csproj
+++ b/Perlang.Parser/Perlang.Parser.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Perlang.Common\Perlang.Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -1,0 +1,564 @@
+﻿using System;
+using System.Collections.Generic;
+using static Perlang.TokenType;
+
+namespace Perlang.Parser
+{
+    // Convoluted name to avoid conflict with namespace
+    public class PerlangParser
+    {
+        private class ParseError : Exception
+        {
+            public ParseErrorType? ParseErrorType { get; }
+
+            public ParseError(ParseErrorType? parseErrorType)
+            {
+                ParseErrorType = parseErrorType;
+            }
+        }
+
+        private readonly IParseErrorHandler parseErrorHandler;
+        private readonly List<Token> tokens;
+
+        private int current;
+
+        public PerlangParser(List<Token> tokens, IParseErrorHandler parseErrorHandler)
+        {
+            this.parseErrorHandler = parseErrorHandler;
+            this.tokens = tokens;
+        }
+
+        public IList<Stmt> ParseStatements()
+        {
+            var statements = new List<Stmt>();
+
+            while (!IsAtEnd())
+            {
+                statements.Add(Declaration());
+            }
+
+            return statements;
+        }
+
+        public Expr ParseExpression()
+        {
+            try
+            {
+                return Expression();
+            }
+            catch (ParseError)
+            {
+                return null;
+            }
+        }
+
+        private Expr Expression()
+        {
+            return Assignment();
+        }
+
+        private Stmt Declaration()
+        {
+            try
+            {
+                if (Match(FUN)) return Function("function");
+                if (Match(VAR)) return VarDeclaration();
+
+                return Statement();
+            }
+            catch (ParseError)
+            {
+                Synchronize();
+                return null;
+            }
+        }
+
+        private Stmt Statement()
+        {
+            if (Match(FOR)) return ForStatement();
+            if (Match(IF)) return IfStatement();
+            if (Match(PRINT)) return PrintStatement();
+            if (Match(RETURN)) return ReturnStatement();
+            if (Match(WHILE)) return WhileStatement();
+            if (Match(LEFT_BRACE)) return new Stmt.Block(Block());
+
+            return ExpressionStatement();
+        }
+
+        private Stmt ForStatement()
+        {
+            // The "for" implementation is a bit special in that it doesn't use any special AST nodes of its own.
+            // Instead, it just desugars the for loop into already existing elements in our toolbox.
+            // More details: http://craftinginterpreters.com/control-flow.html#desugaring
+            Consume(LEFT_PAREN, "Expect '(' after 'for'.");
+
+            Stmt initializer;
+            if (Match(SEMICOLON))
+            {
+                initializer = null;
+            }
+            else if (Match(VAR))
+            {
+                initializer = VarDeclaration();
+            }
+            else
+            {
+                initializer = ExpressionStatement();
+            }
+
+            Expr condition = null;
+            if (!Check(SEMICOLON))
+            {
+                condition = Expression();
+            }
+
+            Consume(SEMICOLON, "Expect ';' after loop condition.");
+
+            Expr increment = null;
+            if (!Check(RIGHT_PAREN))
+            {
+                increment = Expression();
+            }
+
+            Consume(RIGHT_PAREN, "Expect ')' after for clauses.");
+
+            Stmt body = Statement();
+
+            if (increment != null)
+            {
+                body = new Stmt.Block(new List<Stmt>
+                {
+                    body,
+                    new Stmt.ExpressionStmt(increment)
+                });
+            }
+
+            if (condition == null) condition = new Expr.Literal(true);
+            body = new Stmt.While(condition, body);
+
+            if (initializer != null)
+            {
+                body = new Stmt.Block(new List<Stmt> {initializer, body});
+            }
+
+            return body;
+        }
+
+        private Stmt IfStatement()
+        {
+            Consume(LEFT_PAREN, "Expect '(' after 'if'.");
+            Expr condition = Expression();
+            Consume(RIGHT_PAREN, "Expect ')' after if condition.");
+
+            Stmt thenBranch = Statement();
+            Stmt elseBranch = null;
+
+            if (Match(ELSE))
+            {
+                elseBranch = Statement();
+            }
+
+            return new Stmt.If(condition, thenBranch, elseBranch);
+        }
+
+        private Stmt PrintStatement()
+        {
+            Expr value = Expression();
+            Consume(SEMICOLON, "Expect ';' after value.");
+            return new Stmt.Print(value);
+        }
+
+        private Stmt ReturnStatement()
+        {
+            Token keyword = Previous();
+            Expr value = null;
+
+            if (!Check(SEMICOLON))
+            {
+                value = Expression();
+            }
+
+            Consume(SEMICOLON, "Expect ';' after return value.");
+            return new Stmt.Return(keyword, value);
+        }
+
+        private Stmt VarDeclaration()
+        {
+            Token name = Consume(IDENTIFIER, "Expect variable name.");
+
+            Expr initializer = null;
+            if (Match(EQUAL))
+            {
+                initializer = Expression();
+            }
+
+            Consume(SEMICOLON, "Expect ';' after variable declaration.");
+            return new Stmt.Var(name, initializer);
+        }
+
+        private Stmt WhileStatement()
+        {
+            Consume(LEFT_PAREN, "Expect '(' after 'while'.");
+            Expr condition = Expression();
+            Consume(RIGHT_PAREN, "Expect ')' after condition.");
+            Stmt body = Statement();
+
+            return new Stmt.While(condition, body);
+        }
+
+        private Stmt ExpressionStatement()
+        {
+            Expr expr = Expression();
+            Consume(SEMICOLON, "Expect ';' after expression.", ParseErrorType.MISSING_TRAILING_SEMICOLON);
+            return new Stmt.ExpressionStmt(expr);
+        }
+
+        private Stmt.Function Function(string kind)
+        {
+            Token name = Consume(IDENTIFIER, "Expect " + kind + " name.");
+            Consume(LEFT_PAREN, "Expect '(' after " + kind + " name.");
+            var parameters = new List<Token>();
+
+            if (!Check(RIGHT_PAREN))
+            {
+                do
+                {
+                    if (parameters.Count >= 255)
+                    {
+                        Error(Peek(), "Cannot have more than 255 parameters.");
+                    }
+
+                    parameters.Add(Consume(IDENTIFIER, "Expect parameter name."));
+                } while (Match(COMMA));
+            }
+
+            Consume(RIGHT_PAREN, "Expect ')' after parameters.");
+
+            Consume(LEFT_BRACE, "Expect '{' before " + kind + " body.");
+            List<Stmt> body = Block();
+            return new Stmt.Function(name, parameters, body);
+        }
+
+        private List<Stmt> Block()
+        {
+            var statements = new List<Stmt>();
+
+            while (!Check(RIGHT_BRACE) && !IsAtEnd())
+            {
+                statements.Add(Declaration());
+            }
+
+            Consume(RIGHT_BRACE, "Expect '}' after block.");
+            return statements;
+        }
+
+        private Expr Assignment()
+        {
+            Expr expr = Or();
+
+            if (Match(EQUAL))
+            {
+                Token equals = Previous();
+                Expr value = Assignment();
+
+                if (expr is Expr.Variable variable)
+                {
+                    Token name = variable.Name;
+                    return new Expr.Assign(name, value);
+                }
+
+                Error(equals, "Invalid assignment target.");
+            }
+
+            return expr;
+        }
+
+        private Expr Or()
+        {
+            Expr expr = And();
+
+            while (Match(OR))
+            {
+                Token _operator = Previous();
+                Expr right = And();
+                expr = new Expr.Logical(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr And()
+        {
+            Expr expr = Equality();
+
+            while (Match(AND))
+            {
+                Token _operator = Previous();
+                Expr right = Equality();
+                expr = new Expr.Logical(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr Equality()
+        {
+            Expr expr = Comparison();
+
+            while (Match(BANG_EQUAL, EQUAL_EQUAL))
+            {
+                Token _operator = Previous();
+                Expr right = Comparison();
+                expr = new Expr.Binary(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr Comparison()
+        {
+            Expr expr = Addition();
+
+            while (Match(GREATER, GREATER_EQUAL, LESS, LESS_EQUAL))
+            {
+                Token _operator = Previous();
+                Expr right = Addition();
+                expr = new Expr.Binary(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr Addition()
+        {
+            Expr expr = Multiplication();
+
+            while (Match(MINUS, PLUS))
+            {
+                Token _operator = Previous();
+                Expr right = Multiplication();
+                expr = new Expr.Binary(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr Multiplication()
+        {
+            Expr expr = Unary();
+
+            while (Match(SLASH, STAR))
+            {
+                Token _operator = Previous();
+                Expr right = Unary();
+                expr = new Expr.Binary(expr, _operator, right);
+            }
+
+            return expr;
+        }
+
+        private Expr Unary()
+        {
+            if (Match(BANG, MINUS))
+            {
+                Token _operator = Previous();
+                Expr right = Unary();
+                return new Expr.Unary(_operator, right);
+            }
+
+            return Call();
+        }
+
+        private Expr Call()
+        {
+            Expr expr = Primary();
+
+            while (true)
+            {
+                if (Match(LEFT_PAREN))
+                {
+                    expr = FinishCall(expr);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return expr;
+        }
+
+        private Expr FinishCall(Expr callee)
+        {
+            var arguments = new List<Expr>();
+
+            if (!Check(RIGHT_PAREN))
+            {
+                do
+                {
+                    if (arguments.Count >= 255)
+                    {
+                        Error(Peek(), "Cannot have more than 255 arguments.");
+                    }
+
+                    arguments.Add(Expression());
+                } while (Match(COMMA));
+            }
+
+            Token paren = Consume(RIGHT_PAREN, "Expect ')' after arguments.");
+
+            return new Expr.Call(callee, paren, arguments);
+        }
+
+        private Expr Primary()
+        {
+            if (Match(FALSE)) return new Expr.Literal(false);
+            if (Match(TRUE)) return new Expr.Literal(true);
+            if (Match(NIL)) return new Expr.Literal(null);
+
+            if (Match(NUMBER, STRING))
+            {
+                return new Expr.Literal(Previous().Literal);
+            }
+
+            if (Match(IDENTIFIER))
+            {
+                return new Expr.Variable(Previous());
+            }
+
+            if (Match(LEFT_PAREN))
+            {
+                Expr expr = Expression();
+                Consume(RIGHT_PAREN, "Expect ')' after expression.");
+                return new Expr.Grouping(expr);
+            }
+
+            throw Error(Peek(), "Expect expression.");
+        }
+
+        /// <summary>
+        /// Matches the given token type(s), at the current position. If a matching token is found, it gets consumed.
+        ///
+        /// For a non-consuming version of this, see <see cref="Peek"/>.
+        /// </summary>
+        /// <param name="types">One or more token types to match</param>
+        /// <returns>true if a matching token was found and consumed, false otherwise</returns>
+        private bool Match(params TokenType[] types)
+        {
+            foreach (TokenType type in types)
+            {
+                if (Check(type))
+                {
+                    Advance();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Matches the given token type at the current position. If the current token does not match, an exception is
+        /// thrown.
+        /// </summary>
+        /// <param name="type">the type of token to match</param>
+        /// <param name="message">the error message to use if the token does not match</param>
+        /// <param name="parseErrorType">an optional parameter indicating the type of parse error</param>
+        /// <returns>the matched token</returns>
+        /// <exception cref="ParseError">if the token does not match</exception>
+        private Token Consume(TokenType type, string message, ParseErrorType? parseErrorType = null)
+        {
+            if (Check(type))
+            {
+                return Advance();
+            }
+
+            throw Error(Peek(), message, parseErrorType);
+        }
+
+        /// <summary>
+        /// Checks if the current token matches the provided TokenType. Similar to <see cref="Match"/> but does not
+        /// consume the token on matches.
+        /// </summary>
+        /// <param name="type">the TokenType to match</param>
+        /// <returns>true if it matches, false otherwise</returns>
+        private bool Check(TokenType type)
+        {
+            if (IsAtEnd())
+            {
+                return false;
+            }
+
+            return Peek().Type == type;
+        }
+
+        private Token Advance()
+        {
+            if (!IsAtEnd())
+            {
+                current++;
+            }
+
+            return Previous();
+        }
+
+        private bool IsAtEnd()
+        {
+            return Peek().Type == EOF;
+        }
+
+        /// <summary>
+        /// Returns the token at the current position.
+        /// </summary>
+        /// <returns>A Token</returns>
+        private Token Peek()
+        {
+            return tokens[current];
+        }
+
+        /// <summary>
+        /// Returns the token right before the current position.
+        /// </summary>
+        /// <returns>A Token</returns>
+        private Token Previous()
+        {
+            return tokens[current - 1];
+        }
+
+        private ParseError Error(Token token, string message, ParseErrorType? parseErrorType = null)
+        {
+            parseErrorHandler.ParseError(token, message, parseErrorType);
+            return new ParseError(parseErrorType);
+        }
+
+        private void Synchronize()
+        {
+            Advance();
+
+            while (!IsAtEnd())
+            {
+                if (Previous().Type == SEMICOLON)
+                {
+                    return;
+                }
+
+                switch (Peek().Type)
+                {
+                    case CLASS:
+                    case FUN:
+                    case VAR:
+                    case FOR:
+                    case IF:
+                    case WHILE:
+                    case PRINT:
+                    case RETURN:
+                        return;
+                }
+
+                Advance();
+            }
+        }
+    }
+}
+
+    

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using static Perlang.TokenType;
+
+namespace Perlang.Parser
+{
+    public class Scanner
+    {
+        private static readonly IDictionary<string, TokenType> ReservedKeywords = 
+            new Dictionary<string, TokenType>
+        {
+            {"and", AND},
+            {"class", CLASS},
+            {"else", ELSE},
+            {"false", FALSE},
+            {"for", FOR},
+            {"fun", FUN},
+            {"if", IF},
+            {"nil", NIL},
+            {"or", OR},
+            {"print", PRINT},
+            {"return", RETURN},
+            {"super", SUPER},
+            {"this", THIS},
+            {"true", TRUE},
+            {"var", VAR},
+            {"while", WHILE}
+        };
+
+        private readonly string source;
+        private readonly IScannerErrorHandler scannerErrorHandler;
+
+        private readonly List<Token> tokens = new List<Token>();
+        private int start;
+        private int current;
+        private int line = 1;
+
+        public Scanner(string source, IScannerErrorHandler scannerErrorHandler)
+        {
+            this.source = source;
+            this.scannerErrorHandler = scannerErrorHandler;
+        }
+
+        public List<Token> ScanTokens()
+        {
+            while (!IsAtEnd())
+            {
+                // We are at the beginning of the next lexeme.
+                start = current;
+                ScanToken();
+            }
+
+            tokens.Add(new Token(EOF, "", null, line));
+            return tokens;
+        }
+
+        private void ScanToken()
+        {
+            char c = Advance();
+
+            switch (c)
+            {
+                case '(':
+                    AddToken(LEFT_PAREN);
+                    break;
+                case ')':
+                    AddToken(RIGHT_PAREN);
+                    break;
+                case '{':
+                    AddToken(LEFT_BRACE);
+                    break;
+                case '}':
+                    AddToken(RIGHT_BRACE);
+                    break;
+                case ',':
+                    AddToken(COMMA);
+                    break;
+                case '.':
+                    AddToken(DOT);
+                    break;
+                case '-':
+                    AddToken(MINUS);
+                    break;
+                case '+':
+                    AddToken(PLUS);
+                    break;
+                case ';':
+                    AddToken(SEMICOLON);
+                    break;
+                case '*':
+                    AddToken(STAR);
+                    break;
+                case '!':
+                    AddToken(Match('=') ? BANG_EQUAL : BANG);
+                    break;
+                case '=':
+                    AddToken(Match('=') ? EQUAL_EQUAL : EQUAL);
+                    break;
+                case '<':
+                    AddToken(Match('=') ? LESS_EQUAL : LESS);
+                    break;
+                case '>':
+                    AddToken(Match('=') ? GREATER_EQUAL : GREATER);
+                    break;
+
+                case '/':
+                    if (Match('/'))
+                    {
+                        // A comment goes until the end of the line.
+                        while (Peek() != '\n' && !IsAtEnd()) Advance();
+                    }
+                    else
+                    {
+                        AddToken(SLASH);
+                    }
+
+                    break;
+
+                case ' ':
+                case '\r':
+                case '\t':
+                    // Ignore whitespace.
+                    break;
+
+                case '\n':
+                    line++;
+                    break;
+
+                case '"':
+                    String();
+                    break;
+
+                default:
+                    if (IsDigit(c))
+                    {
+                        Number();
+                    }
+                    else if (IsAlpha(c))
+                    {
+                        Identifier();
+                    }
+                    else
+                    {
+                        scannerErrorHandler.ScannerError(line, "Unexpected character " + c);
+                    }
+
+                    break;
+            }
+        }
+
+        private void Identifier()
+        {
+            while (IsAlphaNumeric(Peek())) Advance();
+
+            // See if the identifier is a reserved word.
+            string text = source[start..current];
+            var type = ReservedKeywords.ContainsKey(text) ? ReservedKeywords[text] : IDENTIFIER;
+
+            AddToken(type);
+        }
+
+        private void Number()
+        {
+            while (IsDigit(Peek())) Advance();
+
+            // Look for a fractional part.
+            if (Peek() == '.' && IsDigit(PeekNext()))
+            {
+                // Consume the "."
+                Advance();
+
+                while (IsDigit(Peek())) Advance();
+            }
+
+            AddToken(NUMBER, Double.Parse(source[start..current]));
+        }
+
+        private void String()
+        {
+            while (Peek() != '"' && !IsAtEnd())
+            {
+                if (Peek() == '\n') line++;
+                Advance();
+            }
+
+            // Unterminated string.
+            if (IsAtEnd())
+            {
+                scannerErrorHandler.ScannerError(line, "Unterminated string.");
+                return;
+            }
+
+            // The closing ".
+            Advance();
+
+            // Trim the surrounding quotes.
+            string value = source[(start + 1)..(current - 1)];
+            AddToken(STRING, value);
+        }
+
+        private bool Match(char expected)
+        {
+            if (IsAtEnd())
+            {
+                return false;
+            }
+
+            if (source[current] != expected)
+            {
+                return false;
+            }
+
+            current++;
+            return true;
+        }
+
+        private char Peek()
+        {
+            if (IsAtEnd())
+            {
+                return '\0';
+            }
+
+            return source[current];
+        }
+
+        private char PeekNext()
+        {
+            if (current + 1 >= source.Length)
+            {
+                return '\0';
+            }
+
+            return source[current + 1];
+        }
+
+        private static bool IsAlpha(char c)
+        {
+            return (c >= 'a' && c <= 'z') ||
+                   (c >= 'A' && c <= 'Z') ||
+                   c == '_';
+        }
+
+        private static bool IsAlphaNumeric(char c) => 
+            IsAlpha(c) || IsDigit(c);
+
+        private static bool IsDigit(char c) => 
+            c >= '0' && c <= '9';
+
+        private bool IsAtEnd() => 
+            current >= source.Length;
+
+        private char Advance()
+        {
+            current++;
+            return source[current - 1];
+        }
+
+        private void AddToken(TokenType type, object literal = null)
+        {
+            string text = source[start..current];
+            tokens.Add(new Token(type, text, literal, line));
+        }
+    }
+}

--- a/Perlang.Parser/VoidObject.cs
+++ b/Perlang.Parser/VoidObject.cs
@@ -1,0 +1,6 @@
+namespace Perlang.Parser
+{
+    public abstract class VoidObject
+    {
+    }
+}

--- a/Perlang.sln
+++ b/Perlang.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Interpreter", "Perlang.Interpreter\Perlang.Interpreter.csproj", "{2E39F005-52FF-404D-B570-0AB2E9081272}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Common", "Perlang.Common\Perlang.Common.csproj", "{B338D29B-A85D-4650-9BFF-FBFE55258C58}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Parser", "Perlang.Parser\Perlang.Parser.csproj", "{F1F9229C-D764-4A38-BEA2-1F86A1C2FF1A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2E39F005-52FF-404D-B570-0AB2E9081272}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E39F005-52FF-404D-B570-0AB2E9081272}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E39F005-52FF-404D-B570-0AB2E9081272}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E39F005-52FF-404D-B570-0AB2E9081272}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B338D29B-A85D-4650-9BFF-FBFE55258C58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B338D29B-A85D-4650-9BFF-FBFE55258C58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B338D29B-A85D-4650-9BFF-FBFE55258C58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B338D29B-A85D-4650-9BFF-FBFE55258C58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1F9229C-D764-4A38-BEA2-1F86A1C2FF1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1F9229C-D764-4A38-BEA2-1F86A1C2FF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1F9229C-D764-4A38-BEA2-1F86A1C2FF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1F9229C-D764-4A38-BEA2-1F86A1C2FF1A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/scripts/generate_ast_classes.rb
+++ b/scripts/generate_ast_classes.rb
@@ -1,0 +1,182 @@
+#!/usr/bin/env ruby
+
+# Used for camelize
+require 'active_support'
+require 'active_support/core_ext/string/inflections'
+
+INDENT = ' ' * 4
+VISIBILITY = 'public'
+
+class Type
+  attr_reader :class_name
+  attr_reader :fields
+
+  def initialize(class_name, *fields)
+    @class_name = class_name
+    @fields = fields.flatten
+  end
+end
+
+class Field
+  attr_reader :type
+  attr_reader :name
+
+  def initialize(type, name)
+    @type = type
+    @name = name
+  end
+end
+
+def fix_stmt_name(name)
+  # Hack since we had to rename Expression to ExpressionStmt, to avoid clashing with the
+  # 'Expression' property. Without this, we get VisitExpressionStmtStmt instead of
+  # VisitExpressionStmt
+  name.sub('StmtStmt', 'Stmt')
+end
+
+def define_visitor(base_name, types)
+  stream = StringIO.new
+
+  stream.puts "#{INDENT * 2}#{VISIBILITY} interface IVisitor<TR>"
+  stream.puts "#{INDENT * 2}{"
+
+  types.each { |t|
+    method_name = fix_stmt_name(t.class_name + base_name)
+
+    stream.puts "#{INDENT * 3}TR Visit#{method_name}(#{t.class_name} #{base_name.downcase});"
+  }
+
+  stream.puts "#{INDENT * 2}}"
+
+  stream.string
+end
+
+def define_type(base_name, class_name, fields)
+  stream = StringIO.new
+
+  stream.puts "#{INDENT * 2}#{VISIBILITY} class #{class_name} : #{base_name}"
+  stream.puts "#{INDENT * 2}{"
+
+  # Fields.
+  fields.each { |f|
+    stream.puts("#{INDENT * 3}#{VISIBILITY} #{f.type} #{f.name.camelize} { get; }");
+  }
+
+  stream.puts
+
+  # Constructor.
+  constructor_fields = fields.map { |f|
+    "#{f.type} #{f.name}"
+  }.join(', ')
+  stream.puts "#{INDENT * 3}#{VISIBILITY} #{class_name}(#{constructor_fields}) {"
+
+  # Store parameters in fields.
+  fields.each { |f|
+    stream.puts "#{INDENT * 4}#{f.name.camelize} = #{f.name};"
+  }
+
+  stream.puts "#{INDENT * 3}}";
+
+  stream.puts
+
+  # Visitor pattern implementation
+  method_name = fix_stmt_name(class_name + base_name)
+  stream.puts "#{INDENT * 3}#{VISIBILITY} override TR Accept<TR>(IVisitor<TR> visitor)"
+  stream.puts "#{INDENT * 3}{"
+  stream.puts "#{INDENT * 4}return visitor.Visit#{method_name}(this);"
+  stream.puts "#{INDENT * 3}}"
+
+  stream.puts "#{INDENT * 2}}"
+
+  stream
+end
+
+def define_ast(output_dir, base_name, types)
+  visitor_content = define_visitor(base_name, types)
+
+  inner_classes = types.map { |type|
+    define_type(base_name, type.class_name, type.fields)
+  }
+
+  inner_classes_content = inner_classes
+    .map(&:string)
+    .join("\n")
+    .rstrip
+
+  path = File.join(output_dir, base_name + ".cs");
+  File.write(path, <<~EOF)
+using System.Collections.Generic;
+
+namespace Perlang
+{
+#{INDENT}#{VISIBILITY} abstract class #{base_name}
+#{INDENT}{
+#{visitor_content}
+#{inner_classes_content}
+
+#{INDENT * 2}#{VISIBILITY} abstract TR Accept<TR>(IVisitor<TR> visitor);
+#{INDENT}}
+}
+  EOF
+end
+
+OUTPUT_DIR = 'Perlang.Common'
+
+#
+# Certain names like _params and _operator are prefixed, since they
+# clash with C# reserved words.
+#
+
+# Expressions
+define_ast(OUTPUT_DIR, "Expr", [
+  Type.new('Assign', Field.new('Token', 'name'), Field.new('Expr', 'value')),
+  Type.new('Binary', [
+    Field.new('Expr', 'left'),
+    Field.new('Token', '_operator'),
+    Field.new('Expr', 'right')
+  ]),
+  Type.new('Call', [
+    Field.new('Expr', 'callee'),
+    Field.new('Token', 'paren'),
+    Field.new('List<Expr>', 'arguments')
+  ]),
+  Type.new('Grouping', Field.new('Expr', 'expression')),
+  Type.new('Literal', Field.new('object', 'value')),
+  Type.new('Logical', [
+    Field.new('Expr', 'left'),
+    Field.new('Token', '_operator'),
+    Field.new('Expr', 'right')
+  ]),
+  Type.new('Unary', [
+    Field.new('Token', '_operator'),
+    Field.new('Expr', 'right')
+  ]),
+  Type.new('Variable', Field.new('Token', 'name'))
+])
+
+# Statements
+define_ast(OUTPUT_DIR, "Stmt", [
+  Type.new('Block', Field.new('List<Stmt>', 'statements')),
+
+  # Silly name to avoid clash with the 'Expression' property that
+  # gets generated for the 'expression' field.
+  Type.new('ExpressionStmt', Field.new('Expr', 'expression')),
+
+  Type.new('Function', [
+    Field.new('Token', 'name'),
+    Field.new('List<Token>', '_params'),
+    Field.new('List<Stmt>', 'body')
+  ]),
+  Type.new('If', [
+    Field.new('Expr', 'condition'),
+    Field.new('Stmt', 'thenBranch'),
+    Field.new('Stmt', 'elseBranch')
+  ]),
+  Type.new('Print', Field.new('Expr', 'expression')),
+  Type.new('Return', Field.new('Token', 'keyword'), Field.new('Expr', 'value')),
+  Type.new('Var', [
+    Field.new('Token', 'name'),
+    Field.new('Expr', 'initializer')
+  ]),
+  Type.new('While', Field.new('Expr', 'condition'), Field.new('Stmt', 'body'))
+])


### PR DESCRIPTION
This is pretty much a straight copy of https://github.com/perlun/cslox/commit/64da4fd62808f4a079d99700541ed36d27df9ab4, with the following adjustments made:

- Rename the namespaces to Perlang.*

- Split the project into three parts: `Perlang.Common`, `Perlang.Interpreter` and `Perlang.Parser`. The idea here is to think already at an early stage about making the scanning and parsing parts reusable from non-interpreting/compiling scenarios. For example, to built a VS Code language server; it makes a lot of sense to not force all use cases that want to inspect Perlang source code to reimplement the whole language parser over and over again.

- Fix the code generated by `scripts/generate_ast_classes.rb` feel a bit more natural in the C# world, by using properties instead of plain fields. Also fixed the visibility since the generated code will now be in a different namespace from the classes that consume it.

- Try to improve the error handling slightly. It's still far from perfect and this is probably one of the things that will be improved
  on in the quite near future. Ideally, `ParseStatements()` and `ParseExpression()` would return not just the parsed statements/expression, but in case something goes wrong, the full list of parse errors should be available there. Nothing should be printed to stdout unless the consumer decides to print it.

- Extract a few interfaces like `IInterpreter`, `IParseErrorHandler` etc. We are not using any IOC container yet and time will tell if this will be necessary or not.