### PR TITLE
(interpreter) First steps towards immutability

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -42,20 +42,42 @@ namespace Perlang
             }
         }
 
+        /// <summary>
+        /// An assignment expression.
+        /// </summary>
         public class Assign : Expr
         {
-            public Token Name { get; }
+            /// <summary>
+            /// Gets the identifier which is the target of the assignment. For example, in the `a = 42` expression, `a` is the
+            /// identifier.
+            /// </summary>
+            public new Identifier Identifier { get; }
+
+            /// <summary>
+            /// Gets the value being assigned. Can be either a compile-time constant or an expression with a dynamic
+            /// value, computed at runtime.
+            /// </summary>
             public Expr Value { get; }
 
-            public Assign(Token name, Expr value)
+            /// <summary>
+            /// Gets the name of the identifier being assigned to.
+            /// </summary>
+            public Token Name => Identifier.Name;
+
+            public Assign(Identifier identifier, Expr value)
             {
-                Name = name;
+                Identifier = identifier;
                 Value = value;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)
             {
                 return visitor.VisitAssignExpr(this);
+            }
+
+            public override string ToString()
+            {
+                return $"{Name.Lexeme} = {Value}";
             }
         }
 

--- a/Perlang.Common/VisitorBase.cs
+++ b/Perlang.Common/VisitorBase.cs
@@ -11,6 +11,32 @@ namespace Perlang
     /// </summary>
     public abstract class VisitorBase : Expr.IVisitor<VoidObject>, Stmt.IVisitor<VoidObject>
     {
+        //
+        // Protected methods and methods they depend on. Used by child classes to perform the visitation.
+        //
+
+        protected void Visit(IEnumerable<Stmt> statements)
+        {
+            foreach (Stmt statement in statements)
+            {
+                Visit(statement);
+            }
+        }
+
+        private void Visit(Stmt stmt)
+        {
+            stmt.Accept(this);
+        }
+
+        protected void Visit(Expr expr)
+        {
+            expr.Accept(this);
+        }
+
+        //
+        // Implementation of IVisitor interface methods
+        //
+
         public virtual VoidObject VisitEmptyExpr(Expr.Empty expr)
         {
             return VoidObject.Void;
@@ -178,24 +204,6 @@ namespace Perlang
             Visit(stmt.Body);
 
             return VoidObject.Void;
-        }
-
-        private void Visit(IEnumerable<Stmt> statements)
-        {
-            foreach (Stmt statement in statements)
-            {
-                Visit(statement);
-            }
-        }
-
-        private void Visit(Stmt stmt)
-        {
-            stmt.Accept(this);
-        }
-
-        private void Visit(Expr expr)
-        {
-            expr.Accept(this);
         }
     }
 }

--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Perlang.Interpreter;
 using Perlang.Interpreter.Resolution;
-using Perlang.Interpreter.Typing;
 using Perlang.Parser;
 using ParseError = Perlang.Parser.ParseError;
 
@@ -168,7 +167,7 @@ namespace Perlang.ConsoleApp
 
         internal void Run(string source)
         {
-            object result = interpreter.Eval(source, ScanError, ParseError, ResolveError, TypeValidationError);
+            object result = interpreter.Eval(source, ScanError, ParseError, ResolveError, ValidationError, ValidationError);
 
             if (result != null)
             {
@@ -230,9 +229,9 @@ namespace Perlang.ConsoleApp
             Error(resolveError.Token, resolveError.Message);
         }
 
-        private void TypeValidationError(TypeValidationError typeValidationError)
+        private void ValidationError(ValidationError validationError)
         {
-            Error(typeValidationError.Token, typeValidationError.Message);
+            Error(validationError.Token, validationError.Message);
         }
 
         private class AutoCompletionHandler : IAutoCompleteHandler

--- a/Perlang.Interpreter/ErrorHandlers.cs
+++ b/Perlang.Interpreter/ErrorHandlers.cs
@@ -1,8 +1,7 @@
 using Perlang.Interpreter.Resolution;
-using Perlang.Interpreter.Typing;
 
 namespace Perlang.Interpreter
 {
     public delegate void ResolveErrorHandler(ResolveError resolveError);
-    public delegate void TypeValidationErrorHandler(TypeValidationError typeValidationError);
+    public delegate void ValidationErrorHandler(ValidationError typeValidationError);
 }

--- a/Perlang.Interpreter/Immutability/ImmutabilityValidationError.cs
+++ b/Perlang.Interpreter/Immutability/ImmutabilityValidationError.cs
@@ -1,0 +1,13 @@
+namespace Perlang.Interpreter.Immutability
+{
+    /// <summary>
+    /// Exception thrown on immutability validation errors.
+    /// </summary>
+    public class ImmutabilityValidationError : ValidationError
+    {
+        public ImmutabilityValidationError(Token token, string message)
+            : base(token, message)
+        {
+        }
+    }
+}

--- a/Perlang.Interpreter/Immutability/ImmutabilityValidator.cs
+++ b/Perlang.Interpreter/Immutability/ImmutabilityValidator.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using Perlang.Interpreter.Resolution;
+
+namespace Perlang.Interpreter.Immutability
+{
+    /// <summary>
+    /// Validator which ensures that objects which are intended to be immutable (either by nature or because they have
+    /// been configured in a particular way) cannot be mutated.
+    /// </summary>
+    internal class ImmutabilityValidator : VisitorBase
+    {
+        private readonly Action<ValidationError> immutabilityValidationErrorCallback;
+        private readonly Func<Expr, Binding?> getVariableOrFunctionBinding;
+
+        public static void Validate(
+            ImmutableList<Stmt> statements,
+            Action<ValidationError> immutabilityValidationErrorCallback,
+            Func<Expr, Binding?> getVariableOrFunctionBinding)
+        {
+            new ImmutabilityValidator(immutabilityValidationErrorCallback, getVariableOrFunctionBinding).Visit(statements);
+        }
+
+        public static void Validate(
+            Expr expr,
+            Action<ValidationError> immutabilityValidationErrorCallback,
+            Func<Expr, Binding?> getVariableOrFunctionBinding)
+        {
+            new ImmutabilityValidator(immutabilityValidationErrorCallback, getVariableOrFunctionBinding).Visit(expr);
+        }
+
+        private ImmutabilityValidator(
+            Action<ValidationError> immutabilityValidationErrorCallback,
+            Func<Expr, Binding?> getVariableOrFunctionBinding)
+        {
+            this.immutabilityValidationErrorCallback = immutabilityValidationErrorCallback;
+            this.getVariableOrFunctionBinding = getVariableOrFunctionBinding;
+        }
+
+        public override VoidObject VisitAssignExpr(Expr.Assign expr)
+        {
+            base.VisitAssignExpr(expr);
+
+            Binding? binding = getVariableOrFunctionBinding(expr);
+
+            if (binding == null)
+            {
+                throw new PerlangInterpreterException($"Failed to locate binding for {expr.Identifier}");
+            }
+
+            if (binding.IsImmutable)
+            {
+                immutabilityValidationErrorCallback(new ImmutabilityValidationError(
+                    expr.Name,
+                    $"{binding.ObjectTypeTitleized} '{expr.Name.Lexeme}' is immutable and cannot be modified."
+                ));
+            }
+
+            return VoidObject.Void;
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolution/Binding.cs
+++ b/Perlang.Interpreter/Resolution/Binding.cs
@@ -29,6 +29,29 @@ namespace Perlang.Interpreter.Resolution
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:DocumentationTextMustEndWithAPeriod", Justification = "Code block.")]
         public Expr ReferringExpr { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this binding is mutable (`true`) or immutable (`false`). All binding classes
+        /// not explicitly overriding this are immutable by default.
+        /// </summary>
+        public virtual bool IsMutable => false;
+
+        /// <summary>
+        /// Gets a value indicating whether this binding is immutable (`true`) or mutable (`false`). Convenience
+        /// property which is always the opposite of <see cref="IsMutable"/>.
+        /// </summary>
+        public bool IsImmutable => !IsMutable;
+
+        /// <summary>
+        /// Gets the type of object this binding refers to. Can be used to e.g. construct helpful error messages to end
+        /// users.
+        /// </summary>
+        public abstract string ObjectType { get; }
+
+        /// <summary>
+        /// Gets the type of object this binding refers to, with the initial letter converted to upper-case.
+        /// </summary>
+        public object ObjectTypeTitleized => ObjectType[0].ToString().ToUpper() + ObjectType.Substring(1);
+
         protected Binding(TypeReference? typeReference, Expr referringExpr)
         {
             // We allow null references on this one to sneak through, since it allows this test to succeed:

--- a/Perlang.Interpreter/Resolution/ClassBinding.cs
+++ b/Perlang.Interpreter/Resolution/ClassBinding.cs
@@ -9,6 +9,8 @@ namespace Perlang.Interpreter.Resolution
     {
         public PerlangClass PerlangClass { get; }
 
+        public override string ObjectType => "class";
+
         public ClassBinding(Expr referringExpr, PerlangClass perlangClass)
             : base(new TypeReference(typeof(PerlangClass)), referringExpr)
         {

--- a/Perlang.Interpreter/Resolution/FunctionBinding.cs
+++ b/Perlang.Interpreter/Resolution/FunctionBinding.cs
@@ -6,8 +6,9 @@ namespace Perlang.Interpreter.Resolution
     internal class FunctionBinding : Binding, IDistanceAwareBinding
     {
         public int Distance { get; }
-
         public Stmt.Function Function { get; }
+
+        public override string ObjectType => "function";
 
         public FunctionBinding(Stmt.Function function, TypeReference typeReference, int distance, Expr referringExpr)
             : base(typeReference, referringExpr)

--- a/Perlang.Interpreter/Resolution/NativeClassBinding.cs
+++ b/Perlang.Interpreter/Resolution/NativeClassBinding.cs
@@ -2,9 +2,17 @@ using System;
 
 namespace Perlang.Interpreter.Resolution
 {
+    /// <summary>
+    /// Binding implementation for referring to native .NET classes.
+    /// </summary>
     internal class NativeClassBinding : Binding
     {
         public Type Type { get; }
+
+        // The fact that this is a "native" class is an implementation detail. The end goal is that Perlang classes and
+        // "native" classes should be indistinguishable; in fact, Perlang classes aim to become full CLR classes in the
+        // long run.
+        public override string ObjectType => "class";
 
         internal NativeClassBinding(Expr referringExpr, Type type)
             : base(new TypeReference(type), referringExpr)

--- a/Perlang.Interpreter/Resolution/VariableBinding.cs
+++ b/Perlang.Interpreter/Resolution/VariableBinding.cs
@@ -8,6 +8,9 @@ namespace Perlang.Interpreter.Resolution
     {
         public int Distance { get; }
 
+        public override string ObjectType => "variable";
+        public override bool IsMutable => true;
+
         public VariableBinding(TypeReference? typeReference, int distance, Expr referringExpr)
             : base(typeReference, referringExpr)
         {

--- a/Perlang.Interpreter/Typing/TypeValidationError.cs
+++ b/Perlang.Interpreter/Typing/TypeValidationError.cs
@@ -1,16 +1,13 @@
 namespace Perlang.Interpreter.Typing
 {
-    public class TypeValidationError : PerlangInterpreterException
+    /// <summary>
+    /// Exception thrown on type validation errors.
+    /// </summary>
+    public class TypeValidationError : ValidationError
     {
-        /// <summary>
-        /// Gets the approximate location at which the error occurred.
-        /// </summary>
-        public Token Token { get; }
-
         public TypeValidationError(Token token, string message)
-            : base(message)
+            : base(token, message)
         {
-            Token = token;
         }
     }
 }

--- a/Perlang.Interpreter/Typing/TypeValidationErrors.cs
+++ b/Perlang.Interpreter/Typing/TypeValidationErrors.cs
@@ -1,9 +1,0 @@
-using System.Collections.Generic;
-
-namespace Perlang.Interpreter.Typing
-{
-    public class TypeValidationErrors : List<TypeValidationError>
-    {
-        public bool Empty() => Count == 0;
-    }
-}

--- a/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -32,7 +32,10 @@ namespace Perlang.Interpreter.Typing
     /// </summary>
     internal static class TypeValidator
     {
-        public static void Validate(IList<Stmt> statements, Action<TypeValidationError> typeValidationErrorCallback, Func<Expr, Binding> getVariableOrFunctionCallback)
+        public static void Validate(
+            IList<Stmt> statements,
+            Action<TypeValidationError> typeValidationErrorCallback,
+            Func<Expr, Binding> getVariableOrFunctionCallback)
         {
             bool typeResolvingFailed = false;
 
@@ -47,7 +50,8 @@ namespace Perlang.Interpreter.Typing
 
             try
             {
-                typeResolver.Validate(statements);
+                // Walk the tree, resolving explicit and inferred type references to their corresponding CLR types.
+                typeResolver.Resolve(statements);
             }
             catch (TypeValidationError e)
             {
@@ -107,7 +111,7 @@ namespace Perlang.Interpreter.Typing
 
             try
             {
-                typeResolver.Validate(expr);
+                typeResolver.Resolve(expr);
             }
             catch (TypeValidationError e)
             {
@@ -162,23 +166,14 @@ namespace Perlang.Interpreter.Typing
                 this.typeValidationErrorCallback = typeValidationErrorCallback;
             }
 
-            internal void Validate(IList<Stmt> statements)
+            public void Resolve(IList<Stmt> statements)
             {
-                // Walk the tree, resolving explicit and inferred type references to their corresponding CLR types.
-                foreach (Stmt statement in statements)
-                {
-                    Validate(statement);
-                }
+                Visit(statements);
             }
 
-            internal void Validate(Expr expr)
+            public void Resolve(Expr expr)
             {
-                expr.Accept(this);
-            }
-
-            private void Validate(Stmt stmt)
-            {
-                stmt.Accept(this);
+                Visit(expr);
             }
 
             //

--- a/Perlang.Interpreter/ValidationError.cs
+++ b/Perlang.Interpreter/ValidationError.cs
@@ -1,0 +1,19 @@
+namespace Perlang.Interpreter
+{
+    /// <summary>
+    /// Base class for different kinds of validation errors.
+    /// </summary>
+    public abstract class ValidationError : PerlangInterpreterException
+    {
+        /// <summary>
+        /// Gets the approximate location at which the error occurred.
+        /// </summary>
+        public Token Token { get; }
+
+        protected ValidationError(Token token, string message)
+            : base(message)
+        {
+            Token = token;
+        }
+    }
+}

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -19,8 +19,8 @@ namespace Perlang.Parser
     /// <summary>
     /// Parses Perlang code to either a list of statements or a single expression.
     ///
-    /// This class is not thread safe; a single instance of the class can not be used simultaneously from multiple
-    /// threads.
+    /// This class is not thread safe; a single instance of the class can not be safely used from multiple threads
+    /// simultaneously.
     /// </summary>
     public class PerlangParser
     {
@@ -390,8 +390,7 @@ namespace Perlang.Parser
 
                 if (expr is Expr.Identifier identifier)
                 {
-                    Token name = identifier.Name;
-                    return new Expr.Assign(name, value);
+                    return new Expr.Assign(identifier, value);
                 }
 
                 Error(equals, "Invalid assignment target.");

--- a/Perlang.Stdlib/Exceptions/StdlibException.cs
+++ b/Perlang.Stdlib/Exceptions/StdlibException.cs
@@ -1,7 +1,7 @@
 namespace Perlang.Exceptions
 {
     /// <summary>
-    /// Abstract base class for exceptions thrown by stdlib.
+    /// Abstract base class for exceptions thrown by the Perlang standard library.
     /// </summary>
     public abstract class StdlibException : RuntimeError
     {

--- a/Perlang.Tests.Integration/Blocks.cs
+++ b/Perlang.Tests.Integration/Blocks.cs
@@ -9,20 +9,20 @@ namespace Perlang.Tests.Integration
         [Fact]
         public void calling_an_undefined_function_inside_a_block_throws_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("if (true) { die_hard(); }");
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("if (true) { die_hard(); }");
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Attempting to call undefined function 'die_hard'", exception.Message);
         }
 
         [Fact]
         public void referring_to_an_undefined_variable_inside_a_block_throws_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("if (true) { var a = die_hard; }");
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("if (true) { var a = die_hard; }");
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'die_hard'", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/EvalHelper.cs
+++ b/Perlang.Tests.Integration/EvalHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Perlang.Interpreter;
 using Perlang.Interpreter.Resolution;
-using Perlang.Interpreter.Typing;
 using Perlang.Parser;
 
 namespace Perlang.Tests.Integration
@@ -17,8 +16,8 @@ namespace Perlang.Tests.Integration
         /// errors are encountered, only the first will be thrown.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>The result of evaluating the provided expression, or `null` if provided a list of statements or
-        /// an invalid program.</returns>
+        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
+        /// provided a valid expression, `Value` will be set to `null`.</returns>
         internal static object Eval(string source)
         {
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
@@ -28,7 +27,8 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
         }
 
@@ -41,7 +41,8 @@ namespace Perlang.Tests.Integration
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
-        /// <returns>An EvalResult with the result of the provided expression, or null if not provided an expression.</returns>
+        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
+        /// provided a valid expression, `Value` will be set to `null`.</returns>
         internal static EvalResult EvalWithRuntimeCatch(string source, params string[] arguments)
         {
             var result = new EvalResult();
@@ -53,21 +54,24 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
 
             return result;
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see cref="EvalResult.Value"/>
-        /// contains the value of the evaluated expression; otherwise, this method will return `null`.
+        /// Evaluates the provided expression or list of statements. If provided an expression, <see
+        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
+        /// `null`.
         ///
-        /// This method will propagate all errors apart from  <see cref="ParseError"/> to the caller. Runtime errors
+        /// This method will propagate all errors apart from  <see cref="ParseError"/> to the caller. Parse errors
         /// will be available in the returned <see cref="EvalResult"/>.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the result of the provided expression, or `null` if not provided an expression.</returns>
+        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
+        /// provided a valid expression, `Value` will be set to `null`.</returns>
         internal static EvalResult EvalWithParseErrorCatch(string source)
         {
             var result = new EvalResult();
@@ -78,21 +82,24 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 parseError => result.ParseErrors.Add(parseError),
                 AssertFailResolveErrorHandler,
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
 
             return result;
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see cref="EvalResult.Value"/>
-        /// contains the value of the evaluated expression; otherwise, this method will return `null`.
+        /// Evaluates the provided expression or list of statements. If provided an expression, <see
+        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
+        /// `null`.
         ///
-        /// This method will propagate all errors apart from  <see cref="ResolveError"/> to the caller. Runtime errors
+        /// This method will propagate all errors apart from  <see cref="ResolveError"/> to the caller. Resolve errors
         /// will be available in the returned <see cref="EvalResult"/>.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the result of the provided expression, or `null` if not provided an expression.</returns>
+        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
+        /// provided a valid expression, `Value` will be set to `null`.</returns>
         internal static EvalResult EvalWithResolveErrorCatch(string source)
         {
             var result = new EvalResult();
@@ -103,13 +110,25 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 resolveError => result.ResolveErrors.Add(resolveError),
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
 
             return result;
         }
 
-        internal static EvalResult EvalWithTypeValidationErrorCatch(string source)
+        /// <summary>
+        /// Evaluates the provided expression or list of statements. If provided an expression, <see
+        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
+        /// `null`.
+        ///
+        /// This method will propagate all errors apart from  <see cref="ValidationError"/> to the caller. Validation
+        /// errors will be available in the returned <see cref="EvalResult"/>.
+        /// </summary>
+        /// <param name="source">A valid Perlang program.</param>
+        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
+        /// provided a valid expression, `Value` will be set to `null`.</returns>
+        internal static EvalResult EvalWithValidationErrorCatch(string source)
         {
             var result = new EvalResult();
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
@@ -119,7 +138,8 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                typeValidationError => result.TypeValidationErrors.Add(typeValidationError)
+                validationError => result.ValidationErrors.Add(validationError),
+                validationError => result.ValidationErrors.Add(validationError)
             );
 
             return result;
@@ -142,7 +162,8 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
 
             return output;
@@ -191,7 +212,8 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                AssertFailTypeValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler
             );
         }
 
@@ -215,9 +237,9 @@ namespace Perlang.Tests.Integration
             throw runtimeError;
         }
 
-        private static void AssertFailTypeValidationErrorHandler(TypeValidationError typeValidationError)
+        private static void AssertFailValidationErrorHandler(ValidationError validationError)
         {
-            throw typeValidationError;
+            throw validationError;
         }
     }
 }

--- a/Perlang.Tests.Integration/EvalResult.cs
+++ b/Perlang.Tests.Integration/EvalResult.cs
@@ -1,16 +1,18 @@
+#nullable enable
 using System.Collections.Generic;
+using Perlang.Interpreter;
 using Perlang.Interpreter.Resolution;
-using Perlang.Interpreter.Typing;
 using Perlang.Parser;
 
 namespace Perlang.Tests.Integration
 {
+    // TODO: Change to be a generic class, with ParseError, RuntimeError etc as the type parameter.
     internal class EvalResult
     {
-        public object Value { get; set; }
+        public object? Value { get; set; }
         public List<ParseError> ParseErrors { get; } = new List<ParseError>();
         public List<RuntimeError> RuntimeErrors { get; } = new List<RuntimeError>();
         public List<ResolveError> ResolveErrors { get; } = new List<ResolveError>();
-        public TypeValidationErrors TypeValidationErrors { get; } = new TypeValidationErrors();
+        public List<ValidationError> ValidationErrors { get; } = new List<ValidationError>();
     }
 }

--- a/Perlang.Tests.Integration/Function/Arguments.cs
+++ b/Perlang.Tests.Integration/Function/Arguments.cs
@@ -174,10 +174,10 @@ namespace Perlang.Tests.Integration.Function
                 f(1, 2, 3, 4);
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Function 'f' has 2 parameter\\(s\\) but was called with 4 argument\\(s\\)",
                 exception.Message);
         }
@@ -191,12 +191,15 @@ namespace Perlang.Tests.Integration.Function
                 f(1);
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
-            Assert.Matches("Function 'f' has 2 parameter\\(s\\) but was called with 1 argument\\(s\\)",
-                exception.Message);
+            Assert.Single(result.ValidationErrors);
+
+            Assert.Matches(
+                "Function 'f' has 2 parameter\\(s\\) but was called with 1 argument\\(s\\)",
+                exception.Message
+            );
         }
 
         [Fact]

--- a/Perlang.Tests.Integration/Immutability/Function.cs
+++ b/Perlang.Tests.Integration/Immutability/Function.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Immutability
+{
+    public class Function
+    {
+        // Functions are inherently immutable. Once defined, a function cannot be redefined with another function body.
+
+        [Fact]
+        public void function_cannot_be_overwritten_by_another_function_with_the_same_name()
+        {
+            string source = @"
+                fun f(): void {}
+                fun f(): void {}
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+        }
+
+        [Fact]
+        public void function_cannot_be_overwritten_by_a_variable()
+        {
+            string source = @"
+                fun f(): void {}
+                var f = 42;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+        }
+
+        [Fact]
+        public void function_cannot_be_overwritten_by_assignment()
+        {
+            string source = @"
+                fun f(): void {}
+                f = 42;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
+
+            Assert.Single(result.ValidationErrors);
+            Assert.Matches("Function 'f' is immutable and cannot be modified.", exception.Message);
+        }
+    }
+}

--- a/Perlang.Tests.Integration/Operator/Division.cs
+++ b/Perlang.Tests.Integration/Operator/Division.cs
@@ -43,10 +43,10 @@ namespace Perlang.Tests.Integration.Operator
                 ""1"" / 1
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
         }
 
@@ -57,10 +57,10 @@ namespace Perlang.Tests.Integration.Operator
                 1 / ""1""
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -27,10 +27,10 @@ namespace Perlang.Tests.Integration.Operator
                 x--;
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'x'", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -27,10 +27,10 @@ namespace Perlang.Tests.Integration.Operator
                 x++;
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'x'", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
@@ -16,10 +16,10 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_decode_with_no_arguments_throws_the_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("Base64.decode()");
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("Base64.decode()");
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Contains("Method 'decode' has 1 parameter(s) but was called with 0 argument(s)", exception.Message);
         }
 
@@ -39,10 +39,10 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_decode_with_a_numeric_argument_throws_the_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("Base64.decode(123.45)");
-            var runtimeError = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("Base64.decode(123.45)");
+            var runtimeError = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
 
             Assert.Equal("Cannot pass System.Double argument as System.String parameter to decode()", runtimeError.Message);
         }

--- a/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
@@ -10,10 +10,10 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_encode_with_no_arguments_throws_the_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("Base64.encode()");
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("Base64.encode()");
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Contains("Method 'encode' has 1 parameter(s) but was called with 0 argument(s)", exception.Message);
         }
 
@@ -45,10 +45,10 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_encode_with_a_numeric_argument_throws_the_expected_exception()
         {
-            var result = EvalWithTypeValidationErrorCatch("Base64.encode(123.45)");
-            var runtimeError = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch("Base64.encode(123.45)");
+            var runtimeError = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
 
             Assert.Equal("Cannot pass System.Double argument as System.String parameter to encode()", runtimeError.Message);
         }

--- a/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -39,10 +39,10 @@ namespace Perlang.Tests.Integration.Typing
                 var s: int = ""Hello World"";
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Cannot assign String value to Int32", exception.Message);
         }
 
@@ -53,10 +53,10 @@ namespace Perlang.Tests.Integration.Typing
                 var s: SomeUnknownType = ""Hello World"";
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -71,10 +71,10 @@ namespace Perlang.Tests.Integration.Typing
                 }
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -89,10 +89,10 @@ namespace Perlang.Tests.Integration.Typing
                 }
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -123,10 +123,10 @@ namespace Perlang.Tests.Integration.Typing
                 foo(42);
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Cannot pass System.Int32 argument as parameter 's: System.String'", exception.Message);
         }
 
@@ -172,10 +172,10 @@ namespace Perlang.Tests.Integration.Typing
                 }
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -192,10 +192,10 @@ namespace Perlang.Tests.Integration.Typing
                 print s;
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Cannot assign String value to Int32", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Var/VarTests.cs
+++ b/Perlang.Tests.Integration/Var/VarTests.cs
@@ -299,10 +299,10 @@ namespace Perlang.Tests.Integration.Var
                 print not_defined;
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 
@@ -315,10 +315,10 @@ namespace Perlang.Tests.Integration.Var
                 }
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.First();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.First();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 
@@ -329,10 +329,10 @@ namespace Perlang.Tests.Integration.Var
                 var a;
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Type inference for variable 'a' cannot be performed when initializer is not specified", exception.Message);
         }
 
@@ -351,10 +351,10 @@ namespace Perlang.Tests.Integration.Var
                 print ""ok"";
             ";
 
-            var result = EvalWithTypeValidationErrorCatch(source);
-            var exception = result.TypeValidationErrors.FirstOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.ValidationErrors.FirstOrDefault();
 
-            Assert.Single(result.TypeValidationErrors);
+            Assert.Single(result.ValidationErrors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -13,5 +13,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickz/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Titleized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This implements a significant subset of #125. Once this is done and merged, I should be able to fix #122 to handle the immutability right from the start. It simply doesn't make any sense to be able to overwrite `ARGV` with some random content, that's just plain bizarre. (and not very type-safe either...)