### PR TITLE
(ci) Add osx-arm64 builds to the list of supported architectures

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,6 +27,7 @@ jobs:
           - linux-arm
           - linux-arm64
           - linux-x64
+          - osx-arm64
           - osx-x64
           - win-x64
 


### PR DESCRIPTION
~Also adds (completely untested) support for `arm64` in `perlang-install`. If we are lucky, this should be all that's needed to run on Apple M1 hardware.~ This was no longer needed, because of #243.

Also, the changes made in #244 made this a lot simpler. 