### PR TITLE
(ci) Set DocFx source branch

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Rebuild website
         run: make docs
+        env:
+          DOCFX_SOURCE_BRANCH_NAME: ${{ env.GIT_BRANCH }}
 
       - name: Deploy to perlang.org repo
         uses: jamesives/github-pages-deploy-action@4.1.0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Build Perlang & rebuild website
         run: make -j all docs
+        env:
+          DOCFX_SOURCE_BRANCH_NAME: ${{ env.GIT_BRANCH }}
 
       - name: Ensure examples execute without errors
         run: make docs-test-examples SHELL="sh -x -e"


### PR DESCRIPTION
I discovered when looking at https://github.com/perlang-org/perlang.org/commit/a1e93f462faf438df77e699d1571ab0ca518ea03 that the "improve this doc" links were broken. DocFx seem to have been unable to determine the branch name, in line with its rules as defined here: https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#42-set-branch-name

By setting the `DOCFX_SOURCE_BRANCH_NAME` environment variable manually, we should be able to work around this.