### PR TITLE
Add AST printer

### DIFF
--- a/Perlang.Interpreter/Internals/AstPrinter.cs
+++ b/Perlang.Interpreter/Internals/AstPrinter.cs
@@ -1,0 +1,264 @@
+#nullable enable
+#pragma warning disable SA1629
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JetBrains.Annotations;
+
+namespace Perlang.Interpreter.Internals
+{
+    /// <summary>
+    /// Creates an unambiguous, if ugly, string representation of AST nodes.
+    ///
+    /// Based on an idea &amp; implementation by Bob Nystrom:
+    ///
+    /// - https://craftinginterpreters.com/representing-code.html
+    /// - https://github.com/munificent/craftinginterpreters/blob/7542d2782a620ccbae9aa817b66a8852e4c094e4/java/com/craftinginterpreters/lox/AstPrinter.java
+    /// </summary>
+    internal class AstPrinter : Expr.IVisitor<string>, Stmt.IVisitor<string>
+    {
+        [Pure]
+        internal static string Print(Expr expr)
+        {
+            return expr.Accept(new AstPrinter());
+        }
+
+        [Pure]
+        internal static string Print(Stmt stmt)
+        {
+            return stmt.Accept(new AstPrinter());
+        }
+
+        //
+        // Expr.IVisitor<string> methods
+        //
+
+        public string VisitEmptyExpr(Expr.Empty expr)
+        {
+            return String.Empty;
+        }
+
+        public string VisitAssignExpr(Expr.Assign expr)
+        {
+            return Parenthesize(expr.Name.Lexeme, expr.Value);
+        }
+
+        public string VisitBinaryExpr(Expr.Binary expr)
+        {
+            return Parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right);
+        }
+
+        public string VisitCallExpr(Expr.Call expr)
+        {
+            return Parenthesize2("call", expr.Callee, expr.Arguments);
+        }
+
+        public string VisitGroupingExpr(Expr.Grouping expr)
+        {
+            return Parenthesize("group", expr.Expression);
+        }
+
+        public string VisitLiteralExpr(Expr.Literal expr)
+        {
+            if (expr.Value == null)
+            {
+                return "nil";
+            }
+
+            return expr.Value.ToString()!;
+        }
+
+        public string VisitLogicalExpr(Expr.Logical expr)
+        {
+            return Parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right);
+        }
+
+        public string VisitUnaryPrefixExpr(Expr.UnaryPrefix expr)
+        {
+            return Parenthesize(expr.Operator.Lexeme, expr.Right);
+        }
+
+        public string VisitUnaryPostfixExpr(Expr.UnaryPostfix expr)
+        {
+            return Parenthesize(expr.Operator.Lexeme, expr.Left);
+        }
+
+        public string VisitIdentifierExpr(Expr.Identifier expr)
+        {
+            return expr.Name.Lexeme;
+        }
+
+        public string VisitGetExpr(Expr.Get expr)
+        {
+            return Parenthesize2(".", expr.Object, expr.Name.Lexeme);
+        }
+
+        //
+        // Stmt.IVisitor<string> methods
+        //
+
+        public string VisitBlockStmt(Stmt.Block stmt)
+        {
+            StringBuilder builder = new();
+            builder.Append("(block ");
+
+            foreach (Stmt statement in stmt.Statements)
+            {
+                builder.Append(statement.Accept(this));
+            }
+
+            builder.Append(')');
+
+            return builder.ToString();
+        }
+
+        public string VisitClassStmt(Stmt.Class stmt)
+        {
+            StringBuilder builder = new();
+            builder.Append("(class " + stmt.Name.Lexeme);
+
+            foreach (Stmt.Function method in stmt.Methods)
+            {
+                builder.Append(" " + Print(method));
+            }
+
+            builder.Append(')');
+
+            return builder.ToString();
+        }
+
+        public string VisitExpressionStmt(Stmt.ExpressionStmt stmt)
+        {
+            return Parenthesize(";", stmt.Expression);
+        }
+
+        public string VisitFunctionStmt(Stmt.Function stmt)
+        {
+            StringBuilder builder = new();
+
+            builder.Append("(fun " + stmt.Name.Lexeme + "(");
+
+            foreach (Parameter param in stmt.Parameters)
+            {
+                if (param != stmt.Parameters[0])
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(param.Name.Lexeme);
+            }
+
+            builder.Append(") ");
+
+            foreach (Stmt body in stmt.Body)
+            {
+                builder.Append(body.Accept(this));
+            }
+
+            builder.Append(')');
+
+            return builder.ToString();
+        }
+
+        public string VisitIfStmt(Stmt.If stmt)
+        {
+            if (stmt.ElseBranch == null)
+            {
+                return Parenthesize2("if", stmt.Condition, stmt.ThenBranch);
+            }
+
+            return Parenthesize2("if-else", stmt.Condition, stmt.ThenBranch, stmt.ElseBranch);
+        }
+
+        public string VisitPrintStmt(Stmt.Print stmt)
+        {
+            return Parenthesize("print", stmt.Expression);
+        }
+
+        public string VisitReturnStmt(Stmt.Return stmt)
+        {
+            if (stmt.Value == null)
+            {
+                return "(return)";
+            }
+
+            return Parenthesize("return", stmt.Value);
+        }
+
+        public string VisitVarStmt(Stmt.Var stmt)
+        {
+            if (!stmt.HasInitializer)
+            {
+                return Parenthesize2("var", stmt.Name);
+            }
+            else
+            {
+                return Parenthesize2("var", stmt.Name, "=", stmt.Initializer);
+            }
+        }
+
+        public string VisitWhileStmt(Stmt.While stmt)
+        {
+            return Parenthesize2("while", stmt.Condition, stmt.Body);
+        }
+
+        private string Parenthesize(string name, params Expr[] expressions)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append('(').Append(name);
+
+            foreach (Expr expr in expressions)
+            {
+                builder.Append(' ');
+                builder.Append(expr.Accept(this));
+            }
+
+            builder.Append(')');
+
+            return builder.ToString();
+        }
+
+        private string Parenthesize2(string name, params object[] parts)
+        {
+            StringBuilder builder = new();
+
+            builder.Append('(').Append(name);
+            Transform(builder, parts);
+            builder.Append(')');
+
+            return builder.ToString();
+        }
+
+        private void Transform(StringBuilder builder, params object[] parts)
+        {
+            foreach (object part in parts)
+            {
+                builder.Append(' ');
+
+                if (part is Expr expr)
+                {
+                    builder.Append(expr.Accept(this));
+                }
+                else if (part is Stmt stmt)
+                {
+                    builder.Append(stmt.Accept(this));
+                }
+                else if (part is Token token)
+                {
+                    builder.Append(token.Lexeme);
+                }
+                else if (part is IList<object> list)
+                {
+                    Transform(builder, list.ToArray());
+                }
+                else
+                {
+                    builder.Append(part);
+                }
+            }
+        }
+    }
+}

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable S3626
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine.IO;
 using Perlang.ConsoleApp;
@@ -151,66 +152,106 @@ namespace Perlang.Tests.ConsoleApp
 
         public class MainWithCustomConsole
         {
+            private readonly TestConsole testConsole = new();
+
+            /// <summary>
+            /// Gets the result of the execution, as printed to the standard output stream.
+            /// </summary>
+            private string StdoutResult => testConsole.Out.ToString() ?? String.Empty;
+
+            public class WithPrintParameter
+            {
+                private readonly TestConsole testConsole = new();
+
+                /// <summary>
+                /// Gets the result of the execution, as printed to the standard output stream.
+                /// </summary>
+                private string StdoutResult => testConsole.Out.ToString() ?? String.Empty;
+
+                [Fact]
+                public void assignment_and_increment()
+                {
+                    CallWithPrintParameter("i = i + 1");
+
+                    Assert.Equal("(i (+ i 1))\n", StdoutResult);
+                }
+
+                [Fact]
+                public void addition_assignment()
+                {
+                    CallWithPrintParameter("i += 1");
+
+                    Assert.Equal("(i (+= i 1))\n", StdoutResult);
+                }
+
+                [Fact]
+                public void print_variable()
+                {
+                    CallWithPrintParameter("print hej");
+
+                    Assert.Equal("(print hej)\n", StdoutResult);
+                }
+
+                private void CallWithPrintParameter(string script)
+                {
+                    Program.MainWithCustomConsole(new[] { "-p", script }, testConsole);
+                }
+            }
+
             [Fact]
             public void with_version_parameter_outputs_expected_value()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "--version" }, testConsole);
 
                 // Assert
-                Assert.Equal(CommonConstants.InformationalVersion + "\n", testConsole.Out.ToString());
+                Assert.Equal(CommonConstants.InformationalVersion + "\n", StdoutResult);
             }
 
             [Fact]
             public void with_eval_parameter_outputs_expected_value()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "-e", "print", "10" }, testConsole);
 
                 // Assert
-                Assert.Equal("10" + "\n", testConsole.Out.ToString());
+                Assert.Equal("10" + "\n", StdoutResult);
             }
 
             [Fact]
             public void with_script_outputs_expected_value()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "test/fixtures/hello_world.per" }, testConsole);
 
                 // Assert
-                Assert.Equal("Hello, World\n", testConsole.Out.ToString());
+                Assert.Equal("Hello, World\n", StdoutResult);
             }
 
             [Fact]
             public void with_script_and_script_argument_outputs_expected_value()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "test/fixtures/argv_pop.per", "foo" }, testConsole);
 
                 // Assert
-                Assert.Equal("foo\n", testConsole.Out.ToString());
+                Assert.Equal("foo\n", StdoutResult);
             }
 
             [Fact]
             public void with_invalid_script_throws_expected_exception()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "test/fixtures/invalid.per" }, testConsole);
 
                 // Assert
-                Assert.Contains("Error at end: Expect ';' after value", testConsole.Out.ToString());
+                Assert.Contains("Error at end: Expect ';' after value", StdoutResult);
             }
 
             [Fact]
             public void with_invalid_script_and_script_argument_returns_expected_exit_code()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 int result = Program.MainWithCustomConsole(new[] { "test/fixtures/invalid.per", "foo" }, testConsole);
 
                 // Assert
@@ -221,11 +262,10 @@ namespace Perlang.Tests.ConsoleApp
             public void with_invalid_script_and_script_argument_prints_expected_error_message()
             {
                 // Arrange & Act
-                var testConsole = new TestConsole();
                 Program.MainWithCustomConsole(new[] { "test/fixtures/invalid.per", "foo" }, testConsole);
 
                 // Assert
-                Assert.Contains("Error at end: Expect ';' after value", testConsole.Out.ToString());
+                Assert.Contains("Error at end: Expect ';' after value", StdoutResult);
             }
         }
     }


### PR DESCRIPTION
This is mostly a convenience, but can be handy sometimes when debugging a particular problem with how expressions are being parsed.

A new command line option was also added for this, so you can easily invoke this as needed.

```
  -p                Parse a single-line script and output a human-readable version of the AST
```

This is the mechanism used by the tests for this functionality. We're nowhere near having complete tests for the `AstPrinter` class, but we'll add more test methods as we find a need for it.