### PR TITLE
(interpreter) Detect reassignment from incoercible values

### DIFF
--- a/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Perlang.Interpreter.Resolution;
+using Perlang.Parser;
+
+namespace Perlang.Interpreter.Typing
+{
+    /// <summary>
+    /// Visitor which ensures that all assignments in the given list of statements use values which can be coerced to
+    /// the variable type in question.
+    /// </summary>
+    internal class TypeAssignmentValidator : VisitorBase
+    {
+        private readonly Func<Expr, Binding> getVariableOrFunctionCallback;
+        private readonly Action<TypeValidationError> typeValidationErrorCallback;
+        private readonly TypeCoercer typeCoercer;
+
+        public TypeAssignmentValidator(
+            Func<Expr, Binding> getVariableOrFunctionCallback,
+            Action<TypeValidationError> typeValidationErrorCallback,
+            Action<CompilerWarning> compilerWarningCallback)
+        {
+            this.getVariableOrFunctionCallback = getVariableOrFunctionCallback;
+            this.typeValidationErrorCallback = typeValidationErrorCallback;
+
+            typeCoercer = new TypeCoercer(compilerWarningCallback);
+        }
+
+        public void ReportErrors(IList<Stmt> statements)
+        {
+            foreach (Stmt stmt in statements)
+            {
+                stmt.Accept(this);
+            }
+        }
+
+        public override VoidObject VisitAssignExpr(Expr.Assign expr)
+        {
+            base.VisitAssignExpr(expr);
+
+            Binding variableExpr = getVariableOrFunctionCallback(expr);
+
+            if (variableExpr == null)
+            {
+                // An attempt is made to assign a value to an undefined variable. This is an error, but it's handled
+                // elsewhere so we can silently ignore it at this point.
+                return VoidObject.Void;
+            }
+
+            if (variableExpr is FunctionBinding)
+            {
+                // Functions are immutable, handled by a class in the Perlang.Interpreter.Immutability namespace. We can
+                // ignore it at this point; the attempt to reassign it will be detected elsewhere.
+                return VoidObject.Void;
+            }
+
+            var targetTypeReference = variableExpr.TypeReference;
+            var sourceTypeReference = expr.Value.TypeReference;
+
+            if (!typeCoercer.CanBeCoercedInto(expr.Token, targetTypeReference, sourceTypeReference))
+            {
+                typeValidationErrorCallback(new TypeValidationError(
+                    expr.Token,
+                    $"Cannot assign {sourceTypeReference.ClrType} to variable defined as '{targetTypeReference.ClrType}'"
+                ));
+            }
+
+            return VoidObject.Void;
+        }
+    }
+}

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -63,7 +63,9 @@ namespace Perlang.Interpreter.Typing
                 targetType != typeof(float))
             {
                 // Reassignment to `nil` is valid as long as the target is not a value type. In other words, reference
-                // types are nullable by default.
+                // types are nullable by default. We do emit a compiler warning though, and depending on the
+                // configuration of the front end, this warning can cause compilation to fail (if the front end is
+                // configured to disallow compiler warnings).
                 return true;
             }
 

--- a/src/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -77,6 +77,21 @@ namespace Perlang.Interpreter.Typing
             // errors if desired, though. The key point here is to not discard it at the wrong stage in the pipeline.)
             new TypesResolvedValidator(getVariableOrFunctionCallback, typeValidationErrorCallback, compilerWarningCallback)
                 .ReportErrors(statements);
+
+            //
+            // Phase 3: Ensure that no assignments are made from incoercible values
+            //
+
+            // An example error that the above detects is the following:
+            //
+            // var i = 1;
+            // i = "foo"; // error
+            //
+            // Once a variable has been defined, it's type has been set; it cannot be reassigned with a value of a
+            // completely different type. The only exception to this rule is when a smaller numeric value (e.g. `int`)
+            // is expanded to a larger type (e.g. `long`).
+            new TypeAssignmentValidator(getVariableOrFunctionCallback, typeValidationErrorCallback, compilerWarningCallback)
+                .ReportErrors(statements);
         }
     }
 }

--- a/src/Perlang.Parser/WarningType.cs
+++ b/src/Perlang.Parser/WarningType.cs
@@ -1,7 +1,41 @@
+// Poor-man's replacement for Java-style enums (which are much more like regular classes) in C#. Because we are doing it
+// like this, we allow ourselves to override the rules for this particular file.
+#pragma warning disable SA1310
+#pragma warning disable S3453
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
 namespace Perlang.Parser
 {
-    // Placeholder for now, since we don't yet have any warnings defined.
     public class WarningType
     {
+        public string Name { get; }
+
+        /// <summary>
+        /// `nil` is used. This warning covers multiple usages of nil, like variable assignment (`s = nil`), variable
+        /// initializers (`var s: string = nil`) and function calls (`some_function(nil)`).
+        /// </summary>
+        public static readonly WarningType NIL_USAGE = new("nil-usage");
+
+        private static readonly IReadOnlyDictionary<string, WarningType> AllWarnings = new[]
+        {
+            NIL_USAGE
+        }.ToImmutableDictionary(w => w.Name, w => w);
+
+        private WarningType(string name)
+        {
+            Name = name;
+        }
+
+        public static bool KnownWarning(string warningName)
+        {
+            return AllWarnings.ContainsKey(warningName);
+        }
+
+        public static WarningType Get(string warningName)
+        {
+            return AllWarnings[warningName];
+        }
     }
 }


### PR DESCRIPTION
A typical example of an incoercible assignment is this:

```perlang
var i = 1;
i = "foo";
```

...in other words, an integer value being reassigned a `string` value.

Other use cases are more tricky. For example, should we or should we not allow `nil` assignment by default for reference types? We'll try to decide on this before merging this PR.