### PR TITLE
(many) Implement addition and subtraction assignment

### DIFF
--- a/Perlang.Common/TokenType.cs
+++ b/Perlang.Common/TokenType.cs
@@ -26,6 +26,8 @@ namespace Perlang
         LESS_EQUAL,
         PLUS_PLUS,
         MINUS_MINUS,
+        PLUS_EQUAL,
+        MINUS_EQUAL,
         STAR,
         STAR_STAR,
 

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -908,12 +908,18 @@ namespace Perlang.Interpreter
                 case MINUS:
                     CheckNumberOperands(expr.Operator, left, right);
                     return leftNumber - rightNumber;
+                case MINUS_EQUAL:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return leftNumber - rightNumber;
                 case PLUS:
                     if (left is string s1 && right is string s2)
                     {
                         return s1 + s2;
                     }
 
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return leftNumber + rightNumber;
+                case PLUS_EQUAL:
                     CheckNumberOperands(expr.Operator, left, right);
                     return leftNumber + rightNumber;
                 case SLASH:

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -99,10 +99,34 @@ namespace Perlang.Parser
                     AddToken(DOT);
                     break;
                 case '-':
-                    AddToken(Match('-') ? MINUS_MINUS : MINUS);
+                    if (Match('-'))
+                    {
+                        AddToken(MINUS_MINUS);
+                    }
+                    else if (Match('='))
+                    {
+                        AddToken(MINUS_EQUAL);
+                    }
+                    else
+                    {
+                        AddToken(MINUS);
+                    }
+
                     break;
                 case '+':
-                    AddToken(Match('+') ? PLUS_PLUS : PLUS);
+                    if (Match('+'))
+                    {
+                        AddToken(PLUS_PLUS);
+                    }
+                    else if (Match('='))
+                    {
+                        AddToken(PLUS_EQUAL);
+                    }
+                    else
+                    {
+                        AddToken(PLUS);
+                    }
+
                     break;
                 case ':':
                     AddToken(COLON);

--- a/Perlang.Tests.Integration/Operator/AdditionAssignment.cs
+++ b/Perlang.Tests.Integration/Operator/AdditionAssignment.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Operator
+{
+    public class AdditionAssignment
+    {
+        // "Positive" tests, testing for supported behavior
+
+        [Fact]
+        public void addition_assignment_defined_variable()
+        {
+            string source = @"
+                var i = 0;
+                i += 1;
+                print i;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("1", output);
+        }
+
+        [Fact]
+        public void addition_assignment_can_be_used_in_for_loops()
+        {
+            string source = @"
+                for (var c = 0; c < 3; c += 1)
+                    print c;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+                "2"
+            }, output);
+        }
+
+        [Fact]
+        public void addition_assignment_can_be_used_in_assignment_with_inference()
+        {
+            string source = @"
+                var i = 100;
+                var j = i += 2;
+                print j;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("102", output);
+        }
+
+        [Fact]
+        public void addition_assignment_can_be_used_in_assignment_with_explicit_types()
+        {
+            string source = @"
+                var i: int = 100;
+                var j: int = i += 2;
+                print j;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("102", output);
+        }
+
+        // "Negative tests", ensuring that unsupported operations fail in the expected way.
+
+        [Fact]
+        public void addition_assignment_to_undefined_variable_throws_expected_exception()
+        {
+            string source = @"
+                x += 3;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Undefined identifier 'x'", exception.Message);
+        }
+
+        [Fact]
+        public void addition_assignment_to_nil_throws_expected_exception()
+        {
+            string source = @"
+                var i = nil;
+                i += 4;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Equal("Inferred: Perlang.NullObject is not comparable and can therefore not be used with the $PLUS_EQUAL += operator", exception.Message);
+        }
+
+        [Fact]
+        public void addition_assignment_to_string_throws_expected_exception()
+        {
+            string source = @"
+                var i = ""foo"";
+                i += 5;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Invalid arguments to operator PLUS_EQUAL specified", exception.Message);
+        }
+    }
+}

--- a/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
+++ b/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Operator
+{
+    public class SubtractionAssignment
+    {
+        // "Positive" tests, testing for supported behavior
+
+        [Fact]
+        public void subtraction_assignment_defined_variable()
+        {
+            string source = @"
+                var i = 0;
+                i -= 1;
+                print i;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("-1", output);
+        }
+
+        [Fact]
+        public void subtraction_assignment_can_be_used_in_for_loops()
+        {
+            string source = @"
+                for (var c = 3; c > 0; c -= 1)
+                    print c;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "3",
+                "2",
+                "1"
+            }, output);
+        }
+
+        [Fact]
+        public void subtraction_assignment_can_be_used_in_assignment_with_inference()
+        {
+            string source = @"
+                var i = 100;
+                var j = i -= 2;
+                print j;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("98", output);
+        }
+
+        [Fact]
+        public void subtraction_assignment_can_be_used_in_assignment_with_explicit_types()
+        {
+            string source = @"
+                var i: int = 100;
+                var j: int = i -= 2;
+                print j;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("98", output);
+        }
+
+        // "Negative tests", ensuring that unsupported operations fail in the expected way.
+
+        [Fact]
+        public void subtraction_assignment_to_undefined_variable_throws_expected_exception()
+        {
+            string source = @"
+                x +- 3;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Undefined identifier 'x'", exception.Message);
+        }
+
+        [Fact]
+        public void subtraction_assignment_to_nil_throws_expected_exception()
+        {
+            string source = @"
+                var i = nil;
+                i -= 4;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Equal("Inferred: Perlang.NullObject is not comparable and can therefore not be used with the $MINUS_EQUAL -= operator", exception.Message);
+        }
+
+        [Fact]
+        public void subtraction_assignment_to_string_throws_expected_exception()
+        {
+            string source = @"
+                var i = ""foo"";
+                i -= 5;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Invalid arguments to operator MINUS_EQUAL specified", exception.Message);
+        }
+    }
+}

--- a/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -97,11 +97,25 @@ namespace Perlang.Tests.Integration.Typing
         }
 
         [Fact]
-        public void var_declaration_with_initializer_correctly_infers_type_from_assignment_source()
+        public void var_declaration_with_initializer_correctly_infers_type_from_assignment_source_variable()
         {
             string source = @"
                 var foo = 123;
                 var bar = foo;
+
+                print bar.get_type();
+            ";
+
+            string result = EvalReturningOutputString(source);
+            Assert.Equal("System.Int32", result);
+        }
+
+        [Fact]
+        public void var_declaration_with_initializer_correctly_infers_type_from_assignment_source_expression()
+        {
+            string source = @"
+                var foo = 123;
+                var bar = foo + 2;
 
                 print bar.get_type();
             ";


### PR DESCRIPTION
I started thinking about this when working on some tutorials for #140. It felt lame to not be able to use `+=` operators when converting [this Pi calculation](http://ajennings.net/blog/a-million-digits-of-pi-in-9-lines-of-javascript.html) from JavaScript:

```javascript
let i = 1n;
let x = 3n * (10n ** 1020n);
let pi = x;
while (x > 0) {
        x = x * i / ((i + 1n) * 4n);
        pi += x / (i + 2n);
        i += 2n;
}
console.log(pi / (10n ** 20n));
```

Adding this was fairly straightforward. I used the approach of not introducing specific AST node types for this, but just building on what's already there. There was one slight gotcha which the unit tests helped me uncover; will write some more details about it in the diff.

### Limitations

Note that *only* `+=` and `-=` is added in this PR. C has a bunch of other nice ones, like `*=`, `/=` and perhaps even some slightly more esoteric ones like `%=`. I'm not sure how far we would go (and we don't support `%` for modulo right now anyway), but _if_ we want, at least `*=` and `/=` would be trivial to implement on top of this.