### PR TITLE
(parser) Make `class` reserved keyword

### DIFF
--- a/src/Perlang.Common/TokenType.cs
+++ b/src/Perlang.Common/TokenType.cs
@@ -1,3 +1,5 @@
+#pragma warning disable S4016
+
 namespace Perlang
 {
     public enum TokenType
@@ -39,7 +41,6 @@ namespace Perlang
 
         // Keywords.
         AND,
-        CLASS,
         ELSE,
         FALSE,
         FUN,
@@ -54,6 +55,9 @@ namespace Perlang
         TRUE,
         VAR,
         WHILE,
+
+        // Reserved keywords, not yet used by the language.
+        RESERVED_WORD,
 
         EOF
     }

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -100,7 +100,7 @@ namespace Perlang.Parser
                 if (foundExpression)
                 {
                     Stmt last = statements.Last();
-                    return ((Stmt.ExpressionStmt) last).Expression;
+                    return ((Stmt.ExpressionStmt)last).Expression;
                 }
 
                 allowExpression = false;
@@ -122,7 +122,6 @@ namespace Perlang.Parser
         {
             try
             {
-                if (Match(CLASS)) return ClassDeclaration();
                 if (Match(FUN)) return Function("function");
                 if (Match(VAR)) return VarDeclaration();
 
@@ -304,23 +303,6 @@ namespace Perlang.Parser
             }
 
             return new Stmt.ExpressionStmt(expr);
-        }
-
-        private Stmt.Class ClassDeclaration()
-        {
-            Token name = Consume(IDENTIFIER, "Expect class name.");
-            Consume(LEFT_BRACE, "Expect '{' before class body.");
-
-            var methods = new List<Stmt.Function>();
-
-            while (!Check(RIGHT_BRACE) && !IsAtEnd)
-            {
-                methods.Add(Function("method"));
-            }
-
-            Consume(RIGHT_BRACE, "Expect '}' after class body.");
-
-            return new Stmt.Class(name, methods);
         }
 
         private Stmt.Function Function(string kind)
@@ -743,7 +725,6 @@ namespace Perlang.Parser
 
                 switch (Peek().Type)
                 {
-                    case CLASS:
                     case FUN:
                     case VAR:
                     case FOR:

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -20,7 +20,6 @@ namespace Perlang.Parser
             new Dictionary<string, TokenType>
             {
                 { "and", AND },
-                { "class", CLASS },
                 { "else", ELSE },
                 { "false", FALSE },
                 { "for", FOR },
@@ -34,13 +33,16 @@ namespace Perlang.Parser
                 { "this", THIS },
                 { "true", TRUE },
                 { "var", VAR },
-                { "while", WHILE }
+                { "while", WHILE },
+
+                // Reserved keywords
+                { "class", RESERVED_WORD }, // Pending #66 to be resolved.
             }.ToImmutableDictionary();
 
         private readonly string source;
         private readonly ScanErrorHandler scanErrorHandler;
 
-        private readonly List<Token> tokens = new List<Token>();
+        private readonly List<Token> tokens = new();
         private int start;
         private int current;
         private int line = 1;

--- a/src/Perlang.Tests.Integration/Classes/ClassesTests.cs
+++ b/src/Perlang.Tests.Integration/Classes/ClassesTests.cs
@@ -11,7 +11,7 @@ namespace Perlang.Tests.Integration.Classes
     /// </summary>
     public class ClassesTests
     {
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void empty_class_can_be_accessed_by_name()
         {
             string source = @"
@@ -25,7 +25,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Equal("Foo", output);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void duplicate_class_name_throws_expected_error()
         {
             string source = @"
@@ -57,7 +57,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Equal("Perlang.Stdlib.Base64", output);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void class_name_clash_with_native_class_throws_expected_error()
         {
             string source = @"
@@ -71,7 +71,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Matches("Class Base64 already defined; cannot redefine", exception.Message);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void class_name_clash_with_native_object_throws_expected_error()
         {
             string source = @"
@@ -85,7 +85,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Matches("Object ARGV already defined; cannot redefine", exception.Message);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void class_name_clash_with_function_throws_expected_error()
         {
             string source = @"
@@ -101,7 +101,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Matches("Function Hello already defined; cannot redefine", exception.Message);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void class_name_clash_with_variable_throws_expected_error()
         {
             string source = @"
@@ -117,7 +117,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Matches("Variable Hello already defined; cannot redefine", exception.Message);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void can_get_reference_to_static_method()
         {
             string source = @"
@@ -145,7 +145,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Equal("#<Perlang.Stdlib.Base64 System.String ToString()>", output);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void can_call_static_method()
         {
             string source = @"
@@ -171,7 +171,7 @@ namespace Perlang.Tests.Integration.Classes
             Assert.Equal("Perlang.Stdlib.Base64", output);
         }
 
-        [Fact]
+        [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/66")]
         public void can_chain_method_calls_for_static_method()
         {
             string source = @"

--- a/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.ReservedKeywords
+{
+    public class ReservedKeywordsTests
+    {
+        [Fact]
+        public void reserved_keyword_class_throws_expected_error()
+        {
+            string source = @"
+                class Foo {}
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'class': Expect expression", exception.ToString());
+        }
+
+        [Fact]
+        public void function_return_type_detects_reserved_keywords()
+        {
+            // 'float' is not a valid type name yet, so this test expects a particular error to be thrown.
+            // For more details on reserved words, see #178. (Technically, this test does not exercise the "reserved
+            // words" code paths at all; since float isn't defined, it fails as it would with any other type.)
+            string source = @"
+                fun foo(): float {
+                    return 123.45;
+                }
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Type not found: float", exception.ToString());
+        }
+    }
+}

--- a/src/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -159,7 +159,7 @@ namespace Perlang.Tests.Integration.Typing
         }
 
         [Fact]
-        public void function_return_value_can_provide_a_type()
+        public void function_return_type_can_specify_explicit_type()
         {
             string source = @"
                 fun foo(): String {
@@ -192,7 +192,7 @@ namespace Perlang.Tests.Integration.Typing
         }
 
         [Fact]
-        public void function_return_value_detects_type_not_found()
+        public void function_return_type_detects_type_not_found()
         {
             string source = @"
                 fun foo(): SomeUnknownType {


### PR DESCRIPTION
Extracted from #180, this marks `class` as a reserved keyword. Given that it has never really been fully working, this feels more logical than shipping 0.1.0 with an "half-baked" thing that just makes people confused.

Related issue: #178