### PR TITLE
(interpreter) Catch and handle SystemExceptions gracefully

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -81,7 +81,7 @@ namespace Perlang
             }
         }
 
-        public class Binary : Expr
+        public class Binary : Expr, ITokenAwareExpr
         {
             public Expr Left { get; }
             public Token Operator { get; }
@@ -103,6 +103,8 @@ namespace Perlang
             {
                 return $"{Left} {Operator} {Right}";
             }
+
+            public Token Token => Operator;
         }
 
         public class Call : Expr, ITokenAwareExpr

--- a/Perlang.Common/RuntimeError.cs
+++ b/Perlang.Common/RuntimeError.cs
@@ -10,7 +10,7 @@ namespace Perlang
     {
         public Token? Token { get; set; }
 
-        public RuntimeError(Token token, string message)
+        public RuntimeError(Token? token, string message)
             : base(message)
         {
             Token = token;

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -793,6 +793,13 @@ namespace Perlang.Interpreter
                     throw;
                 }
             }
+            catch (SystemException systemException)
+            {
+                Token? token = (expr as ITokenAwareExpr)?.Token;
+
+                runtimeErrorHandler(new RuntimeError(token, systemException.Message));
+                return null;
+            }
         }
 
         private void Execute(Stmt stmt)

--- a/Perlang.Tests.Integration/Operator/Division.cs
+++ b/Perlang.Tests.Integration/Operator/Division.cs
@@ -64,5 +64,19 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Single(result.Errors);
             Assert.Matches("Invalid arguments to / operator specified", exception.Message);
         }
+
+        [Fact]
+        public void division_by_zero_throws_expected_runtime_error()
+        {
+            string source = @"
+                1 / 0
+            ";
+
+            var result = EvalWithRuntimeErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Attempted to divide by zero.", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
This was investigated as a "bi-product" of #162. The same problem exists with operations like this, but before this PR, they would kill the whole Perlang interpreter IIRC (because of the exception thrown in the first statement).

Once we have #162 under control, we could consider adding a unit test for the error below, to ensure that execution halts correctly.

`1 / 0; print "hejhej";`