### PR TITLE
(many) Support empty statements

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -1,3 +1,8 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// Instead, change the ./scripts/generate_ast_classes.rb script that generated this code.
+//
 using System.Collections.Generic;
 
 namespace Perlang
@@ -6,6 +11,7 @@ namespace Perlang
     {
         public interface IVisitor<TR>
         {
+            TR VisitEmptyExpr(Empty expr);
             TR VisitAssignExpr(Assign expr);
             TR VisitBinaryExpr(Binary expr);
             TR VisitCallExpr(Call expr);
@@ -14,6 +20,18 @@ namespace Perlang
             TR VisitLogicalExpr(Logical expr);
             TR VisitUnaryExpr(Unary expr);
             TR VisitVariableExpr(Variable expr);
+        }
+
+        public class Empty : Expr
+        {
+
+            public Empty() {
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitEmptyExpr(this);
+            }
         }
 
         public class Assign : Expr

--- a/Perlang.Common/Stmt.cs
+++ b/Perlang.Common/Stmt.cs
@@ -1,3 +1,8 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// Instead, change the ./scripts/generate_ast_classes.rb script that generated this code.
+//
 using System.Collections.Generic;
 
 namespace Perlang

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -388,6 +388,11 @@ namespace Perlang.Interpreter
             return null;
         }
 
+        public object VisitEmptyExpr(Expr.Empty expr)
+        {
+            return null;
+        }
+
         public object VisitAssignExpr(Expr.Assign expr)
         {
             object value = Evaluate(expr.Value);

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -89,6 +89,11 @@ namespace Perlang.Interpreter
             // Not found. Assume it is global.
         }
 
+        public VoidObject VisitEmptyExpr(Expr.Empty expr)
+        {
+            return null;
+        }
+
         public VoidObject VisitAssignExpr(Expr.Assign expr)
         {
             Resolve(expr.Value);

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -434,13 +434,20 @@ namespace Perlang.Parser
                 return new Expr.Grouping(expr);
             }
 
+            if (Check(SEMICOLON))
+            {
+                // Bare semicolon, no expression inside. To avoid having to handle pesky null exceptions all over
+                // the code base, we have a dedicated expression for this.
+                return new Expr.Empty();
+            }
+
             throw Error(Peek(), "Expect expression.");
         }
 
         /// <summary>
         /// Matches the given token type(s), at the current position. If a matching token is found, it gets consumed.
         ///
-        /// For a non-consuming version of this, see <see cref="Peek"/>.
+        /// For a non-consuming version of this, see <see cref="Check"/>.
         /// </summary>
         /// <param name="types">One or more token types to match</param>
         /// <returns>true if a matching token was found and consumed, false otherwise</returns>

--- a/scripts/generate_ast_classes.rb
+++ b/scripts/generate_ast_classes.rb
@@ -105,6 +105,11 @@ def define_ast(output_dir, base_name, types)
 
   path = File.join(output_dir, base_name + ".cs");
   File.write(path, <<~EOF)
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// Instead, change the #{$0} script that generated this code.
+//
 using System.Collections.Generic;
 
 namespace Perlang
@@ -129,6 +134,7 @@ OUTPUT_DIR = 'Perlang.Common'
 
 # Expressions
 define_ast(OUTPUT_DIR, "Expr", [
+  Type.new('Empty'),
   Type.new('Assign', Field.new('Token', 'name'), Field.new('Expr', 'value')),
   Type.new('Binary', [
     Field.new('Expr', 'left'),


### PR DESCRIPTION
This might nonsensical, but it isn't. At the moment, typing ;;;; in the REPL causes an ugly exception. I think we need to be more liberal with parsing the source code than that.