### PR TITLE
(install) Fix error handling on unsupported architectures

### DIFF
--- a/scripts/perlang-install
+++ b/scripts/perlang-install
@@ -45,6 +45,8 @@ main() {
     need_cmd rmdir
     need_cmd tar
 
+    ansi_escapes_are_valid=false
+
     get_architecture || return 1
     local _arch="$RETVAL"
     assert_nz "$_arch" "arch"
@@ -54,8 +56,6 @@ main() {
     local _file="${_dir}/perlang-build.tar.gz"
 
     local _is_tty=false
-
-    ansi_escapes_are_valid=false
 
     if [ -t 2 ]; then
         _is_tty=true


### PR DESCRIPTION
Previously, because the `ansi_escapes_are_valid` variable was set _after_ the CPU architecture check had taken place, errors during that check would trigger a call to the `err`  function - which in turn required this variable to be set, to avoid runtime errors.

This commit fixes this.

The error was seen both with `sh` and `bash`:

```
% curl -sSL https://perlang.org/install.sh | sh
sh: line 252: ansi_escapes_are_valid: unbound variable
% curl -sSL https://perlang.org/install.sh | bash
bash: line 252: ansi_escapes_are_valid: unbound variable
```