### PR TITLE
(docs) Ensure "git contribute" links refer to the correct branch

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Rebuild website
         run: make docs
-        env:
-          DOCFX_SOURCE_BRANCH_NAME: ${{ env.GIT_BRANCH }}
 
       - name: Deploy to perlang.org repo
         uses: jamesives/github-pages-deploy-action@4.1.0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Build Perlang & rebuild website
         run: make -j all docs
-        env:
-          DOCFX_SOURCE_BRANCH_NAME: ${{ env.GIT_BRANCH }}
 
       - name: Ensure examples execute without errors
         run: make docs-test-examples SHELL="sh -x -e"

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -65,7 +65,10 @@
         "fileMetadataFiles": [],
 
         "globalMetadata": {
-            "_appFooter": "© Copyright 2020 The Perlang Authors"
+            "_appFooter": "© Copyright 2020 The Perlang Authors",
+            "_gitContribute": {
+                "branch": "master"
+              }
         },
 
         // Our custom template changes are in docs/template


### PR DESCRIPTION
This also reverts #169. It didn't seem to have the desired impact anyway, so we might as well be without it.