### PR TITLE
(many) Mark certain keywords as reserved for future use

### DIFF
--- a/src/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -565,6 +565,10 @@ namespace Perlang.Interpreter.Typing
                 {
                     // TODO: Replace these with a dictionary of type names in the currently imported namespaces or similar.
                     // TODO: This is not really a scalable approach. :)
+                    //
+                    // Note that adding more supported types here also means the list of reserved identifiers in
+                    // PerlangParser.BlockReservedIdentifiers() should be updated. (Adding unit tests for the new
+                    // types in ReservedKeywordsTests is a good way to ensure this is not forgotten.)
                     case "int":
                     case "Int32":
                         typeReference.ClrType = typeof(int);

--- a/src/Perlang.Parser/ParseErrorType.cs
+++ b/src/Perlang.Parser/ParseErrorType.cs
@@ -1,7 +1,11 @@
+#pragma warning disable S4016
+
 namespace Perlang.Parser
 {
     public enum ParseErrorType
     {
-        MISSING_TRAILING_SEMICOLON
+        MISSING_TRAILING_SEMICOLON,
+
+        RESERVED_WORD_ENCOUNTERED
     }
 }

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using static Perlang.TokenType;
 
 namespace Perlang.Parser
@@ -37,7 +38,81 @@ namespace Perlang.Parser
 
                 // Reserved keywords
                 { "class", RESERVED_WORD }, // Pending #66 to be resolved.
+
+                // Type names
+                //
+                // NOTE: only types not supported by
+                // Perlang.Interpreter.Typing.TypeValidator.TypeResolver.ResolveExplicitTypes should be listed here.
+                // Otherwise, we make it impossible to use them for variable declarations, return types etc.
+                //
+                { "byte", RESERVED_WORD },
+                { "sbyte", RESERVED_WORD },
+                { "short", RESERVED_WORD },
+                { "long", RESERVED_WORD },
+                { "ushort", RESERVED_WORD },
+                { "uint", RESERVED_WORD },
+                { "ulong", RESERVED_WORD },
+                { "float", RESERVED_WORD },
+                { "double", RESERVED_WORD },
+                { "decimal", RESERVED_WORD },
+                { "char", RESERVED_WORD },
+
+                // // Visibility, static/instance, etc
+                { "public", RESERVED_WORD },
+                { "private", RESERVED_WORD },
+                { "protected", RESERVED_WORD },
+                { "internal", RESERVED_WORD },
+                { "static", RESERVED_WORD },
+                { "volatile", RESERVED_WORD },
+
+                // Standard functions
+                { "printf", RESERVED_WORD },
+
+                // Flow control
+                { "switch", RESERVED_WORD },
+                { "break", RESERVED_WORD },
+                { "continue", RESERVED_WORD },
+
+                // Exception handling
+                { "try", RESERVED_WORD },
+                { "catch", RESERVED_WORD },
+                { "finally", RESERVED_WORD },
+
+                // Asynchronous programming
+                { "async", RESERVED_WORD },
+                { "await", RESERVED_WORD },
+
+                // Locking/synchronization
+                { "lock", RESERVED_WORD },
+                { "synchronized", RESERVED_WORD },
+
+                // Others
+                { "new", RESERVED_WORD },
+                { "mut", RESERVED_WORD },
+                { "let", RESERVED_WORD },
+                { "const", RESERVED_WORD },
+                { "struct", RESERVED_WORD },
+                { "enum", RESERVED_WORD },
+                { "sizeof", RESERVED_WORD },
+                { "nameof", RESERVED_WORD },
+                { "typeof", RESERVED_WORD },
+                { "asm", RESERVED_WORD }
             }.ToImmutableDictionary();
+
+        private static ISet<string> reservedKeywordStrings;
+
+        public static ISet<string> ReservedKeywordStrings
+        {
+            get
+            {
+                reservedKeywordStrings ??= ReservedKeywords
+                    .Where(kvp => kvp.Value == RESERVED_WORD)
+                    .Select(kvp => kvp.Key)
+                    .ToHashSet();
+
+                return reservedKeywordStrings;
+            }
+        }
 
         private readonly string source;
         private readonly ScanErrorHandler scanErrorHandler;
@@ -254,15 +329,15 @@ namespace Perlang.Parser
 
                 if (value < Int32.MaxValue)
                 {
-                    AddToken(NUMBER, (int) value);
+                    AddToken(NUMBER, (int)value);
                 }
                 else if (value < UInt32.MaxValue)
                 {
-                    AddToken(NUMBER, (uint) value);
+                    AddToken(NUMBER, (uint)value);
                 }
                 else if (value < Int64.MaxValue)
                 {
-                    AddToken(NUMBER, (long) value);
+                    AddToken(NUMBER, (long)value);
                 }
                 else // ulong
                 {

--- a/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using Perlang.Parser;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -6,6 +8,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
 {
     public class ReservedKeywordsTests
     {
+        // Special-cased test for this keyword, to ensure that it consumes the class name as expected
         [Fact]
         public void reserved_keyword_class_throws_expected_error()
         {
@@ -17,26 +20,443 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'class': Expect expression", exception.ToString());
+            Assert.Matches($"Error at 'class': Expect expression", exception.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReservedWords))]
+        public void reserved_keyword_throws_expected_error(string reservedWord)
+        {
+            string source = @$"
+                var {reservedWord} = 1;
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches($"Error at '{reservedWord}': Reserved word encountered", exception.ToString());
         }
 
         [Fact]
-        public void function_return_type_detects_reserved_keywords()
+        public void reserved_keyword_public_throws_expected_error()
         {
-            // 'float' is not a valid type name yet, so this test expects a particular error to be thrown.
-            // For more details on reserved words, see #178. (Technically, this test does not exercise the "reserved
-            // words" code paths at all; since float isn't defined, it fails as it would with any other type.)
+            string source = @"
+                var public = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'public': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_private_throws_expected_error()
+        {
+            string source = @"
+                var private = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'private': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_protected_throws_expected_error()
+        {
+            string source = @"
+                var protected = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'protected': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_internal_throws_expected_error()
+        {
+            string source = @"
+                var internal = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'internal': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_static_throws_expected_error()
+        {
+            string source = @"
+                var static = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'static': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_volatile_throws_expected_error()
+        {
+            string source = @"
+                var volatile = 1
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'volatile': Reserved word encountered", exception.ToString());
+        }
+
+        //
+        // Variable declarations: ensure that reserved keywords cannot be used as variable names
+        //
+
+        [Fact]
+        public void reserved_keyword_int_cannot_be_used_as_variable_name()
+        {
+            string source = @"
+                var int = 123;
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+
+            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_float_cannot_be_used_as_variable_name()
+        {
+            string source = @"
+                var float = 123.45;
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+
+            Assert.Matches("Error at 'float': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_string_cannot_be_used_as_variable_name()
+        {
+            string source = @"
+                var string = ""foo"";
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+
+            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+        }
+
+        //
+        // Functions: ensure that reserved keywords cannot be used as function names
+        //
+
+        [Fact]
+        public void reserved_keyword_int_cannot_be_used_as_function_name()
+        {
+            string source = @"
+                fun int(): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_float_cannot_be_used_as_function_name()
+        {
+            string source = @"
+                fun float(): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'float': Expect function name", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_string_cannot_be_used_as_function_name()
+        {
+            string source = @"
+                fun string(): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+        }
+
+        //
+        // Functions: ensure that reserved words cannot be used as function parameter names
+        //
+
+        [Fact]
+        public void reserved_keyword_int_cannot_be_used_as_function_parameter_name()
+        {
+            string source = @"
+                fun foo(int: int): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_float_cannot_be_used_as_function_parameter_name()
+        {
+            string source = @"
+                fun foo(float: float): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'float': Reserved word encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_string_cannot_be_used_as_function_parameter_name()
+        {
+            string source = @"
+                fun foo(string: string): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+        }
+
+        //
+        // Return types: ensure that reserved keywords cannot be used as return types
+        //
+        // Note that as 'byte', 'sbyte', 'float' etc are not valid types name yet, this test expects a particular error
+        // to be thrown. For more details on reserved words, see #178. (Technically, these test does not exercise the
+        // "reserved words" code paths at all; since the type names aren't defined, they fail as they would with any
+        // other non-defined type name.)
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_byte()
+        {
+            string source = @"
+                fun foo(): byte {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'byte': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_sbyte()
+        {
+            string source = @"
+                fun foo(): sbyte {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'sbyte': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_short()
+        {
+            string source = @"
+                fun foo(): short {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'short': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_long()
+        {
+            string source = @"
+                fun foo(): long {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'long': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_ushort()
+        {
+            string source = @"
+                fun foo(): ushort {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'ushort': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_uint()
+        {
+            string source = @"
+                fun foo(): uint {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'uint': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_ulong()
+        {
+            string source = @"
+                fun foo(): ulong {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'ulong': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_float()
+        {
             string source = @"
                 fun foo(): float {
                     return 123.45;
                 }
             ";
 
-            var result = EvalWithValidationErrorCatch(source);
+            var result = EvalWithParseErrorCatch(source);
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Type not found: float", exception.ToString());
+            Assert.Matches("Error at 'float': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_double()
+        {
+            string source = @"
+                fun foo(): double {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'double': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_decimal()
+        {
+            string source = @"
+                fun foo(): decimal {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'decimal': Expecting type name", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keyword_char()
+        {
+            string source = @"
+                fun foo(): char {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'char': Expecting type name", exception.ToString());
+        }
+
+        public static IEnumerable<object[]> GetReservedWords()
+        {
+            return Scanner.ReservedKeywordStrings
+                .Select(s => new object[] { s });
         }
     }
 }


### PR DESCRIPTION
~I started thinking about this the other day. Shipping version 0.1.0 of Perlang with a half-baked `class` implementation makes little sense, if any, at all. It's much better to just make `class` a reserved word for now, clearly implying that it's likely to come in a future release but not giving the completely false impression that it's already here (when it truly isn't).~ The above is still valid, but the removal of `class` as a reserved word was extracted to #183.

I also added a bunch of other reserved words for now, inspired by C and Java/C#. There might be things here that are not present; this is not a problem, we'll just add them to 0.2.0. Hopefully this list will shrink as time passes (and we implement some of these into the language proper). In a distant future when we ship 1.0, I hope this list would be to close to empty, unless we know with a _very_ high degree of certainty that we have things we will want to use for something useful in a future release.

Closes #178