### PR TITLE
Implement proper Eval() method

### DIFF
--- a/Perlang.Interpreter/Delegates.cs
+++ b/Perlang.Interpreter/Delegates.cs
@@ -1,0 +1,4 @@
+namespace Perlang.Interpreter
+{
+    public delegate void ResolveErrorHandler(Token token, string message);
+}

--- a/Perlang.Interpreter/ResolveErrors.cs
+++ b/Perlang.Interpreter/ResolveErrors.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Perlang.Parser;
+
+namespace Perlang.Interpreter
+{
+    public class ResolveError
+    {
+        public Token Token { get; set; }
+        public string Message { get; set; }
+    }
+
+    public class ResolveErrors : List<ResolveError>
+    {
+        public bool Empty() => Count == 0;
+
+        // Convenience method to free consumers from having to construct ScanErrors manually.
+        public void Add(Token token, string message)
+        {
+            Add(new ResolveError { Token = token, Message = message });
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -12,9 +12,9 @@ namespace Perlang.Interpreter
         private FunctionType currentFunction = FunctionType.None;
 
         private readonly IInterpreter interpreter;
-        private readonly Action<Token, string> resolveErrorHandler;
+        private readonly ResolveErrorHandler resolveErrorHandler;
 
-        internal Resolver(IInterpreter interpreter, Action<Token, string> resolveErrorHandler)
+        internal Resolver(IInterpreter interpreter, ResolveErrorHandler resolveErrorHandler)
         {
             this.interpreter = interpreter;
             this.resolveErrorHandler = resolveErrorHandler;

--- a/Perlang.Parser/ParseErrorHandler.cs
+++ b/Perlang.Parser/ParseErrorHandler.cs
@@ -1,0 +1,4 @@
+namespace Perlang.Parser
+{
+    public delegate void ParseErrorHandler(Token token, string message, ParseErrorType? parseErrorType);
+}

--- a/Perlang.Parser/ParseErrors.cs
+++ b/Perlang.Parser/ParseErrors.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Perlang.Parser
+{
+    public class ParseError
+    {
+        public Token Token { get; set; }
+        public string Message { get; set; }
+        public ParseErrorType? ParseErrorType { get; set; }
+    }
+
+    public class ParseErrors : List<ParseError>
+    {
+        public bool Empty() => Count == 0;
+
+        // Convenience method to free consumers from having to construct ScanErrors manually.
+        public void Add(Token token, string message, ParseErrorType? parseErrorType)
+        {
+            Add(new ParseError { Token = token, Message = message, ParseErrorType = parseErrorType });
+        }
+    }
+}

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -17,12 +17,12 @@ namespace Perlang.Parser
             }
         }
 
-        private readonly Action<Token, string, ParseErrorType?> parseErrorHandler;
+        private readonly ParseErrorHandler parseErrorHandler;
         private readonly List<Token> tokens;
 
         private int current;
 
-        public PerlangParser(List<Token> tokens, Action<Token, string, ParseErrorType?> parseErrorHandler)
+        public PerlangParser(List<Token> tokens, ParseErrorHandler parseErrorHandler)
         {
             this.parseErrorHandler = parseErrorHandler;
             this.tokens = tokens;
@@ -48,6 +48,7 @@ namespace Perlang.Parser
             }
             catch (ParseError)
             {
+                // Error has already been reported at this point
                 return null;
             }
         }

--- a/Perlang.Parser/ScanErrorHandler.cs
+++ b/Perlang.Parser/ScanErrorHandler.cs
@@ -1,0 +1,4 @@
+namespace Perlang.Parser
+{
+    public delegate void ScanErrorHandler(ScanError scanError);
+}

--- a/Perlang.Parser/ScanErrors.cs
+++ b/Perlang.Parser/ScanErrors.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Perlang.Parser
+{
+    public class ScanError
+    {
+        public int Line { get; set; }
+        public string Message { get; set; }
+    }
+
+    public class ScanErrors : List<ScanError>
+    {
+        public bool Empty() => Count == 0;
+
+        // Convenience method to free consumers from having to construct ScanErrors manually.
+        public void Add(in int line, string message)
+        {
+            Add(new ScanError { Line = line, Message = message });
+        }
+    }
+}

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -6,39 +6,39 @@ namespace Perlang.Parser
 {
     public class Scanner
     {
-        private static readonly IDictionary<string, TokenType> ReservedKeywords = 
+        private static readonly IDictionary<string, TokenType> ReservedKeywords =
             new Dictionary<string, TokenType>
-        {
-            {"and", AND},
-            {"class", CLASS},
-            {"else", ELSE},
-            {"false", FALSE},
-            {"for", FOR},
-            {"fun", FUN},
-            {"if", IF},
-            {"nil", NIL},
-            {"or", OR},
-            {"print", PRINT},
-            {"return", RETURN},
-            {"super", SUPER},
-            {"this", THIS},
-            {"true", TRUE},
-            {"var", VAR},
-            {"while", WHILE}
-        };
+            {
+                {"and", AND},
+                {"class", CLASS},
+                {"else", ELSE},
+                {"false", FALSE},
+                {"for", FOR},
+                {"fun", FUN},
+                {"if", IF},
+                {"nil", NIL},
+                {"or", OR},
+                {"print", PRINT},
+                {"return", RETURN},
+                {"super", SUPER},
+                {"this", THIS},
+                {"true", TRUE},
+                {"var", VAR},
+                {"while", WHILE}
+            };
 
         private readonly string source;
-        private readonly Action<int, string> scannerErrorHandler;
+        private readonly ScanErrorHandler scanErrorHandler;
 
         private readonly List<Token> tokens = new List<Token>();
         private int start;
         private int current;
         private int line = 1;
 
-        public Scanner(string source, Action<int,string> scannerErrorHandler)
+        public Scanner(string source, ScanErrorHandler scanErrorHandler)
         {
             this.source = source;
-            this.scannerErrorHandler = scannerErrorHandler;
+            this.scanErrorHandler = scanErrorHandler;
         }
 
         public List<Token> ScanTokens()
@@ -141,7 +141,7 @@ namespace Perlang.Parser
                     }
                     else
                     {
-                        scannerErrorHandler(line, "Unexpected character " + c);
+                        scanErrorHandler(new ScanError { Line = line, Message = "Unexpected character " + c });
                     }
 
                     break;
@@ -186,7 +186,7 @@ namespace Perlang.Parser
             // Unterminated string.
             if (IsAtEnd())
             {
-                scannerErrorHandler(line, "Unterminated string.");
+                scanErrorHandler(new ScanError { Line = line, Message = "Unterminated string." });
                 return;
             }
 
@@ -241,13 +241,13 @@ namespace Perlang.Parser
                    c == '_';
         }
 
-        private static bool IsAlphaNumeric(char c) => 
+        private static bool IsAlphaNumeric(char c) =>
             IsAlpha(c) || IsDigit(c);
 
-        private static bool IsDigit(char c) => 
+        private static bool IsDigit(char c) =>
             c >= '0' && c <= '9';
 
-        private bool IsAtEnd() => 
+        private bool IsAtEnd() =>
             current >= source.Length;
 
         private char Advance()


### PR DESCRIPTION
The previous approach had a lot of this code in the main `Program` class. This _worked_, but meant the code was much harder to use from other scenarios (embedding, unit tests etc).

The `PerlangInterpreter` class now has a proper `Eval()` method, to which you pass a `ScanErrorHandler`, a `ParseErrorHandler`, and a `ResolveErrorHandler`. This makes it fit much better with unit tests, coming up next.

(I realize while writing this that we should probably add a `RuntimeErrorHandler` or something, which we can use to propagate runtime errors to the caller as well.)