### PR TITLE
(tests) Make EvalResult a generic class

### DIFF
--- a/Perlang.Tests.Integration/Blocks.cs
+++ b/Perlang.Tests.Integration/Blocks.cs
@@ -10,9 +10,9 @@ namespace Perlang.Tests.Integration
         public void calling_an_undefined_function_inside_a_block_throws_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("if (true) { die_hard(); }");
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Attempting to call undefined function 'die_hard'", exception.Message);
         }
 
@@ -20,9 +20,9 @@ namespace Perlang.Tests.Integration
         public void referring_to_an_undefined_variable_inside_a_block_throws_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("if (true) { var a = die_hard; }");
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'die_hard'", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Classes/ClassesTests.cs
+++ b/Perlang.Tests.Integration/Classes/ClassesTests.cs
@@ -34,9 +34,9 @@ namespace Perlang.Tests.Integration.Classes
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Class Foo already defined; cannot redefine", exception.Message);
         }
 
@@ -65,9 +65,9 @@ namespace Perlang.Tests.Integration.Classes
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Class Base64 already defined; cannot redefine", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/EvalHelper.cs
+++ b/Perlang.Tests.Integration/EvalHelper.cs
@@ -9,15 +9,13 @@ namespace Perlang.Tests.Integration
     internal static class EvalHelper
     {
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, returns the result;
-        /// otherwise, returns null.
+        /// Evaluates the provided expression or list of statements, returning the evaluated value.
         ///
         /// This method will propagate both scanner, parser, resolver and runtime errors to the caller. If multiple
         /// errors are encountered, only the first will be thrown.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
-        /// provided a valid expression, `Value` will be set to `null`.</returns>
+        /// <returns>The result of evaluating the provided expression, or `null` if provided a list of statements.</returns>
         internal static object Eval(string source)
         {
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
@@ -33,21 +31,22 @@ namespace Perlang.Tests.Integration
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see cref="EvalResult.Value"/>
-        /// contains the value of the evaluated expression; otherwise, this method will return `null`.
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
-        /// This method will propagate all errors apart from runtime errors to the caller. Runtime errors will be
-        /// available in the returned <see cref="EvalResult"/>.
+        /// This method will propagate all errors apart from  <see cref="RuntimeError"/> to the caller. Runtime errors
+        /// will be available in the returned <see cref="EvalResult{T}"/>.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
-        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
-        /// provided a valid expression, `Value` will be set to `null`.</returns>
-        internal static EvalResult EvalWithRuntimeCatch(string source, params string[] arguments)
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<RuntimeError> EvalWithRuntimeCatch(string source, params string[] arguments)
         {
-            var result = new EvalResult();
+            var result = new EvalResult<RuntimeError>();
             var interpreter =
-                new PerlangInterpreter(runtimeError => result.RuntimeErrors.Add(runtimeError), null, arguments);
+                new PerlangInterpreter(runtimeError => result.Errors.Add(runtimeError), null, arguments);
 
             result.Value = interpreter.Eval(
                 source,
@@ -62,25 +61,25 @@ namespace Perlang.Tests.Integration
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see
-        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
-        /// `null`.
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
         /// This method will propagate all errors apart from  <see cref="ParseError"/> to the caller. Parse errors
-        /// will be available in the returned <see cref="EvalResult"/>.
+        /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
-        /// provided a valid expression, `Value` will be set to `null`.</returns>
-        internal static EvalResult EvalWithParseErrorCatch(string source)
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<ParseError> EvalWithParseErrorCatch(string source)
         {
-            var result = new EvalResult();
+            var result = new EvalResult<ParseError>();
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
 
             result.Value = interpreter.Eval(
                 source,
                 AssertFailScanErrorHandler,
-                parseError => result.ParseErrors.Add(parseError),
+                parseError => result.Errors.Add(parseError),
                 AssertFailResolveErrorHandler,
                 AssertFailValidationErrorHandler,
                 AssertFailValidationErrorHandler
@@ -90,26 +89,26 @@ namespace Perlang.Tests.Integration
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see
-        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
-        /// `null`.
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
         /// This method will propagate all errors apart from  <see cref="ResolveError"/> to the caller. Resolve errors
-        /// will be available in the returned <see cref="EvalResult"/>.
+        /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
-        /// provided a valid expression, `Value` will be set to `null`.</returns>
-        internal static EvalResult EvalWithResolveErrorCatch(string source)
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<ResolveError> EvalWithResolveErrorCatch(string source)
         {
-            var result = new EvalResult();
+            var result = new EvalResult<ResolveError>();
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
 
             result.Value = interpreter.Eval(
                 source,
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
-                resolveError => result.ResolveErrors.Add(resolveError),
+                resolveError => result.Errors.Add(resolveError),
                 AssertFailValidationErrorHandler,
                 AssertFailValidationErrorHandler
             );
@@ -118,19 +117,19 @@ namespace Perlang.Tests.Integration
         }
 
         /// <summary>
-        /// Evaluates the provided expression or list of statements. If provided an expression, <see
-        /// cref="EvalResult.Value"/> contains the value of the evaluated expression; otherwise, this method will return
-        /// `null`.
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
         /// This method will propagate all errors apart from  <see cref="ValidationError"/> to the caller. Validation
-        /// errors will be available in the returned <see cref="EvalResult"/>.
+        /// errors will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>An EvalResult with the `Value` property set to the result of the provided expression. If not
-        /// provided a valid expression, `Value` will be set to `null`.</returns>
-        internal static EvalResult EvalWithValidationErrorCatch(string source)
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<ValidationError> EvalWithValidationErrorCatch(string source)
         {
-            var result = new EvalResult();
+            var result = new EvalResult<ValidationError>();
             var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
 
             result.Value = interpreter.Eval(
@@ -138,8 +137,8 @@ namespace Perlang.Tests.Integration
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                validationError => result.ValidationErrors.Add(validationError),
-                validationError => result.ValidationErrors.Add(validationError)
+                validationError => result.Errors.Add(validationError),
+                validationError => result.Errors.Add(validationError)
             );
 
             return result;

--- a/Perlang.Tests.Integration/EvalResult.cs
+++ b/Perlang.Tests.Integration/EvalResult.cs
@@ -1,18 +1,26 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
-using Perlang.Interpreter;
-using Perlang.Interpreter.Resolution;
-using Perlang.Parser;
 
 namespace Perlang.Tests.Integration
 {
-    // TODO: Change to be a generic class, with ParseError, RuntimeError etc as the type parameter.
-    internal class EvalResult
+    /// <summary>
+    /// Represents a result from a single `Eval` invocation, with support for returning a single type of errors as
+    /// specified by the `T` type parameter.
+    /// </summary>
+    /// <typeparam name="T">The type of the error.</typeparam>
+    internal class EvalResult<T>
+        where T : Exception
     {
+        /// <summary>
+        /// Gets or sets the value returned from the `Eval` call. Can be `null` if the source code evaluated didn't
+        /// parse cleanly as a valid expression, or if it parsed as a set of statements.
+        /// </summary>
         public object? Value { get; set; }
-        public List<ParseError> ParseErrors { get; } = new List<ParseError>();
-        public List<RuntimeError> RuntimeErrors { get; } = new List<RuntimeError>();
-        public List<ResolveError> ResolveErrors { get; } = new List<ResolveError>();
-        public List<ValidationError> ValidationErrors { get; } = new List<ValidationError>();
+
+        /// <summary>
+        /// Gets a list of the errors thrown during the evaluation of the program.
+        /// </summary>
+        public List<T> Errors { get; } = new List<T>();
     }
 }

--- a/Perlang.Tests.Integration/Function/Arguments.cs
+++ b/Perlang.Tests.Integration/Function/Arguments.cs
@@ -175,9 +175,9 @@ namespace Perlang.Tests.Integration.Function
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Function 'f' has 2 parameter\\(s\\) but was called with 4 argument\\(s\\)",
                 exception.Message);
         }
@@ -192,9 +192,9 @@ namespace Perlang.Tests.Integration.Function
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
 
             Assert.Matches(
                 "Function 'f' has 2 parameter\\(s\\) but was called with 1 argument\\(s\\)",
@@ -210,9 +210,9 @@ namespace Perlang.Tests.Integration.Function
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Expect '\\)' after parameters.", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Immutability/Function.cs
+++ b/Perlang.Tests.Integration/Immutability/Function.cs
@@ -17,9 +17,9 @@ namespace Perlang.Tests.Integration.Immutability
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
         }
 
@@ -32,9 +32,9 @@ namespace Perlang.Tests.Integration.Immutability
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
         }
 
@@ -47,9 +47,9 @@ namespace Perlang.Tests.Integration.Immutability
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Function 'f' is immutable and cannot be modified.", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Number/NumberTests.cs
+++ b/Perlang.Tests.Integration/Number/NumberTests.cs
@@ -15,9 +15,9 @@ namespace Perlang.Tests.Integration.Number
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Expect identifier after '.'", exception.Message);
         }
 
@@ -29,9 +29,9 @@ namespace Perlang.Tests.Integration.Number
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Expect expression", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Operator/Division.cs
+++ b/Perlang.Tests.Integration/Operator/Division.cs
@@ -44,9 +44,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
         }
 
@@ -58,9 +58,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -28,9 +28,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'x'", exception.Message);
         }
 
@@ -43,9 +43,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("can only be used to decrement numbers, not nil", exception.Message);
         }
 
@@ -58,9 +58,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("can only be used to decrement numbers, not String", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -28,9 +28,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'x'", exception.Message);
         }
 
@@ -43,9 +43,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("can only be used to increment numbers, not nil", exception.Message);
         }
 
@@ -58,9 +58,9 @@ namespace Perlang.Tests.Integration.Operator
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("can only be used to increment numbers, not String", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Return.cs
+++ b/Perlang.Tests.Integration/Return.cs
@@ -64,9 +64,9 @@ namespace Perlang.Tests.Integration
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Cannot return from top-level code.", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
@@ -28,9 +28,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void argv_pop_with_no_arguments_throws_the_expected_exception()
         {
             var result = EvalWithRuntimeCatch("Argv.pop()");
-            var exception = result.RuntimeErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("No arguments left", exception.Message);
         }
 
@@ -62,9 +62,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void argv_pop_too_many_times_throws_the_expected_exception()
         {
             var result = EvalWithRuntimeCatch("Argv.pop(); Argv.pop();", "arg1");
-            var exception = result.RuntimeErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("No arguments left", exception.Message);
         }
 

--- a/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
@@ -17,9 +17,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void Base64_decode_with_no_arguments_throws_the_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("Base64.decode()");
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Contains("Method 'decode' has 1 parameter(s) but was called with 0 argument(s)", exception.Message);
         }
 
@@ -40,9 +40,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void Base64_decode_with_a_numeric_argument_throws_the_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("Base64.decode(123.45)");
-            var runtimeError = result.ValidationErrors.First();
+            var runtimeError = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
 
             Assert.Equal("Cannot pass System.Double argument as System.String parameter to decode()", runtimeError.Message);
         }

--- a/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
@@ -11,9 +11,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void Base64_encode_with_no_arguments_throws_the_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("Base64.encode()");
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Contains("Method 'encode' has 1 parameter(s) but was called with 0 argument(s)", exception.Message);
         }
 
@@ -46,9 +46,9 @@ namespace Perlang.Tests.Integration.Stdlib
         public void Base64_encode_with_a_numeric_argument_throws_the_expected_exception()
         {
             var result = EvalWithValidationErrorCatch("Base64.encode(123.45)");
-            var runtimeError = result.ValidationErrors.First();
+            var runtimeError = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
 
             Assert.Equal("Cannot pass System.Double argument as System.String parameter to encode()", runtimeError.Message);
         }

--- a/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -26,9 +26,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Expecting type name", exception.Message);
         }
 
@@ -40,9 +40,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Cannot assign String value to Int32", exception.Message);
         }
 
@@ -54,9 +54,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -72,9 +72,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -90,9 +90,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -124,9 +124,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Cannot pass System.Int32 argument as parameter 's: System.String'", exception.Message);
         }
 
@@ -173,9 +173,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Type not found: SomeUnknownType", exception.Message);
         }
 
@@ -193,9 +193,9 @@ namespace Perlang.Tests.Integration.Typing
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Cannot assign String value to Int32", exception.Message);
         }
     }

--- a/Perlang.Tests.Integration/Var/VarTests.cs
+++ b/Perlang.Tests.Integration/Var/VarTests.cs
@@ -18,7 +18,7 @@ namespace Perlang.Tests.Integration.Var
 
             var result = EvalWithRuntimeCatch(source);
 
-            Assert.Empty(result.RuntimeErrors);
+            Assert.Empty(result.Errors);
         }
 
         [Fact]
@@ -31,9 +31,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Error at 'a': Variable with this name already declared in this scope.", exception.ToString());
         }
 
@@ -48,9 +48,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Error at 'a': Variable with this name already declared in this scope.", exception.ToString());
         }
 
@@ -65,9 +65,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Error at 'arg': Variable with this name already declared in this scope.", exception.ToString());
         }
 
@@ -173,9 +173,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
         }
 
@@ -189,9 +189,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithRuntimeCatch(source);
-            var exception = result.RuntimeErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.RuntimeErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
         }
 
@@ -300,9 +300,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 
@@ -316,9 +316,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 
@@ -330,9 +330,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Type inference for variable 'a' cannot be performed when initializer is not specified", exception.Message);
         }
 
@@ -352,9 +352,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithValidationErrorCatch(source);
-            var exception = result.ValidationErrors.FirstOrDefault();
+            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.ValidationErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Undefined identifier 'not_defined'", exception.Message);
         }
 
@@ -366,9 +366,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
 
             Assert.Matches("Error at 'false': Expecting variable name", exception.ToString());
         }
@@ -399,9 +399,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithResolveErrorCatch(source);
-            var exception = result.ResolveErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ResolveErrors);
+            Assert.Single(result.Errors);
             Assert.Matches("Error at 'a': Cannot read local variable in its own initializer", exception.ToString());
         }
 
@@ -413,9 +413,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
 
             Assert.Matches("Error at 'nil': Expecting variable name.", exception.ToString());
         }
@@ -428,9 +428,9 @@ namespace Perlang.Tests.Integration.Var
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.ParseErrors.First();
+            var exception = result.Errors.First();
 
-            Assert.Single(result.ParseErrors);
+            Assert.Single(result.Errors);
 
             Assert.Matches("Error at 'this': Expecting variable name", exception.ToString());
         }


### PR DESCRIPTION
The previous approach - a container class with basically one property which contained the relevant errors and three which were always empty lists - was nice in that the test code was very explicit; `result.ValidationErrors` etc is quite readable code. However, it felt a bit odd. I realized today we could probably get rid of this and simplify things a bit by making the class be type-parameterized instead.