### PR TITLE
Use Actions instead of interfaces for error handlers

### DIFF
--- a/Perlang.Interpreter/IResolveErrorHandler.cs
+++ b/Perlang.Interpreter/IResolveErrorHandler.cs
@@ -1,7 +1,0 @@
-namespace Perlang.Interpreter
-{
-    internal interface IResolveErrorHandler
-    {
-        void ResolveError(Token name, string message);
-    }
-}

--- a/Perlang.Interpreter/IRuntimeErrorHandler.cs
+++ b/Perlang.Interpreter/IRuntimeErrorHandler.cs
@@ -1,7 +1,0 @@
-namespace Perlang.Interpreter
-{
-    internal interface IRuntimeErrorHandler
-    {
-        void RuntimeError(RuntimeError error);
-    }
-}

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -7,13 +7,13 @@ namespace Perlang.Interpreter
 {
     internal class PerlangInterpreter : IInterpreter, Expr.IVisitor<object>, Stmt.IVisitor<VoidObject>
     {
-        private readonly IRuntimeErrorHandler runtimeErrorHandler;
+        private readonly Action<RuntimeError> runtimeErrorHandler;
         private readonly PerlangEnvironment globals = new PerlangEnvironment();
         private readonly IDictionary<Expr, int> locals = new Dictionary<Expr, int>();
 
         private PerlangEnvironment perlangEnvironment;
 
-        public PerlangInterpreter(IRuntimeErrorHandler runtimeErrorHandler)
+        public PerlangInterpreter(Action<RuntimeError> runtimeErrorHandler)
         {
             this.runtimeErrorHandler = runtimeErrorHandler;
             
@@ -33,7 +33,7 @@ namespace Perlang.Interpreter
             }
             catch (RuntimeError error)
             {
-                runtimeErrorHandler.RuntimeError(error);
+                runtimeErrorHandler(error);
             }
         }
 

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,9 +12,9 @@ namespace Perlang.Interpreter
         private FunctionType currentFunction = FunctionType.None;
 
         private readonly IInterpreter interpreter;
-        private readonly IResolveErrorHandler resolveErrorHandler;
+        private readonly Action<Token, string> resolveErrorHandler;
 
-        internal Resolver(IInterpreter interpreter, IResolveErrorHandler resolveErrorHandler)
+        internal Resolver(IInterpreter interpreter, Action<Token, string> resolveErrorHandler)
         {
             this.interpreter = interpreter;
             this.resolveErrorHandler = resolveErrorHandler;
@@ -48,7 +49,7 @@ namespace Perlang.Interpreter
 
             if (scope.ContainsKey(name.Lexeme))
             {
-                resolveErrorHandler.ResolveError(name, "Variable with this name already declared in this scope.");
+                resolveErrorHandler(name, "Variable with this name already declared in this scope.");
             }
 
             scope[name.Lexeme] = false;
@@ -141,8 +142,7 @@ namespace Perlang.Interpreter
             if (!IsEmpty(scopes) &&
                 scopes.Peek()[expr.Name.Lexeme] == false)
             {
-                resolveErrorHandler.ResolveError(expr.Name,
-                    "Cannot read local variable in its own initializer.");
+                resolveErrorHandler(expr.Name, "Cannot read local variable in its own initializer.");
             }
 
             ResolveLocal(expr, expr.Name);
@@ -225,7 +225,7 @@ namespace Perlang.Interpreter
         {
             if (currentFunction == FunctionType.None)
             {
-                resolveErrorHandler.ResolveError(stmt.Keyword, "Cannot return from top-level code.");
+                resolveErrorHandler(stmt.Keyword, "Cannot return from top-level code.");
             }
 
             if (stmt.Value != null)

--- a/Perlang.Parser/IParseErrorHandler.cs
+++ b/Perlang.Parser/IParseErrorHandler.cs
@@ -1,7 +1,0 @@
-namespace Perlang.Parser
-{
-    public interface IParseErrorHandler
-    {
-        void ParseError(Token token, string message, ParseErrorType? parseErrorType);
-    }
-}

--- a/Perlang.Parser/IScannerErrorHandler.cs
+++ b/Perlang.Parser/IScannerErrorHandler.cs
@@ -1,7 +1,0 @@
-namespace Perlang.Parser
-{
-    public interface IScannerErrorHandler
-    {
-        void ScannerError(int line, string unexpectedCharacter);
-    }
-}

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -17,12 +17,12 @@ namespace Perlang.Parser
             }
         }
 
-        private readonly IParseErrorHandler parseErrorHandler;
+        private readonly Action<Token, string, ParseErrorType?> parseErrorHandler;
         private readonly List<Token> tokens;
 
         private int current;
 
-        public PerlangParser(List<Token> tokens, IParseErrorHandler parseErrorHandler)
+        public PerlangParser(List<Token> tokens, Action<Token, string, ParseErrorType?> parseErrorHandler)
         {
             this.parseErrorHandler = parseErrorHandler;
             this.tokens = tokens;
@@ -527,7 +527,7 @@ namespace Perlang.Parser
 
         private ParseError Error(Token token, string message, ParseErrorType? parseErrorType = null)
         {
-            parseErrorHandler.ParseError(token, message, parseErrorType);
+            parseErrorHandler(token, message, parseErrorType);
             return new ParseError(parseErrorType);
         }
 

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -28,14 +28,14 @@ namespace Perlang.Parser
         };
 
         private readonly string source;
-        private readonly IScannerErrorHandler scannerErrorHandler;
+        private readonly Action<int, string> scannerErrorHandler;
 
         private readonly List<Token> tokens = new List<Token>();
         private int start;
         private int current;
         private int line = 1;
 
-        public Scanner(string source, IScannerErrorHandler scannerErrorHandler)
+        public Scanner(string source, Action<int,string> scannerErrorHandler)
         {
             this.source = source;
             this.scannerErrorHandler = scannerErrorHandler;
@@ -141,7 +141,7 @@ namespace Perlang.Parser
                     }
                     else
                     {
-                        scannerErrorHandler.ScannerError(line, "Unexpected character " + c);
+                        scannerErrorHandler(line, "Unexpected character " + c);
                     }
 
                     break;
@@ -186,7 +186,7 @@ namespace Perlang.Parser
             // Unterminated string.
             if (IsAtEnd())
             {
-                scannerErrorHandler.ScannerError(line, "Unterminated string.");
+                scannerErrorHandler(line, "Unterminated string.");
                 return;
             }
 


### PR DESCRIPTION
I've been living in Java land for some time now, which seems to have affected my way to write C#/.NET code as well. :see_no_evil: In Java, there are no "delegates" per se; only interfaces. OTOH, you can easily do an anonymous class to implement an interface, and [functional interfaces](https://docs.oracle.com/javase/8/docs/api/java/util/function/package-summary.html#package.description) means you can even use a lambda to implement an interface type. This makes interfaces usable for the scenarios handled here: handling scanning, parsing, resolving and runtime errors.

In _.NET_, on the other hand, working with interfaces is interestingly enough more inconvenient than in Java. Here, it makes more sense to use an `Action<T1, T2>` etc pattern for these, which can easily be handled using a lambda etc.