### PR TITLE
(many) Use ResolveError, ParseError etc in error handler delegates

### DIFF
--- a/Perlang.Interpreter/Delegates.cs
+++ b/Perlang.Interpreter/Delegates.cs
@@ -1,4 +1,4 @@
 namespace Perlang.Interpreter
 {
-    public delegate void ResolveErrorHandler(Token token, string message);
+    public delegate void ResolveErrorHandler(ResolveError resolveError);
 }

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -59,8 +59,7 @@ namespace Perlang.Interpreter
             }
 
             var statementParseErrors = new ParseErrors();
-            var parser = new PerlangParser(tokens,
-                (token, message, parseErrorType) => statementParseErrors.Add(token, message, parseErrorType));
+            var parser = new PerlangParser(tokens, parseError => statementParseErrors.Add(parseError));
             var statements = parser.ParseStatements();
 
             if (statementParseErrors.Empty())
@@ -69,7 +68,7 @@ namespace Perlang.Interpreter
                 // evaluation.
 
                 var resolveErrors = new ResolveErrors();
-                var resolver = new Resolver(this, (token, message) => resolveErrors.Add(token, message));
+                var resolver = new Resolver(this, resolveError => resolveErrors.Add(resolveError));
                 resolver.Resolve(statements);
 
                 if (!resolveErrors.Empty())
@@ -79,7 +78,7 @@ namespace Perlang.Interpreter
                     // to the Resolver constructor, we would have no idea if any errors has occurred at this stage.
                     foreach (ResolveError resolveError in resolveErrors)
                     {
-                        resolveErrorHandler(resolveError.Token, resolveError.Message);
+                        resolveErrorHandler(resolveError);
                     }
 
                     return null;
@@ -96,8 +95,7 @@ namespace Perlang.Interpreter
                 // is to just create a new parser at this point.
                 var expressionParseErrors = new ParseErrors();
 
-                parser = new PerlangParser(tokens,
-                    (token, message, parseErrorType) => expressionParseErrors.Add(token, message, parseErrorType));
+                parser = new PerlangParser(tokens, parseError => expressionParseErrors.Add(parseError));
                 Expr expression = parser.ParseExpression();
 
                 // TODO: This approach (parsing the provided program as a set of statements first, then an
@@ -108,7 +106,7 @@ namespace Perlang.Interpreter
                 {
                     foreach (ParseError parseError in expressionParseErrors)
                     {
-                        parseErrorHandler(parseError.Token, parseError.Message, parseError.ParseErrorType);
+                        parseErrorHandler(parseError);
                     }
 
                     return null;

--- a/Perlang.Interpreter/Program.cs
+++ b/Perlang.Interpreter/Program.cs
@@ -114,9 +114,9 @@ namespace Perlang.Interpreter
             }
         }
 
-        public void ParseError(Token token, string message, ParseErrorType? parseErrorType)
+        private void ParseError(ParseError parseError)
         {
-            if (parseErrorType == ParseErrorType.MISSING_TRAILING_SEMICOLON)
+            if (parseError.ParseErrorType == ParseErrorType.MISSING_TRAILING_SEMICOLON)
             {
                 // These errors are ignored; we will get them all them when we try to parse expressions as
                 // statements.
@@ -124,12 +124,12 @@ namespace Perlang.Interpreter
                 return;
             }
 
-            Error(token, message);
+            Error(parseError.Token, parseError.Message);
         }
 
-        private static void ResolveError(Token token, string message)
+        private static void ResolveError(ResolveError resolveError)
         {
-            Error(token, message);
+            Error(resolveError.Token, resolveError.Message);
         }
     }
 }

--- a/Perlang.Interpreter/ResolveErrors.cs
+++ b/Perlang.Interpreter/ResolveErrors.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Perlang.Parser;
 
 namespace Perlang.Interpreter
 {
@@ -7,16 +6,26 @@ namespace Perlang.Interpreter
     {
         public Token Token { get; set; }
         public string Message { get; set; }
+
+        public override string ToString()
+        {
+            string where;
+
+            if (Token.Type == TokenType.EOF)
+            {
+                where = " at end";
+            }
+            else
+            {
+                where = " at '" + Token.Lexeme + "'";
+            }
+
+            return $"[line {Token.Line}] Error{where}: {Message}";
+        }
     }
 
     public class ResolveErrors : List<ResolveError>
     {
         public bool Empty() => Count == 0;
-
-        // Convenience method to free consumers from having to construct ScanErrors manually.
-        public void Add(Token token, string message)
-        {
-            Add(new ResolveError { Token = token, Message = message });
-        }
     }
 }

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -6,7 +6,7 @@ using Perlang.Parser;
 
 namespace Perlang.Interpreter
 {
-    class Resolver : Expr.IVisitor<VoidObject>, Stmt.IVisitor<VoidObject>
+    internal class Resolver : Expr.IVisitor<VoidObject>, Stmt.IVisitor<VoidObject>
     {
         private readonly Stack<IDictionary<string, bool>> scopes = new Stack<IDictionary<string, bool>>();
         private FunctionType currentFunction = FunctionType.None;
@@ -49,7 +49,11 @@ namespace Perlang.Interpreter
 
             if (scope.ContainsKey(name.Lexeme))
             {
-                resolveErrorHandler(name, "Variable with this name already declared in this scope.");
+                resolveErrorHandler(new ResolveError
+                {
+                    Token = name,
+                    Message = "Variable with this name already declared in this scope."
+                });
             }
 
             scope[name.Lexeme] = false;
@@ -82,7 +86,7 @@ namespace Perlang.Interpreter
                 }
             }
 
-            // Not found. Assume it is global.                   
+            // Not found. Assume it is global.
         }
 
         public VoidObject VisitAssignExpr(Expr.Assign expr)
@@ -126,14 +130,14 @@ namespace Perlang.Interpreter
         {
             Resolve(expr.Left);
             Resolve(expr.Right);
-            
+
             return null;
         }
 
         public VoidObject VisitUnaryExpr(Expr.Unary expr)
         {
             Resolve(expr.Right);
-            
+
             return null;
         }
 
@@ -142,7 +146,11 @@ namespace Perlang.Interpreter
             if (!IsEmpty(scopes) &&
                 scopes.Peek()[expr.Name.Lexeme] == false)
             {
-                resolveErrorHandler(expr.Name, "Cannot read local variable in its own initializer.");
+                resolveErrorHandler(new ResolveError
+                {
+                    Token = expr.Name,
+                    Message = "Cannot read local variable in its own initializer."
+                });
             }
 
             ResolveLocal(expr, expr.Name);
@@ -205,7 +213,7 @@ namespace Perlang.Interpreter
         {
             Resolve(stmt.Condition);
             Resolve(stmt.ThenBranch);
-            
+
             if (stmt.ElseBranch != null)
             {
                 Resolve(stmt.ElseBranch);
@@ -217,7 +225,7 @@ namespace Perlang.Interpreter
         public VoidObject VisitPrintStmt(Stmt.Print stmt)
         {
             Resolve(stmt.Expression);
-            
+
             return null;
         }
 
@@ -225,7 +233,11 @@ namespace Perlang.Interpreter
         {
             if (currentFunction == FunctionType.None)
             {
-                resolveErrorHandler(stmt.Keyword, "Cannot return from top-level code.");
+                resolveErrorHandler(new ResolveError
+                {
+                    Token = stmt.Keyword,
+                    Message = "Cannot return from top-level code."
+                });
             }
 
             if (stmt.Value != null)
@@ -239,14 +251,14 @@ namespace Perlang.Interpreter
         public VoidObject VisitVarStmt(Stmt.Var stmt)
         {
             Declare(stmt.Name);
-            
+
             if (stmt.Initializer != null)
             {
                 Resolve(stmt.Initializer);
             }
 
             Define(stmt.Name);
-            
+
             return null;
         }
 
@@ -254,7 +266,7 @@ namespace Perlang.Interpreter
         {
             Resolve(stmt.Condition);
             Resolve(stmt.Body);
-            
+
             return null;
         }
 

--- a/Perlang.Parser/ParseErrorHandler.cs
+++ b/Perlang.Parser/ParseErrorHandler.cs
@@ -1,4 +1,4 @@
 namespace Perlang.Parser
 {
-    public delegate void ParseErrorHandler(Token token, string message, ParseErrorType? parseErrorType);
+    public delegate void ParseErrorHandler(ParseError parseError);
 }

--- a/Perlang.Parser/ParseErrors.cs
+++ b/Perlang.Parser/ParseErrors.cs
@@ -7,16 +7,26 @@ namespace Perlang.Parser
         public Token Token { get; set; }
         public string Message { get; set; }
         public ParseErrorType? ParseErrorType { get; set; }
+
+        public override string ToString()
+        {
+            string where;
+
+            if (Token.Type == TokenType.EOF)
+            {
+                where = " at end";
+            }
+            else
+            {
+                where = " at '" + Token.Lexeme + "'";
+            }
+
+            return $"[line {Token.Line}] Error{where}: {Message}";
+        }
     }
 
     public class ParseErrors : List<ParseError>
     {
         public bool Empty() => Count == 0;
-
-        // Convenience method to free consumers from having to construct ScanErrors manually.
-        public void Add(Token token, string message, ParseErrorType? parseErrorType)
-        {
-            Add(new ParseError { Token = token, Message = message, ParseErrorType = parseErrorType });
-        }
     }
 }

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -528,7 +528,12 @@ namespace Perlang.Parser
 
         private ParseError Error(Token token, string message, ParseErrorType? parseErrorType = null)
         {
-            parseErrorHandler(token, message, parseErrorType);
+            parseErrorHandler(new Parser.ParseError
+            {
+                Token = token,
+                Message = message,
+                ParseErrorType = parseErrorType
+            });
             return new ParseError(parseErrorType);
         }
 
@@ -561,5 +566,3 @@ namespace Perlang.Parser
         }
     }
 }
-
-    

--- a/Perlang.Parser/ScanErrors.cs
+++ b/Perlang.Parser/ScanErrors.cs
@@ -11,11 +11,5 @@ namespace Perlang.Parser
     public class ScanErrors : List<ScanError>
     {
         public bool Empty() => Count == 0;
-
-        // Convenience method to free consumers from having to construct ScanErrors manually.
-        public void Add(in int line, string message)
-        {
-            Add(new ScanError { Line = line, Message = message });
-        }
     }
 }

--- a/Perlang.Tests/EvalHelper.cs
+++ b/Perlang.Tests/EvalHelper.cs
@@ -1,0 +1,41 @@
+using Perlang.Interpreter;
+using Perlang.Parser;
+
+namespace Perlang.Tests
+{
+    internal static class EvalHelper
+    {
+        /// <summary>
+        /// Evaluates the provided expression or list of statements. If provided an expression, returns the result;
+        /// otherwise, returns null.
+        /// </summary>
+        /// <param name="source">a valid Perlang programs</param>
+        /// <returns>the result of the provided expression, or null if not provided an expression.</returns>
+        internal static object Eval(string source)
+        {
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
+            return interpreter.Eval(source, AssertFailScanErrorHandler, AssertFailParseErrorHandler,
+                AssertFailResolveErrorHandler);
+        }
+
+        private static void AssertFailScanErrorHandler(ScanError scanError)
+        {
+            throw new ScanErrorXunitException(scanError.ToString());
+        }
+
+        private static void AssertFailParseErrorHandler(ParseError parseError)
+        {
+            throw new ParseErrorXunitException(parseError.ToString());
+        }
+
+        private static void AssertFailResolveErrorHandler(ResolveError resolveError)
+        {
+            throw new ResolveErrorXunitException(resolveError.ToString());
+        }
+
+        private static void AssertFailRuntimeErrorHandler(RuntimeError runtimeError)
+        {
+            throw runtimeError;
+        }
+    }
+}

--- a/Perlang.Tests/Precedence.cs
+++ b/Perlang.Tests/Precedence.cs
@@ -1,7 +1,5 @@
-using System;
-using Perlang.Interpreter;
-using Perlang.Parser;
 using Xunit;
+using static Perlang.Tests.EvalHelper;
 
 namespace Perlang.Tests
 {
@@ -68,39 +66,6 @@ namespace Perlang.Tests
         public void parentheses_can_be_used_for_grouping()
         {
             Assert.Equal(4.0, Eval("(2 * (6 - (2 + 2)))"));
-        }
-
-        /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, returns the result;
-        /// otherwise, returns null.
-        /// </summary>
-        /// <param name="source">a valid Perlang programs</param>
-        /// <returns>the result of the provided expression, or null if not provided an expression.</returns>
-        private static object Eval(string source)
-        {
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
-            return interpreter.Eval(source, AssertFailScanErrorHandler, AssertFailParseErrorHandler,
-                AssertFailResolveErrorHandler);
-        }
-
-        private static void AssertFailScanErrorHandler(ScanError scanError)
-        {
-            MoreAssert.Fail(scanError.ToString());
-        }
-
-        private static void AssertFailParseErrorHandler(Token token, string message, ParseErrorType? parseerrortype)
-        {
-            throw new NotImplementedException();
-        }
-
-        private static void AssertFailResolveErrorHandler(Token token, string message)
-        {
-            throw new NotImplementedException();
-        }
-
-        private static void AssertFailRuntimeErrorHandler(RuntimeError runtimeError)
-        {
-            MoreAssert.Fail(runtimeError.ToString());
         }
     }
 }

--- a/Perlang.Tests/TestExceptions.cs
+++ b/Perlang.Tests/TestExceptions.cs
@@ -1,0 +1,28 @@
+using Xunit.Sdk;
+
+namespace Perlang.Tests
+{
+    internal class ScanErrorXunitException : XunitException
+    {
+        public ScanErrorXunitException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    internal class ParseErrorXunitException : XunitException
+    {
+        public ParseErrorXunitException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    internal class ResolveErrorXunitException : XunitException
+    {
+        public ResolveErrorXunitException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Again, this is mostly paving the way for other changes coming. This one is pretty nice though, since it decouples the data structure from the delegate in a nice way. If/when we want to add more fields to one of these errors, we can do so without having to touch any of the existing usages, as long as the new fields are not being used by them. OOP at its finest. :slightly_smiling_face: 