### PR TITLE
(solution) Upgrade StyleCop to 1.2.0-beta.321

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="all" />
         <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
 
         <PackageReference Include="SonarAnalyzer.CSharp" Version="8.14.0.22654" />

--- a/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
+++ b/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
@@ -7,12 +7,12 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Tests.Integration.xml</DocumentationFile>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <NoWarn>SA1116;SA1300;S3881;1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <NoWarn>SA1116;SA1300;S3881;1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.Integration.xml</DocumentationFile>
     </PropertyGroup>
 

--- a/Perlang.Tests/Perlang.Tests.csproj
+++ b/Perlang.Tests/Perlang.Tests.csproj
@@ -9,13 +9,12 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <DocumentationFile>bin\Debug\Perlang.Tests.xml</DocumentationFile>
-      <NoWarn>SA1116;SA1300;
-1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <NoWarn>SA1116;SA1300;1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.xml</DocumentationFile>
     </PropertyGroup>
 


### PR DESCRIPTION
Among other things, this adds support for `new()`, i.e. "Target-typed new expressions" introduced in C# 9.0. Because #126 was recently merged, Rider now suggests this form of writing. However, StyleCop complained about it before this fix.