### PR TITLE
(interpreter) Change postfix increment and decrement value semantics

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -219,6 +219,10 @@ namespace Perlang
             }
         }
 
+        /// <summary>
+        /// Represents unary prefix expressions. Examples of such expressions are `!flag` and `-10`. Note that prefix
+        /// increment and decrement are currently not supported.
+        /// </summary>
         public class UnaryPrefix : Expr
         {
             public Token Operator { get; }
@@ -236,6 +240,9 @@ namespace Perlang
             }
         }
 
+        /// <summary>
+        /// Represents unary postfix expressions. Examples of such expressions are `i++` and `j--`.
+        /// </summary>
         public class UnaryPostfix : Expr
         {
             public Expr Left { get; }

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -503,7 +503,8 @@ namespace Perlang.Interpreter
                 }
             }
 
-            dynamic? previousValue = left;
+            // The nullability check has been taken care of by IsValidNumberType() for us.
+            dynamic previousValue = left!;
             var variable = (Expr.Identifier) expr.Left;
             object value;
 
@@ -537,7 +538,7 @@ namespace Perlang.Interpreter
                 globals.Assign(variable.Name, value);
             }
 
-            return value;
+            return previousValue;
         }
 
         public object VisitIdentifierExpr(Expr.Identifier expr)

--- a/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -51,7 +51,10 @@ namespace Perlang.Tests.Integration.Operator
 
             var output = EvalReturningOutput(source).SingleOrDefault();
 
-            Assert.Equal("99", output);
+            // As in languages C# and Java (and unlike C and C++), the operation above has well-defined semantics.
+            // The value of i++ is the value of the expression _before_ it gets evaluated, just like in those other
+            // languages. If we had a prefix decrement operator, it would differ in this regard.
+            Assert.Equal("100", output);
         }
 
         // "Negative tests", ensuring that unsupported operations fail in the expected way.

--- a/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -51,7 +51,10 @@ namespace Perlang.Tests.Integration.Operator
 
             var output = EvalReturningOutputString(source);
 
-            Assert.Equal("101", output);
+            // As in languages C# and Java (and unlike C and C++), the operation above has well-defined semantics.
+            // The value of i++ is the value of the expression _before_ it gets evaluated, just like in those other
+            // languages. If we had a prefix increment operator, it would differ in this regard.
+            Assert.Equal("100", output);
         }
 
         // "Negative tests", ensuring that unsupported operations fail in the expected way.


### PR DESCRIPTION
Before this change, the value of a postfix increment or decrement was the value of the expression _after_ the assignment of the new value, unlike languages like Java and C# where the value of the expression is taken _before_ the assignment. We should be really careful with semantic differences like this, _when they are not rational and easily explained_. The "principle of least astonishment" is an important one.