### PR TITLE
(ci) Build with .NET 5.0

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 5.0.102
 
       - name: Re-generate auto-generated files
         run: make auto-generated
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 5.0.102
 
       - name: Re-generate auto-generated files
         run: make auto-generated

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 5.0.102
 
       - name: Re-generate auto-generated files
         run: make auto-generated
@@ -44,18 +44,18 @@ jobs:
       #
       - name: Create linux-x64 .tar.gz file
         run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-linux-x64.tar.gz *
-        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
+        working-directory: Perlang.ConsoleApp/bin/Release/net5.0/linux-x64/publish
 
       - name: Create osx-x64 .tar.gz file
         run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-osx-x64.tar.gz *
-        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
+        working-directory: Perlang.ConsoleApp/bin/Release/net5.0/osx-x64/publish
 
       - name: Create win-x64 .tar.gz file
         run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-win-x64.tar.gz *
-        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
+        working-directory: Perlang.ConsoleApp/bin/Release/net5.0/win-x64/publish
 
       - name: List .tar.gz files
-        run: ls -l Perlang.ConsoleApp/bin/Release/netcoreapp3.1/*/*.tar.gz
+        run: ls -l Perlang.ConsoleApp/bin/Release/net5.0/*/*.tar.gz
 
       #
       # Upload files to releases server via rsync
@@ -65,7 +65,7 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           ARGS: "-rltgoDzvO"
-          SOURCE: "./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/*.tar.gz"
+          SOURCE: "./Perlang.ConsoleApp/bin/Release/net5.0/linux-x64/*.tar.gz"
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
@@ -76,7 +76,7 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           ARGS: "-rltgoDzvO"
-          SOURCE: "./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/*.tar.gz"
+          SOURCE: "./Perlang.ConsoleApp/bin/Release/net5.0/osx-x64/*.tar.gz"
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
@@ -87,7 +87,7 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           ARGS: "-rltgoDzvO"
-          SOURCE: "./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/*.tar.gz"
+          SOURCE: "./Perlang.ConsoleApp/bin/Release/net5.0/win-x64/*.tar.gz"
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
     <!-- C# analyzers configuration -->
     <PropertyGroup>
         <CodeAnalysisRuleSet>$(SolutionDir)global.ruleset</CodeAnalysisRuleSet>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ run: auto-generated
 	# Cannot use 'dotnet run' at the moment, since it's impossible to pass
 	# /p:SolutionDir=$(pwd)/ to it.
 	dotnet build
-	./Perlang.ConsoleApp/bin/Debug/netcoreapp3.1/perlang
+	./Perlang.ConsoleApp/bin/Debug/net5.0/perlang

--- a/Perlang.Common/Perlang.Common.csproj
+++ b/Perlang.Common/Perlang.Common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <RootNamespace>Perlang</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Nullable>disable</Nullable>

--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PublishTrimmed>true</PublishTrimmed>
 
@@ -24,9 +23,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- Assemblies implicitly referenced via reflection must be listed here, to be included in the
-             trimmed result -->
+        <!-- Assemblies implicitly referenced via reflection must be listed here, to be included in the trimmed result.
+             If you get an error about 'Could not load type 'Foo' from assembly 'Bar', add the assembly for the _Foo_
+             type to this list. -->
         <TrimmerRootAssembly Include="System.Runtime.Extensions" />
+        <TrimmerRootAssembly Include="System.Runtime.InteropServices" />
+
+        <!-- Certain assemblies generate errors on R2R compilation. We run them in JIT mode for now. -->
+        <PublishReadyToRunExclude Include="System.Diagnostics.Process.dll" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Perlang.Interpreter/Perlang.Interpreter.csproj
+++ b/Perlang.Interpreter/Perlang.Interpreter.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Humanizer;
-using Perlang.Interpreter.Extensions;
 using Perlang.Interpreter.Resolution;
 using static Perlang.TokenType;
 

--- a/Perlang.Parser/Perlang.Parser.csproj
+++ b/Perlang.Parser/Perlang.Parser.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/Perlang.Stdlib/Perlang.Stdlib.csproj
+++ b/Perlang.Stdlib/Perlang.Stdlib.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>Perlang</RootNamespace>
     </PropertyGroup>

--- a/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
+++ b/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 

--- a/Perlang.Tests/Perlang.Tests.csproj
+++ b/Perlang.Tests/Perlang.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/scripts/local_install_linux.sh
+++ b/scripts/local_install_linux.sh
@@ -10,4 +10,4 @@ set -e
 mkdir -p $HOME/.perlang/nightly/bin
 
 dotnet publish Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
-cp -r Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish/* $HOME/.perlang/nightly/bin
+cp -r Perlang.ConsoleApp/bin/Release/net5.0/linux-x64/publish/* $HOME/.perlang/nightly/bin


### PR DESCRIPTION
.NET 5 was [released yesterday](https://devblogs.microsoft.com/dotnet/announcing-net-5-0/). This PR moves CI building to the new version, and hence published versions will also bundle the .NET 5 runtime when this gets merged.

`make install` (& likely publishing in CI) currently fails on the following error, will need to look into this further some other day before this is mergable.

```
/usr/share/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(397,5): error : Error compiling obj/Release/net5.0/linux-x64/linked/System.Diagnostics.Process.dll: Could not load type 'System.Threading.Tasks.TaskCompletionSource`1' from assembly 'System.Collections, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. [/home/per/git/perlang/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj]
/usr/share/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(397,5): error : Error: compilation failed for "obj/Release/net5.0/linux-x64/linked/System.Diagnostics.Process.dll" (0x80131522) [/home/per/git/perlang/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj]
/usr/share/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(295,5): error NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false. [/home/per/git/perlang/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj]
```