### PR TITLE
(consoleapp) Add -e flag, to eval single line script

### DIFF
--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -121,6 +121,17 @@ namespace Perlang.Tests.ConsoleApp
             Assert.Equal(CommonConstants.InformationalVersion + "\n", testConsole.Out.ToString());
         }
 
+        [Fact]
+        public void MainWithCustomConsole_with_eval_parameter_outputs_expected_value()
+        {
+            // Arrange & Act
+            var testConsole = new TestConsole();
+            Program.MainWithCustomConsole(new[] { "-e", "print", "10" }, testConsole);
+
+            // Assert
+            Assert.Equal("10" + "\n", testConsole.Out.ToString());
+        }
+
         // Test added to assert the bug fix for #117. Interestingly enough, the NRE described there did not occur when
         // the test was placed in the ArgvTests class.
         [Fact]


### PR DESCRIPTION
A nice side effect of this is that the added test here actually gives us a significant boost in the code coverage for the ConsoleApp project, from about 16% up to 37%. The coverage is not at the moment easily visible here from the repo; we should look into that at some point. For now, the following screenshot from Rider will have to suffice:

![image](https://user-images.githubusercontent.com/630613/107861332-f660ac80-6e4d-11eb-8726-0e4982ede50c.png)