### PR TITLE
(interpreter) #162 Ensure RuntimeErrors stops script execution

### DIFF
--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -281,7 +281,7 @@ namespace Perlang.ConsoleApp
         {
             object result = interpreter.Eval(source, ScanError, ParseError, ResolveError, ValidationError, ValidationError);
 
-            if (result != null)
+            if (result != null && result != VoidObject.Void)
             {
                 standardOutputHandler(result.ToString());
             }

--- a/Perlang.Tests.Integration/Operator/Division.cs
+++ b/Perlang.Tests.Integration/Operator/Division.cs
@@ -78,5 +78,19 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Single(result.Errors);
             Assert.Matches("Attempted to divide by zero.", exception.Message);
         }
+
+        [Fact]
+        public void division_by_zero_halts_execution()
+        {
+            string source = @"
+                1 / 0;
+                print ""hejhej"";
+            ";
+
+            string result = null;
+            Assert.Throws<RuntimeError>(() => result = EvalReturningOutputString(source));
+
+            Assert.DoesNotMatch("hejhej.", result);
+        }
     }
 }

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -132,7 +132,7 @@ namespace Perlang.Tests.ConsoleApp
 
             // There used to be an exception in the default runtimeErrorHandler. This test would illustrate it.
             [Fact]
-            public void ARGV_pop_with_no_arguments_throws_the_expected_exception()
+            public void ARGV_pop_expr_with_no_arguments_throws_the_expected_exception()
             {
                 // Cannot use 'subject' here since we need it instantiated with different parameters to provoke this exact
                 // error.
@@ -142,6 +142,25 @@ namespace Perlang.Tests.ConsoleApp
                 );
 
                 program.Run("ARGV.pop()");
+
+                Assert.Equal(new List<string>
+                {
+                    "[line 1] No arguments left"
+                }, output);
+            }
+
+            [Fact]
+            public void ARGV_pop_stmt_with_no_arguments_throws_the_expected_exception()
+            {
+                // Cannot use 'subject' here since we need it instantiated with different parameters to provoke this exact
+                // error.
+                var program = new Program(
+                    replMode: true,
+                    standardOutputHandler: s => output.Add(s)
+                );
+
+                // Note that the trailing ; makes this a complete statement.
+                program.Run("ARGV.pop();");
 
                 Assert.Equal(new List<string>
                 {
@@ -246,6 +265,16 @@ namespace Perlang.Tests.ConsoleApp
 
                 // Assert
                 Assert.Equal("foo\n", StdoutResult);
+            }
+
+            [Fact]
+            public void with_script_and_no_argument_prints_expected_error()
+            {
+                // Arrange & Act
+                Program.MainWithCustomConsole(new[] { "test/fixtures/argv_pop.per" }, testConsole);
+
+                // Assert
+                Assert.Equal("[line 1] No arguments left\n", StdoutResult);
             }
 
             [Fact]


### PR DESCRIPTION
This one turned out to be rather nasty and non-trivial. The way we handled exceptions was basically broken. We propagated them to the `runtimeErrorHandler` and carried on. For all other error types (scanner, parser, type validation etc) this makes perfect sense, but not so with runtime errors. They are _intended_ to halt the script from further execution.

Closes #162