### PR TITLE
(interpreter) #124 Bug fix: calling methods in expr mode was broken in REPL

### DIFF
--- a/Perlang.Common/Stmt.cs
+++ b/Perlang.Common/Stmt.cs
@@ -50,6 +50,9 @@ namespace Perlang
             }
         }
 
+        /// <summary>
+        /// An expression statement is a statement for wrapping a single expression in statement form.
+        /// </summary>
         public class ExpressionStmt : Stmt
         {
             public Expr Expression { get; }

--- a/Perlang.Interpreter/Immutability/ImmutabilityValidator.cs
+++ b/Perlang.Interpreter/Immutability/ImmutabilityValidator.cs
@@ -22,14 +22,6 @@ namespace Perlang.Interpreter.Immutability
             new ImmutabilityValidator(immutabilityValidationErrorCallback, getVariableOrFunctionBinding).Visit(statements);
         }
 
-        public static void Validate(
-            Expr expr,
-            Action<ValidationError> immutabilityValidationErrorCallback,
-            Func<Expr, Binding?> getVariableOrFunctionBinding)
-        {
-            new ImmutabilityValidator(immutabilityValidationErrorCallback, getVariableOrFunctionBinding).Visit(expr);
-        }
-
         private ImmutabilityValidator(
             Action<ValidationError> immutabilityValidationErrorCallback,
             Func<Expr, Binding?> getVariableOrFunctionBinding)

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -7,10 +7,14 @@ using Xunit;
 
 namespace Perlang.Tests.ConsoleApp
 {
+    /// <summary>
+    /// Test for the Program class. This essentially lets us test the REPL, or various aspects of the language which
+    /// behaves differently in REPL mode vs regular interpreted/compiled modes.
+    /// </summary>
     public class ProgramTest
     {
         private readonly Program subject;
-        private readonly List<string> output = new List<string>();
+        private readonly List<string> output = new();
 
         public ProgramTest()
         {
@@ -51,6 +55,26 @@ namespace Perlang.Tests.ConsoleApp
         }
 
         [Fact]
+        public void Run_can_call_function_from_statement()
+        {
+            subject.Run("fun hello(): void { print 1; }");
+            subject.Run("hello();");
+
+            Assert.Equal(new List<string> { "1" }, output);
+        }
+
+        // This illustrates the bug described in #124; the example there used to throw an exception like this:
+        // [line 1] Error at 'hello': Attempting to call undefined function 'hello'
+        [Fact]
+        public void Run_can_call_function_from_expression()
+        {
+            subject.Run("fun hello(): void { print 1; }");
+            subject.Run("hello()");
+
+            Assert.Equal(new List<string> { "1" }, output);
+        }
+
+        [Fact]
         public void Run_state_does_not_persist_if_one_statement_is_invalid()
         {
             // When a program has an error (like the second Run() invocation below), all variables defined in it are
@@ -87,7 +111,7 @@ namespace Perlang.Tests.ConsoleApp
         }
 
         [Fact]
-        public void Run_with_version_parameter_outputs_expected_value()
+        public void MainWithCustomConsole_with_version_parameter_outputs_expected_value()
         {
             // Arrange & Act
             var testConsole = new TestConsole();
@@ -97,10 +121,10 @@ namespace Perlang.Tests.ConsoleApp
             Assert.Equal(CommonConstants.InformationalVersion + "\n", testConsole.Out.ToString());
         }
 
-        // Test added to assert the bug fix for #117. Interestingly enough, the NRE did not occur when the test was
-        // placed in the ArgvTests class.
+        // Test added to assert the bug fix for #117. Interestingly enough, the NRE described there did not occur when
+        // the test was placed in the ArgvTests class.
         [Fact]
-        public void Time_now_tickz_fails_with_expected_exception()
+        public void Run_Time_now_tickz_fails_with_expected_exception()
         {
             subject.Run("Time.now().tickz()");
 
@@ -112,7 +136,7 @@ namespace Perlang.Tests.ConsoleApp
 
         // There used to be an exception in the default runtimeErrorHandler. This test would illustrate it.
         [Fact]
-        public void ARGV_pop_with_no_arguments_throws_the_expected_exception()
+        public void Run_ARGV_pop_with_no_arguments_throws_the_expected_exception()
         {
             // Cannot use 'subject' here since we need it instantiated with different parameters to provoke this exact
             // error.

--- a/Perlang.Tests/Interpreter/TypeValidatorTest.cs
+++ b/Perlang.Tests/Interpreter/TypeValidatorTest.cs
@@ -19,7 +19,7 @@ namespace Perlang.Tests.Interpreter
             var identifier = new Expr.Identifier(name);
             var get = new Expr.Get(identifier, name);
             var paren = new Token(TokenType.RIGHT_PAREN, ")", null, 1);
-            var call = new Expr.Call(get, paren, new List<Expr>());
+            var callExpr = new Expr.Call(get, paren, new List<Expr>());
             var bindings = new Dictionary<Expr, Binding>
             {
                 { identifier, new NativeClassBinding(identifier, typeof(string)) }
@@ -28,7 +28,11 @@ namespace Perlang.Tests.Interpreter
             var typeValidationErrors = new List<TypeValidationError>();
 
             // Act
-            TypeValidator.Validate(call, error => typeValidationErrors.Add(error), expr => bindings[expr]);
+            TypeValidator.Validate(
+                new List<Stmt> { new Stmt.ExpressionStmt(callExpr) },
+                error => typeValidationErrors.Add(error),
+                expr => bindings[expr]
+            );
 
             // Assert
             Assert.Empty(typeValidationErrors);
@@ -40,7 +44,7 @@ namespace Perlang.Tests.Interpreter
             // Arrange
             var name = new Token(TokenType.IDENTIFIER, "foo", null, -1);
             var identifier = new Expr.Identifier(name);
-            var get = new Expr.Get(identifier, name);
+            var getExpr = new Expr.Get(identifier, name);
 
             var bindings = new Dictionary<Expr, Binding>
             {
@@ -51,7 +55,11 @@ namespace Perlang.Tests.Interpreter
             var typeValidationErrors = new List<TypeValidationError>();
 
             // Act
-            TypeValidator.Validate(get, error => typeValidationErrors.Add(error), expr => bindings[expr]);
+            TypeValidator.Validate(
+                new List<Stmt> { new Stmt.ExpressionStmt(getExpr) },
+                error => typeValidationErrors.Add(error),
+                expr => bindings[expr]
+            );
 
             // Assert
             Assert.Single(typeValidationErrors);
@@ -67,7 +75,7 @@ namespace Perlang.Tests.Interpreter
             // Foo is a defined Perlang class.
             var name = new Token(TokenType.IDENTIFIER, "to_string", null, -1);
             var identifier = new Expr.Identifier(name);
-            var get = new Expr.Get(identifier, name);
+            var getExpr = new Expr.Get(identifier, name);
 
             var bindings = new Dictionary<Expr, Binding>
             {
@@ -77,7 +85,11 @@ namespace Perlang.Tests.Interpreter
             var typeValidationErrors = new List<TypeValidationError>();
 
             // Act
-            TypeValidator.Validate(get, error => typeValidationErrors.Add(error), expr => bindings[expr]);
+            TypeValidator.Validate(
+                new List<Stmt> { new Stmt.ExpressionStmt(getExpr) },
+                error => typeValidationErrors.Add(error),
+                expr => bindings[expr]
+            );
 
             // Assert
             Assert.Empty(typeValidationErrors);


### PR DESCRIPTION
This turned out to be quite easy in the end; for a change, I realized fairly quickly that the problem was that we special-cased expressions in an unhealthy way in `Perlang.Interpreter.PerlangInterpreter.Eval()`. Will write more in the diff view in a minute.

Closes #124.