### PR TITLE
Update perlang-install to detect tls1.2 for curl 7.73+

### DIFF
--- a/scripts/perlang-install
+++ b/scripts/perlang-install
@@ -354,6 +354,13 @@ check_help_for() {
     _cmd="$1"
     shift
 
+    local _category
+    if "$_cmd" --help | grep -q 'For all options use the manual or "--help all".'; then
+      _category="all"
+    else
+      _category=""
+    fi
+
     case "$_arch" in
 
         # If we're running on OS-X, older than 10.13, then we always
@@ -371,7 +378,7 @@ check_help_for() {
     esac
 
     for _arg in "$@"; do
-        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+        if ! "$_cmd" --help $_category | grep -q -- "$_arg"; then
             return 1
         fi
     done


### PR DESCRIPTION
As can be seen in the `perlang-install` sceencast at https://perlang.org/download/, certain versions of cURL fails in terms of the TLS 1.2 detection. This is the error we emit in these cases:

```
Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure
Warning: Not enforcing TLS v1.2, this is potentially less secure                                                                                                                 
```

The root cause for this is that the `curl --help` syntax has changed in recent versions (and ideally, parsing the `curl --help` output isn't a particularly great way anyway, but there's probably not much we can do about that). This commit, originally done by @apnorton in https://github.com/rust-lang/rustup/pull/2604 (thanks!) fixes the issue. Given that `perlang-install` is essentially a fork of `rustup-init.sh`, the patch applied cleanly after merely editing the file name.

(After importing the commit, I did change the author of the commit to myself, since it would be a bit misleading to just copy commits from another author in another repo into this repo without their consent; it just looked weird that way.)

### Original commit message

(from https://github.com/rust-lang/rustup/commit/01fd3a19774e97839f6b3c52075a491ea9479abd)

This fixes rust-lang/rustup#2603.  In curl 7.73.0, the help format was
changed so as to only show a summary when calling `curl --help`, while
the old menu can be accessed as `curl --help all`.  This change updates
the `check_help_for` function to detect if the command being checked
contains the curl 7.73.0+ language indicating the use of `--help all`.

If this language is present, `check_help_for` will insert the `all`
category after the `--help` flag, allowing the query to work.  If the
language is not present, then it will insert an empty string following
the `--help` flag, maintaining the same behavior with pre-7.73 versions
of curl.