### PR TITLE
(docs) Add CI testing of examples

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail -O inherit_errexit {0}
 
 jobs:
-  build:
+  publish-packages:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -12,7 +12,7 @@ on:
       - Perlang**
 
 jobs:
-  publish:
+  publish-website:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,16 +4,18 @@ name: Website
 # for that branch.
 on:
   push:
-    branches:
-      - "*"
-      - "!master"
+    branches-ignore:
+      - master
 
 jobs:
-  rebuild:
+  build-website:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
 
-      - name: Rebuild website
-        run: make docs
+      - name: Build Perlang & rebuild website
+        run: make -j all docs
+
+      - name: Ensure examples execute without errors
+        run: make docs-test-examples

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Perlang.Common/CommonConstants.Generated.cs is not phony, but we always want
 # to force it to be regenerated.
-.PHONY: all auto-generated clean docs docs-serve install release run Perlang.Common/CommonConstants.Generated.cs
+.PHONY: \
+	all auto-generated clean docs docs-serve docs-test-examples \
+	install release run Perlang.Common/CommonConstants.Generated.cs
 
 # Enable fail-fast in case of errors
 SHELL=/bin/bash -e -o pipefail
@@ -32,6 +34,9 @@ docs: docfx/docfx.exe
 
 docs-autobuild:
 	while true; do find docs Makefile src -type f | entr -d bash -c 'scripts/time_it make docs' ; done
+
+docs-test-examples:
+	for e in docs/examples/*.per ; do Perlang.ConsoleApp/bin/Debug/net5.0/perlang $$e ; done
 
 docs-serve:
 	live-server _site

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The installer will download the latest Perlang build and unpack it in a folder u
 
 ### Further reading
 
-At the moment, there isn't much documentation about what you can do with Perlang available, but as soon as it exists, it will be published at the following locations:
+At the moment, there isn't much documentation about what you can do with Perlang available, but we are continuously working on making more and more material available at the following location:
 
-* https://perlang.org (currently redirects to the GitHub repository)
-* https://docs.perlang.org
+* https://perlang.org
+* [docs/syntax-grammar.md](docs/syntax-grammar.md): Specification of the syntax grammar for the Perlang language.
 
 ## Building from source
 
@@ -55,9 +55,15 @@ $ make
 
 You should now have a `perlang` executable. Run `make run` to run it. If you are brave, `make install` (currently Linux only) will put binaries in a path under `~/.perlang` which you can put in your `$PATH` so you can easily use it from anywhere. **Note**: this script uses the same folder (`~/.perlang/nightly/bin`) as the nightly build installer. Any previous version will be overwritten without prompting. This means that if you have previously installed a nightly build and added the folder to your `$PATH`, the version installed with `make install` will now be available in the `$PATH` instead of the previous nightly version.
 
-## Documentation
+## Building the docs
 
-- [docs/syntax-grammar.md](docs/syntax-grammar.md): Specification of the syntax grammar for the Perlang language.
+```shell
+$ npm install -g live-server
+$ make docs
+$ make docs-serve
+```
+
+If you want continuously rebuilt documentation, `make docs-autobuild` in a separate terminal window.
 
 ## License
 

--- a/docs/download/index.md
+++ b/docs/download/index.md
@@ -28,4 +28,4 @@ For more details about this bug, please see https://github.com/perlang-org/perla
 
 For those of you who prefer to learn by watching videos, here's a short screencast (courtesy of [Asciinema](https://asciinema.org/)) which shows what the installer looks like when you run it:
 
-<asciinema-player cols="177" rows="28" src="/casts/perlang-install.cast"></asciinema-player>
+<asciinema-player cols="177" rows="28" speed="2" src="/casts/perlang-install.cast"></asciinema-player>

--- a/docs/examples/hello_world.per
+++ b/docs/examples/hello_world.per
@@ -1,0 +1,2 @@
+// hello_world.per
+print "Hello World"

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -47,10 +47,7 @@ Worth mentioning is that normally in Perlang, each complete _statement_ (like `p
 
 #### Scripting mode
 
-```perlang
-// hello_world.per
-print "Hello World"
-```
+[!code-perlang[hello_world](../examples/hello_world.per)]
 
 The comment on the first line is strictly speaking not a required part in this script. It is only there to help you understand that this program should be saved to disk using the suggested file name given there. (Feel free to disobey this suggestion if you are a little rebellious, just like me.)
 
@@ -99,4 +96,4 @@ user	0m0.383s
 sys	0m0.005s
 ```
 
-So, we are running about 60% slower than the JavaScript counterpart. For many applications, this could be tolerable but it's quite obvious that there's a lot of work that needs to be done in this are before Perlang is anywhere near "production quality".
+So, we are running about 60% slower than the JavaScript counterpart. For many applications, this could be tolerable but it's quite obvious that there's a lot of work that needs to be done in this area before Perlang is anywhere near "production quality".


### PR DESCRIPTION
I received a message from one of our users recently, making me aware that one of the examples in the newly published Learn section of our website (https://perlang.org/learn) had a syntax error.

This is not good, such thoughts ought never to happen. This PR does two things:

- Extracts the example in question (`hello_world.per`) to a separate Perlang script, making it easier to test from the commandline
- Added CI runs to ensure that this examples, and all other examples going forward will be tested in CI before a PR gets merged. This should help us avoid problems like this in the future.
----

The syntax used in the example mentioned currently behaves incorrectly (the example works, even though it should generate a syntax error). I filed a separate issue about that: https://github.com/perlang-org/perlang/issues/157