### PR TITLE
(solution) Disable warnings-as-errors for Debug builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,4 +11,21 @@
 
         <PackageReference Include="SonarAnalyzer.CSharp" Version="8.14.0.22654" />
     </ItemGroup>
+
+    <!--
+        WarningsAsErrors configuration
+
+        We configure these to be more relaxed in Debug builds, to avoid being a pain in the neck while editing code
+        (where you might want to be able to e.g. comment out code temporarily, sometimes breaking these rules). However,
+        since we build a full build using the Release configuration in CI for each pull request, none of these warnings
+        should be able to slip through into the 'master' branch. This aims to be a suitable compromise between
+        conformity and convenience.
+      -->
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 </Project>

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 # Perlang.Common/CommonConstants.Generated.cs is not phony, but we always want
 # to force it to be regenerated.
-.PHONY: all auto-generated clean docs docs-serve install run Perlang.Common/CommonConstants.Generated.cs
+.PHONY: all auto-generated clean docs docs-serve install release run Perlang.Common/CommonConstants.Generated.cs
 
 # Enable fail-fast in case of errors
 SHELL=/bin/bash -e -o pipefail
 
 all: auto-generated
 	dotnet build
+
+release:
+	dotnet build -c Release
 
 auto-generated: Perlang.Common/CommonConstants.Generated.cs
 

--- a/Perlang.Common/Perlang.Common.csproj
+++ b/Perlang.Common/Perlang.Common.csproj
@@ -7,13 +7,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <DocumentationFile>bin\Debug\Perlang.Common.xml</DocumentationFile>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <DocumentationFile>bin\Release\Perlang.Common.xml</DocumentationFile>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>

--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -12,13 +12,11 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DocumentationFile>bin\Release\Perlang.ConsoleApp.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.ConsoleApp.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 

--- a/Perlang.Interpreter/Perlang.Interpreter.csproj
+++ b/Perlang.Interpreter/Perlang.Interpreter.csproj
@@ -7,13 +7,11 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Interpreter.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DocumentationFile>bin\Release\Perlang.Interpreter.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 

--- a/Perlang.Parser/Perlang.Parser.csproj
+++ b/Perlang.Parser/Perlang.Parser.csproj
@@ -7,13 +7,11 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Parser.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DocumentationFile>bin\Release\Perlang.Parser.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 

--- a/Perlang.Stdlib/Perlang.Stdlib.csproj
+++ b/Perlang.Stdlib/Perlang.Stdlib.csproj
@@ -7,13 +7,11 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Stdlib.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DocumentationFile>bin\Release\Perlang.Stdlib.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 

--- a/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
+++ b/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
@@ -6,12 +6,10 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Tests.Integration.xml</DocumentationFile>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.Integration.xml</DocumentationFile>
     </PropertyGroup>

--- a/Perlang.Tests/Perlang.Tests.csproj
+++ b/Perlang.Tests/Perlang.Tests.csproj
@@ -7,13 +7,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <DocumentationFile>bin\Debug\Perlang.Tests.xml</DocumentationFile>
       <NoWarn>SA1116;SA1117;SA1300;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <NoWarn>SA1116;SA1117;SA1300;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.xml</DocumentationFile>
     </PropertyGroup>


### PR DESCRIPTION
This is just a convenience, since the previous setting gets _very_ annoying when you e.g. comment out code while debugging/testing various scenarios. The rules are basically mostly good, but cannot be applied _always_ - only to the final result that you end up submitting as a PR.

The `make release` Makefile target was added to easily be able to validate your changes locally, before submitting a PR.