### PR TITLE
(many) Implement modulo operator

### DIFF
--- a/Perlang.Common/TokenType.cs
+++ b/Perlang.Common/TokenType.cs
@@ -11,6 +11,7 @@ namespace Perlang
         DOT,
         MINUS,
         PLUS,
+        PERCENT,
         SEMICOLON,
         COLON,
         SLASH,

--- a/Perlang.Interpreter/Extensions/TokenTypeExtensions.cs
+++ b/Perlang.Interpreter/Extensions/TokenTypeExtensions.cs
@@ -28,6 +28,8 @@ namespace Perlang.Interpreter.Extensions
                     "*",
                 TokenType.STAR_STAR =>
                     "**",
+                TokenType.PERCENT =>
+                    "%",
                 _ =>
                     throw new ArgumentOutOfRangeException(nameof(tokenType), tokenType, null)
             };

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -893,6 +893,10 @@ namespace Perlang.Interpreter
 
             switch (expr.Operator.Type)
             {
+                //
+                // Comparison operators
+                //
+
                 case GREATER:
                     CheckNumberOperands(expr.Operator, left, right);
                     return leftNumber > rightNumber;
@@ -905,6 +909,15 @@ namespace Perlang.Interpreter
                 case LESS_EQUAL:
                     CheckNumberOperands(expr.Operator, left, right);
                     return leftNumber <= rightNumber;
+                case BANG_EQUAL:
+                    return !IsEqual(left, right);
+                case EQUAL_EQUAL:
+                    return IsEqual(left, right);
+
+                //
+                // Arithmetic operators
+                //
+
                 case MINUS:
                     CheckNumberOperands(expr.Operator, left, right);
                     return leftNumber - rightNumber;
@@ -946,10 +959,9 @@ namespace Perlang.Interpreter
                         return BigInteger.Pow(leftNumber, rightNumber);
                     }
 
-                case BANG_EQUAL:
-                    return !IsEqual(left, right);
-                case EQUAL_EQUAL:
-                    return IsEqual(left, right);
+                case PERCENT:
+                    CheckNumberOperands(expr.Operator, left, right);
+                    return leftNumber % rightNumber;
 
                 default:
                     throw new RuntimeError(expr.Operator, $"Internal error: Unsupported operator {expr.Operator.Type} in binary expression.");

--- a/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -171,25 +171,23 @@ namespace Perlang.Interpreter.Typing
                 switch (expr.Operator.Type)
                 {
                     case PLUS:
-                        if (leftTypeReference.ClrType == typeof(string) ||
-                            rightTypeReference.ClrType == typeof(string))
-                        {
-                            // Special-casing of strings, to allow for string concatenation.
-                            expr.TypeReference.ClrType = leftTypeReference.ClrType;
-
-                            return VoidObject.Void;
-                        }
-
-                        // goto is indeed evil, but code duplication is an even greater evil.
-                        goto STAR_STAR;
-
                     case PLUS_EQUAL:
                     case MINUS:
                     case MINUS_EQUAL:
                     case SLASH:
                     case STAR:
                     case STAR_STAR:
-                        STAR_STAR:
+                    case PERCENT:
+                        if (expr.Operator.Type == PLUS &&
+                            (leftTypeReference.ClrType == typeof(string) ||
+                             rightTypeReference.ClrType == typeof(string)))
+                        {
+                            // Special-casing of "string" + "string", to allow for convenient string concatenation.
+                            expr.TypeReference.ClrType = leftTypeReference.ClrType;
+
+                            return VoidObject.Void;
+                        }
+
                         TypeReference typeReference = GreaterType(leftTypeReference, rightTypeReference);
 
                         if (typeReference == null)

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -532,7 +532,7 @@ namespace Perlang.Parser
         {
             Expr expr = UnaryPrefix();
 
-            while (Match(SLASH, STAR, STAR_STAR))
+            while (Match(SLASH, STAR, STAR_STAR, PERCENT))
             {
                 Token @operator = Previous();
                 Expr right = UnaryPrefix();

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -134,6 +134,9 @@ namespace Perlang.Parser
                 case ';':
                     AddToken(SEMICOLON);
                     break;
+                case '%':
+                    AddToken(PERCENT);
+                    break;
                 case '*':
                     AddToken(Match('*') ? STAR_STAR : STAR);
                     break;

--- a/Perlang.Tests.Integration/Operator/Modulo.cs
+++ b/Perlang.Tests.Integration/Operator/Modulo.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Operator
+{
+    /// <summary>
+    /// Tests for the % (modulo) operator.
+    /// </summary>
+    public class Modulo
+    {
+        //
+        // "Positive" tests, testing for supported behavior
+        //
+
+        [Fact]
+        public void modulo_operation_on_integers_returns_integer()
+        {
+            string source = @"
+                5 % 3
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public void modulo_operation_on_doubles_returns_double()
+        {
+            string source = @"
+                12.34 % 0.3
+            ";
+
+            object result = Eval(source);
+
+            // IEEE 754... :-)
+            Assert.Equal(0.04000000000000031, result);
+        }
+
+        [Fact]
+        public void modulo_operation_combined_with_others_without_grouping()
+        {
+            string source = @"
+                2 * 5 / 10 * 4 % 2.1
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(1.9, result);
+        }
+
+        [Fact]
+        public void modulo_operation_combined_with_others_with_grouping_first_operators()
+        {
+            string source = @"
+                (2 * 5 / 10 * 4) % 2.1
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(1.9, result);
+        }
+
+        [Fact]
+        public void modulo_operation_combined_with_others_with_grouping_last_operators()
+        {
+            string source = @"
+                2 * 5 / 10 * (4 % 2.1)
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(1.9, result);
+        }
+
+        //
+        // "Negative tests", ensuring that unsupported operations fail in the expected way.
+        //
+
+        [Fact]
+        public void modulo_operation_on_non_number_with_number_throws_expected_error()
+        {
+            string source = @"
+                ""1"" % 1;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Equal("Invalid arguments to % operator specified", exception.Message);
+        }
+
+        [Fact]
+        public void modulo_operation_on_number_with_non_number_throws_expected_error()
+        {
+            string source = @"
+                1 % ""1"";
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Equal("Invalid arguments to % operator specified", exception.Message);
+        }
+    }
+}

--- a/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -6,7 +6,9 @@ namespace Perlang.Tests.Integration.Operator
 {
     public class PostfixDecrement
     {
+        //
         // "Positive" tests, testing for supported behavior
+        //
 
         [Fact]
         public void decrementing_defined_variable()
@@ -57,7 +59,9 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("100", output);
         }
 
+        //
         // "Negative tests", ensuring that unsupported operations fail in the expected way.
+        //
 
         [Fact]
         public void decrementing_undefined_variable_throws_expected_exception()

--- a/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -6,7 +6,9 @@ namespace Perlang.Tests.Integration.Operator
 {
     public class PostfixIncrement
     {
+        //
         // "Positive" tests, testing for supported behavior
+        //
 
         [Fact]
         public void incrementing_defined_variable()
@@ -57,7 +59,9 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("100", output);
         }
 
+        //
         // "Negative tests", ensuring that unsupported operations fail in the expected way.
+        //
 
         [Fact]
         public void incrementing_undefined_variable_throws_expected_exception()


### PR DESCRIPTION
This was in no way _required_, but when working on/thinking about #140 I realized that for simple math programs like "calculate prime numbers", it's much easier if you have a proper modulo operator in place. Given that it's quite trivial to add, it feels like reasonable "low-hanging fruit" that can easily be added without destroying too much of the simplicity of the language.