### PR TITLE
(common)(interpreter) Fix NullReferenceException in RuntimeError handling

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -83,7 +83,7 @@ namespace Perlang
             }
         }
 
-        public class Call : Expr
+        public class Call : Expr, ITokenAwareExpr
         {
             public Expr Callee { get; }
             public Token Paren { get; }
@@ -131,6 +131,8 @@ namespace Perlang
                     return base.ToString();
                 }
             }
+
+            public Token Token => Paren;
         }
 
         public class Grouping : Expr
@@ -244,7 +246,7 @@ namespace Perlang
                 $"#<Identifier {Name.Lexeme}>";
         }
 
-        public class Get : Expr
+        public class Get : Expr, ITokenAwareExpr
         {
             public Expr Object { get; }
             public Token Name { get; }
@@ -264,6 +266,8 @@ namespace Perlang
             {
                 return visitor.VisitGetExpr(this);
             }
+
+            public Token Token => Name;
         }
 
         public abstract TR Accept<TR>(IVisitor<TR> visitor);

--- a/Perlang.Common/ITokenAwareExpr.cs
+++ b/Perlang.Common/ITokenAwareExpr.cs
@@ -1,0 +1,14 @@
+namespace Perlang
+{
+    /// <summary>
+    /// Interface for expressions which provide a <see cref="Token"/>. This is used to augment error handling,for a
+    /// better end-user experience.
+    /// </summary>
+    public interface ITokenAwareExpr
+    {
+        /// <summary>
+        /// Gets the token that this expression represents, or a token close to it.
+        /// </summary>
+        public Token Token { get; }
+    }
+}

--- a/Perlang.Common/RuntimeError.cs
+++ b/Perlang.Common/RuntimeError.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Perlang
@@ -7,7 +8,7 @@ namespace Perlang
     // some point anyway, at which point we should be able to completely get rid of this class altogether.
     public class RuntimeError : Exception
     {
-        public Token Token { get; }
+        public Token? Token { get; set; }
 
         public RuntimeError(Token token, string message)
             : base(message)

--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -188,7 +188,9 @@ namespace Perlang.ConsoleApp
 
         private void RuntimeError(RuntimeError error)
         {
-            standardOutputHandler($"[line {error.Token.Line}] {error.Message}");
+            string line = error.Token?.Line.ToString() ?? "unknown";
+
+            standardOutputHandler($"[line {line}] {error.Message}");
             hadRuntimeError = true;
         }
 

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -144,7 +144,7 @@ namespace Perlang.Interpreter
         }
 
         /// <summary>
-        /// Runs the provided source code, in an eval()/REPL fashion.
+        /// Runs the provided source code, in an `eval()`/REPL fashion.
         ///
         /// If provided an expression, returns the result; otherwise, null.
         /// </summary>
@@ -625,6 +625,13 @@ namespace Perlang.Interpreter
             {
                 if (e.InnerException is RuntimeError error)
                 {
+                    if (expr is ITokenAwareExpr tokenAwareExpr)
+                    {
+                        // Mutating this is ugly, but we really don't want to loose the stack trace (by creating a new
+                        // expression) at this point. An InnerException _could_ work, worth looking into at some point.
+                        error.Token = tokenAwareExpr.Token;
+                    }
+
                     runtimeErrorHandler(error);
                     return null;
                 }

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -109,5 +109,20 @@ namespace Perlang.Tests.ConsoleApp
                 "[line 1] Error at 'tickz': Failed to locate method 'tickz' in class 'DateTime'"
             }, output);
         }
+
+        // There used to be an exception in the default runtimeErrorHandler. This test would illustrate it.
+        [Fact]
+        public void ARGV_pop_with_no_arguments_throws_the_expected_exception()
+        {
+            // Cannot use 'subject' here since we need it instantiated with different parameters to provoke this exact
+            // error.
+            var program = new Program(standardOutputHandler: s => output.Add(s));
+            program.Run("Argv.pop()");
+
+            Assert.Equal(new List<string>
+            {
+                "[line 1] No arguments left"
+            }, output);
+        }
     }
 }


### PR DESCRIPTION
Discovered while working on #122, extracted to a separate PR to keep the history clean and manageable.