### PR TITLE
(consoleapp) Fix bug with parsing of incomplete assignments

### DIFF
--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -334,14 +334,6 @@ namespace Perlang.ConsoleApp
 
         private void ParseError(ParseError parseError)
         {
-            if (parseError.ParseErrorType == ParseErrorType.MISSING_TRAILING_SEMICOLON)
-            {
-                // These errors are ignored; we will get them all them when we try to parse expressions as
-                // statements.
-                hadError = true;
-                return;
-            }
-
             Error(parseError.Token, parseError.Message);
         }
 

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static Perlang.TokenType;
@@ -716,6 +717,7 @@ namespace Perlang.Parser
         /// Returns the token right before the current position.
         /// </summary>
         /// <returns>A token.</returns>
+        [DebuggerStepThrough]
         private Token Previous()
         {
             return tokens[current - 1];

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -192,6 +192,16 @@ namespace Perlang.Tests.ConsoleApp
                     Assert.Equal("(print hej)\n", StdoutResult);
                 }
 
+                // This was previously broken, before #161. The incomplete expression was not properly detected by the
+                // interpreter.
+                [Fact]
+                public void invalid_expression()
+                {
+                    CallWithPrintParameter("hej hej");
+
+                    Assert.Contains("Error at 'hej': Expect ';' after expression.", StdoutResult);
+                }
+
                 private void CallWithPrintParameter(string script)
                 {
                     Program.MainWithCustomConsole(new[] { "-p", script }, testConsole);


### PR DESCRIPTION
Certain incomplete statements were incorrectly being considered valid, as a result of https://github.com/perlang-org/perlang/pull/34 being merged (almost a year ago). The special-casing in `ParseError` needed to be removed after that was merged, but was incorrectly retained. This PR fixes that.