### PR TITLE
(ci) Publish website to perlang.org repo

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -21,15 +21,13 @@ jobs:
       - name: Rebuild website
         run: make docs
 
-      #
-      # Upload files to public web server via rsync
-      #
-      - name: Upload generated web site
-        uses: easingthemes/ssh-deploy@v2.1.1
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.WWW_SSH_PRIVATE_KEY }}
-          ARGS: "-rlgoDzvO"
-          SOURCE: "./_site/"
-          REMOTE_HOST: ${{ secrets.WWW_SSH_REMOTE_HOST }}
-          REMOTE_USER: ${{ secrets.WWW_SSH_REMOTE_USER }}
-          TARGET: ${{ secrets.WWW_SSH_REMOTE_TARGET }}
+      - name: Deploy to perlang.org repo
+        uses: jamesives/github-pages-deploy-action@4.1.0
+        with:
+          repository-name: perlang-org/perlang.org
+          branch: master
+          folder: _site
+          target-folder: public
+          ssh-key: ${{ secrets.WEBSITE_DEPLOY_KEY }}
+          git-config-name: perlang.org-ci-uploader
+          git-config-email: perlang-ci-uploader@noreply.github.com


### PR DESCRIPTION
Together with the https://github.com/perlang-org/perlang.org/commit/0e44e8783484499bf6c2c5a939788a9a6f7ee01f change in the newly created `perlang.org` repository, this changes the https://perlang.org publishing to be a three-step process:

## Before the change

- CI would run in this repo, building the website on each push to the `master` branch
- Once the website is built, it would be `rsync`:ed to the web site to be made available at https://perlang.org

## After the change

- CI still runs and builds the website
- Instead of publishing the results via `rsync`, they are instead added as a `git` commit to the https://github.com/perlang-org/perlang.org repository
- Once that commit is pushed, another CI action is executed in the `perlang.org` repository which `rsync`:s the files to the web site, making it available at https://perlang.org

## Motivation for the change

This does indeed make things a bit more complex, but the advantage is that the revision history _of the actual HTML content_ for the website is available so we can look at it when needed. In other words, we can much more easily see how a particular Perlang change affected the web site. The current driving force for this is the https://github.com/perlang-org/perlang/pull/134 PR, in which we are upgrading DocFx. That's a typical case when it really makes a lot of sense to easily be able to see how a particular change affects (or hopefully, doesn't affect that much) the generated HTML files.