### PR TITLE
(interpreter) Add infrastructure for compiler warnings

### DIFF
--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -17,4 +17,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Titleized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werror/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/scripts/local_install_linux.sh
+++ b/scripts/local_install_linux.sh
@@ -9,5 +9,5 @@ set -e
 
 mkdir -p $HOME/.perlang/nightly/bin
 
-dotnet publish Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
-cp -r Perlang.ConsoleApp/bin/Release/net5.0/linux-x64/publish/* $HOME/.perlang/nightly/bin
+dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
+cp -r src/Perlang.ConsoleApp/bin/Release/net5.0/linux-x64/publish/* $HOME/.perlang/nightly/bin

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -59,6 +59,11 @@ namespace Perlang
         public bool IsResolved => ClrType != null;
 
         /// <summary>
+        /// Gets a value indicating whether this type reference refers to a `nil` value.
+        /// </summary>
+        public bool IsNullObject => ClrType == typeof(NullObject);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TypeReference"/> class, for a given type specifier. The type
         /// specifier can be null, in which case type inference will be attempted.
         /// </summary>

--- a/src/Perlang.Interpreter/Immutability/ImmutabilityValidationError.cs
+++ b/src/Perlang.Interpreter/Immutability/ImmutabilityValidationError.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Perlang.Interpreter.Immutability
 {
     /// <summary>

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -1,0 +1,74 @@
+using System;
+using Perlang.Parser;
+
+namespace Perlang.Interpreter.Typing
+{
+    /// <summary>
+    /// Handles type coercions.
+    /// </summary>
+    public class TypeCoercer
+    {
+        private readonly Action<CompilerWarning> compilerWarningCallback;
+
+        public TypeCoercer(Action<CompilerWarning> compilerWarningCallback)
+        {
+            this.compilerWarningCallback = compilerWarningCallback;
+        }
+
+        /// <summary>
+        /// Determines if a value of <paramref name="sourceTypeReference"/> can be coerced into
+        /// <paramref name="targetTypeReference"/>.
+        ///
+        /// The `source` and `target` concepts are important here. Sometimes values can be coerced in one direction
+        /// but not the other. For example, an `int` can be coerced to a `long`, but not the other way around
+        /// (without an explicit type cast). The same goes for unsigned integer types; they can not be coerced to
+        /// their signed counterpart (`uint` -> `int`), but they can be coerced to a larger signed type if
+        /// available.
+        /// </summary>
+        /// <param name="token">The approximate location of the source token (the token from which the <paramref
+        ///     name="sourceTypeReference"/> is derived).</param>
+        /// <param name="targetTypeReference">A reference to the target type.</param>
+        /// <param name="sourceTypeReference">A reference to the source type.</param>
+        /// <returns>`true` if a source value can be coerced into the target type, `false` otherwise.</returns>
+        public bool CanBeCoercedInto(Token token, TypeReference targetTypeReference, TypeReference sourceTypeReference)
+        {
+            return CanBeCoercedInto(token, targetTypeReference.ClrType, sourceTypeReference.ClrType);
+        }
+
+        /// <summary>
+        /// Determines if a value of <paramref name="sourceType"/> can be coerced into
+        /// <paramref name="targetType"/>.
+        ///
+        /// The `source` and `target` concepts are important here. Sometimes values can be coerced in one direction
+        /// but not the other. For example, an `int` can be coerced to a `long`, but not the other way around
+        /// (without an explicit type cast). The same goes for unsigned integer types; they can not be coerced to
+        /// their signed counterpart (`uint` -> `int`), but they can be coerced to a larger signed type if
+        /// available.
+        /// </summary>
+        /// <param name="token">The approximate location of the source token (the token from which the <paramref
+        ///     name="sourceType"/> is derived).</param>
+        /// <param name="targetType">The target type.</param>
+        /// <param name="sourceType">The source type.</param>
+        /// <returns>`true` if a source value can be coerced into the target type, `false` otherwise.</returns>
+        public bool CanBeCoercedInto(Token token, Type targetType, Type sourceType)
+        {
+            // TODO: Implement some of these coercions being advertised in the XML docs. ;)
+            if (targetType == sourceType)
+            {
+                return true;
+            }
+
+            if (sourceType == typeof(NullObject) &&
+                targetType != typeof(int) &&
+                targetType != typeof(float))
+            {
+                // Reassignment to `nil` is valid as long as the target is not a value type. In other words, reference
+                // types are nullable by default.
+                return true;
+            }
+
+            // None of the defined type coercions was successful.
+            return false;
+        }
+    }
+}

--- a/src/Perlang.Interpreter/Typing/TypeValidationError.cs
+++ b/src/Perlang.Interpreter/Typing/TypeValidationError.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Perlang.Interpreter.Typing
 {
     /// <summary>

--- a/src/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Perlang.Interpreter.Resolution;
+using Perlang.Parser;
 
 namespace Perlang.Interpreter.Typing
 {
@@ -25,7 +26,8 @@ namespace Perlang.Interpreter.Typing
         public static void Validate(
             IList<Stmt> statements,
             Action<TypeValidationError> typeValidationErrorCallback,
-            Func<Expr, Binding> getVariableOrFunctionCallback)
+            Func<Expr, Binding> getVariableOrFunctionCallback,
+            Action<CompilerWarning> compilerWarningCallback)
         {
             bool typeResolvingFailed = false;
 
@@ -73,7 +75,7 @@ namespace Perlang.Interpreter.Typing
             // as possible, the full list errors (if any) are reported back to the caller; we don't just stop at the
             // first error encountered. (The compiler could potentially discard information except for the first n
             // errors if desired, though. The key point here is to not discard it at the wrong stage in the pipeline.)
-            new TypesResolvedValidator(getVariableOrFunctionCallback, typeValidationErrorCallback)
+            new TypesResolvedValidator(getVariableOrFunctionCallback, typeValidationErrorCallback, compilerWarningCallback)
                 .ReportErrors(statements);
         }
     }

--- a/src/Perlang.Interpreter/ValidationError.cs
+++ b/src/Perlang.Interpreter/ValidationError.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Perlang.Interpreter
 {
     /// <summary>

--- a/src/Perlang.Parser/CompilerWarning.cs
+++ b/src/Perlang.Parser/CompilerWarning.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Perlang.Parser
+{
+    /// <summary>
+    /// Represents a compiler warning.
+    /// </summary>
+    /// <remarks>
+    /// Note that Warnings derive from <see cref="Exception"/>, even though they may or may not cause compilation to
+    /// fail. It can make sense to think of them like "exceptions which may or may not be thrown", since that's exactly
+    /// what they are.
+    /// </remarks>
+    public class CompilerWarning : Exception
+    {
+        public Token Token { get; }
+        public WarningType WarningType { get; }
+
+        public CompilerWarning(string message, Token token, WarningType warningType)
+            : base(message)
+        {
+            Token = token;
+            WarningType = warningType;
+        }
+
+        public override string ToString()
+        {
+            string where;
+
+            if (Token.Type == TokenType.EOF)
+            {
+                where = " at end";
+            }
+            else
+            {
+                where = " at '" + Token.Lexeme + "'";
+            }
+
+            return $"[line {Token.Line}] Warning{where}: {Message}";
+        }
+    }
+}

--- a/src/Perlang.Parser/ErrorHandlers.cs
+++ b/src/Perlang.Parser/ErrorHandlers.cs
@@ -2,4 +2,5 @@ namespace Perlang.Parser
 {
     public delegate void ParseErrorHandler(ParseError parseError);
     public delegate void ScanErrorHandler(ScanError scanError);
+    public delegate bool CompilerWarningHandler(CompilerWarning compilerWarning);
 }

--- a/src/Perlang.Parser/WarningType.cs
+++ b/src/Perlang.Parser/WarningType.cs
@@ -1,0 +1,7 @@
+namespace Perlang.Parser
+{
+    // Placeholder for now, since we don't yet have any warnings defined.
+    public class WarningType
+    {
+    }
+}

--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -13,12 +13,19 @@ namespace Perlang.Tests.Integration
         ///
         /// This method will propagate both scanner, parser, resolver and runtime errors to the caller. If multiple
         /// errors are encountered, only the first will be thrown.
+        ///
+        /// Output printed to the standard output stream will be silently discarded by this method. For tests which need
+        /// to make assertions based on the output printed, see e.g. the <see cref="EvalReturningOutput"/> method.
+        ///
+        /// Note that compiler warnings will be propagated as exceptions to the caller; in other words, this resembles
+        /// the `-Werror` flag being enabled.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
-        /// <returns>The result of evaluating the provided expression, or `null` if provided a list of statements.</returns>
+        /// <returns>The result of evaluating the provided expression, or `null` if provided a list of
+        /// statements.</returns>
         internal static object Eval(string source)
         {
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, _ => { });
 
             return interpreter.Eval(
                 source,
@@ -26,7 +33,8 @@ namespace Perlang.Tests.Integration
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
                 AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                AssertFailCompilerWarningHandler
             );
         }
 
@@ -34,8 +42,13 @@ namespace Perlang.Tests.Integration
         /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
         /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
         /// This method will propagate all errors apart from  <see cref="RuntimeError"/> to the caller. Runtime errors
         /// will be available in the returned <see cref="EvalResult{T}"/>.
+        ///
+        /// If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
@@ -45,8 +58,10 @@ namespace Perlang.Tests.Integration
         internal static EvalResult<RuntimeError> EvalWithRuntimeErrorCatch(string source, params string[] arguments)
         {
             var result = new EvalResult<RuntimeError>();
-            var interpreter =
-                new PerlangInterpreter(runtimeError => result.Errors.Add(runtimeError), null, arguments);
+
+            var interpreter = new PerlangInterpreter(
+                result.ErrorHandler, result.OutputHandler, arguments
+            );
 
             result.Value = interpreter.Eval(
                 source,
@@ -54,7 +69,8 @@ namespace Perlang.Tests.Integration
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
                 AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                result.WarningHandler
             );
 
             return result;
@@ -64,8 +80,13 @@ namespace Perlang.Tests.Integration
         /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
         /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
         /// This method will propagate all errors apart from  <see cref="ParseError"/> to the caller. Parse errors
         /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
+        ///
+        /// If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
@@ -74,15 +95,16 @@ namespace Perlang.Tests.Integration
         internal static EvalResult<ParseError> EvalWithParseErrorCatch(string source)
         {
             var result = new EvalResult<ParseError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
             result.Value = interpreter.Eval(
                 source,
                 AssertFailScanErrorHandler,
-                parseError => result.Errors.Add(parseError),
+                result.ErrorHandler,
                 AssertFailResolveErrorHandler,
                 AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                result.WarningHandler
             );
 
             return result;
@@ -92,8 +114,13 @@ namespace Perlang.Tests.Integration
         /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
         /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
         /// This method will propagate all errors apart from  <see cref="ResolveError"/> to the caller. Resolve errors
         /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
+        ///
+        /// If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
@@ -102,15 +129,16 @@ namespace Perlang.Tests.Integration
         internal static EvalResult<ResolveError> EvalWithResolveErrorCatch(string source)
         {
             var result = new EvalResult<ResolveError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
             result.Value = interpreter.Eval(
                 source,
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
-                resolveError => result.Errors.Add(resolveError),
+                result.ErrorHandler,
                 AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
+                AssertFailValidationErrorHandler,
+                result.WarningHandler
             );
 
             return result;
@@ -120,8 +148,13 @@ namespace Perlang.Tests.Integration
         /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
         /// cref="EvalResult{T}.Value"/> set to the evaluated value.
         ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
         /// This method will propagate all errors apart from  <see cref="ValidationError"/> to the caller. Validation
         /// errors will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
+        ///
+        /// If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
@@ -130,15 +163,49 @@ namespace Perlang.Tests.Integration
         internal static EvalResult<ValidationError> EvalWithValidationErrorCatch(string source)
         {
             var result = new EvalResult<ValidationError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler);
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
             result.Value = interpreter.Eval(
                 source,
                 AssertFailScanErrorHandler,
                 AssertFailParseErrorHandler,
                 AssertFailResolveErrorHandler,
-                validationError => result.Errors.Add(validationError),
-                validationError => result.Errors.Add(validationError)
+                result.ErrorHandler,
+                result.ErrorHandler,
+                result.WarningHandler
+            );
+
+            return result;
+        }
+
+        /// <summary>
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
+        ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
+        /// This method will propagate all kinds of errors to the caller, throwing an exception on the first error
+        /// encountered. If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
+        /// </summary>
+        /// <param name="source">A valid Perlang program.</param>
+        /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<Exception> EvalWithResult(string source, params string[] arguments)
+        {
+            var result = new EvalResult<Exception>();
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler, arguments);
+
+            result.Value = interpreter.Eval(
+                source,
+                AssertFailScanErrorHandler,
+                AssertFailParseErrorHandler,
+                AssertFailResolveErrorHandler,
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler,
+                result.WarningHandler
             );
 
             return result;
@@ -147,30 +214,34 @@ namespace Perlang.Tests.Integration
         /// <summary>
         /// Evaluates the provided expression or list of statements. If the expression or statements prints to the
         /// standard output, the content will be returned as a collection of strings (one string per line printed).
+        ///
+        /// This method will propagate all errors to the caller. Note that compiler warnings will also be propagated as
+        /// exceptions to the caller; in other words, this resembles the `-Werror` flag being enabled.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
         /// <returns>The output from the provided expression/statements.</returns>
         internal static IEnumerable<string> EvalReturningOutput(string source, params string[] arguments)
         {
-            var output = new List<string>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, s => output.Add(s), arguments);
+            var result = EvalWithResult(source, arguments);
 
-            interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                AssertFailParseErrorHandler,
-                AssertFailResolveErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
-            );
+            if (result.CompilerWarnings.Count > 0)
+            {
+                // Only the first warning will be thrown. This is still better than ignoring the warnings altogether.
+                // For scenarios where more control over compiler warnings is desired, use `EvalWithResult` or one of
+                // the `EvalWith*ErrorCatch` methods.
+                throw result.CompilerWarnings[0];
+            }
 
-            return output;
+            return result.Output;
         }
 
         /// <summary>
         /// Evaluates the provided expression or list of statements. If the expression or statements prints to the
         /// standard output, the content will be returned as a string with LF as line separator between each line.
+        ///
+        /// This method will propagate all errors to the caller. Note that compiler warnings will also be propagated as
+        /// exceptions to the caller; in other words, this resembles the `-Werror` flag being enabled.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
@@ -182,6 +253,9 @@ namespace Perlang.Tests.Integration
 
         /// <summary>
         /// Evaluates the provided expression or list of statements, with the provided arguments.
+        ///
+        /// This method will propagate all errors to the caller. Note that compiler warnings will also be propagated as
+        /// exceptions to the caller; in other words, this resembles the `-Werror` flag being enabled.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
@@ -189,31 +263,7 @@ namespace Perlang.Tests.Integration
         /// an invalid program.</returns>
         internal static object EvalWithArguments(string source, params string[] arguments)
         {
-            return EvalWithArguments(source, standardOutputHandler: null, arguments);
-        }
-
-        /// <summary>
-        /// Evaluates the provided expression or list of statements, with the provided arguments.
-        /// </summary>
-        /// <param name="source">A valid Perlang program.</param>
-        /// <param name="standardOutputHandler">An optional parameter that will receive output printed to standard
-        /// output. If not provided or null, output will be printed to the standard output of the running
-        /// process.</param>
-        /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
-        /// <returns>The result of evaluating the provided expression, or `null` if provided a list of statements or
-        /// an invalid program.</returns>
-        internal static object EvalWithArguments(string source, Action<string> standardOutputHandler, params string[] arguments)
-        {
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, standardOutputHandler, arguments);
-
-            return interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                AssertFailParseErrorHandler,
-                AssertFailResolveErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler
-            );
+            return EvalWithResult(source, arguments).Value;
         }
 
         private static void AssertFailScanErrorHandler(ScanError scanError)
@@ -239,6 +289,11 @@ namespace Perlang.Tests.Integration
         private static void AssertFailValidationErrorHandler(ValidationError validationError)
         {
             throw validationError;
+        }
+
+        private static bool AssertFailCompilerWarningHandler(CompilerWarning compilerWarning)
+        {
+            throw compilerWarning;
         }
     }
 }

--- a/src/Perlang.Tests.Integration/EvalResult.cs
+++ b/src/Perlang.Tests.Integration/EvalResult.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Perlang.Parser;
 
 namespace Perlang.Tests.Integration
 {
@@ -19,8 +21,44 @@ namespace Perlang.Tests.Integration
         public object? Value { get; set; }
 
         /// <summary>
-        /// Gets a list of the errors thrown during the evaluation of the program.
+        /// Gets a collection of all lines printed to the output stream while executing the program.
         /// </summary>
-        public List<T> Errors { get; } = new List<T>();
+        public IReadOnlyList<string> Output => output.AsReadOnly();
+
+        private readonly List<string> output = new();
+
+        public IEnumerable<char> OutputAsString => String.Join("\n", output);
+
+        /// <summary>
+        /// Gets a collection of the errors thrown during the evaluation of the program.
+        /// </summary>
+        public ReadOnlyCollection<T> Errors => errors.AsReadOnly();
+
+        private readonly List<T> errors = new();
+
+        /// <summary>
+        /// Gets a collection of the compiler warnings emitted during the compilation of the program.
+        /// </summary>
+        public IReadOnlyList<CompilerWarning> CompilerWarnings => compilerWarnings.AsReadOnly();
+
+        private readonly List<CompilerWarning> compilerWarnings = new();
+
+        public void ErrorHandler(T error)
+        {
+            errors.Add(error);
+        }
+
+        public void OutputHandler(string line)
+        {
+            output.Add(line);
+        }
+
+        public bool WarningHandler(CompilerWarning compilerWarning)
+        {
+            compilerWarnings.Add(compilerWarning);
+
+            // Indicate to the caller that this warning is not considered an error.
+            return false;
+        }
     }
 }

--- a/src/Perlang.Tests.Integration/Immutability/Function.cs
+++ b/src/Perlang.Tests.Integration/Immutability/Function.cs
@@ -43,7 +43,7 @@ namespace Perlang.Tests.Integration.Immutability
         {
             string source = @"
                 fun f(): void {}
-                f = 42;
+                f = 123;
             ";
 
             var result = EvalWithValidationErrorCatch(source);

--- a/src/Perlang.Tests.Integration/Immutability/SuperGlobals.cs
+++ b/src/Perlang.Tests.Integration/Immutability/SuperGlobals.cs
@@ -10,7 +10,8 @@ namespace Perlang.Tests.Integration.Immutability
         public void ARGV_cannot_be_overwritten_by_assignment()
         {
             string source = @"
-                ARGV = 42
+                // Nonsensical code, but since #188 we cannot assign from an incoercible type any more. :-)
+                ARGV = ARGV
             ";
 
             var result = EvalWithValidationErrorCatch(source);

--- a/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
@@ -71,11 +71,12 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void short_circuits_at_the_first_true_argument()
         {
             string source = @"
-                var a = ""before"";
-                var b = ""before"";
+                var a = true;
+                var b = false;
+
                 (a = false) or
                     (b = true) or
-                    (a = ""bad"");
+                    (a = true);
                 
                 print a;
                 print b;
@@ -85,8 +86,8 @@ namespace Perlang.Tests.Integration.LogicalOperator
 
             Assert.Equal(new[]
             {
-                "False",
-                "True" // The a = "bad" assignment should never execute
+                "False", // The `a = true` assignment should never execute
+                "True"
             }, output);
         }
     }

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -81,8 +81,8 @@ namespace Perlang.Tests.Integration.Operator
         public void decrementing_nil_throws_expected_exception()
         {
             string source = @"
-                var i = nil;
-                i--;
+                var s: string = nil;
+                s--;
             ";
 
             var result = EvalWithRuntimeErrorCatch(source);
@@ -96,8 +96,8 @@ namespace Perlang.Tests.Integration.Operator
         public void decrementing_string_throws_expected_exception()
         {
             string source = @"
-                var i = ""foo"";
-                i--;
+                var s = ""foo"";
+                s--;
             ";
 
             var result = EvalWithRuntimeErrorCatch(source);

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -81,8 +81,8 @@ namespace Perlang.Tests.Integration.Operator
         public void incrementing_nil_throws_expected_exception()
         {
             string source = @"
-                var i = nil;
-                i++;
+                var s: string= nil;
+                s++;
             ";
 
             var result = EvalWithRuntimeErrorCatch(source);

--- a/src/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
+++ b/src/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using Perlang.Interpreter;
 using Perlang.Stdlib;
@@ -48,11 +47,9 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void ARGV_pop_with_multiple_arguments_returns_the_expected_result()
         {
-            var output = new List<string>();
+            var result = EvalReturningOutput("ARGV.pop(); print ARGV.pop();", "arg1", "arg2").Single();
 
-            EvalWithArguments("ARGV.pop(); print ARGV.pop();", s => output.Add(s), "arg1", "arg2");
-
-            Assert.Equal("arg2", output.Single());
+            Assert.Equal("arg2", result);
         }
 
         [Fact]

--- a/src/Perlang.Tests/Interpreter/TypeValidatorTest.cs
+++ b/src/Perlang.Tests/Interpreter/TypeValidatorTest.cs
@@ -2,12 +2,21 @@ using System.Collections.Generic;
 using System.Linq;
 using Perlang.Interpreter.Resolution;
 using Perlang.Interpreter.Typing;
+using Perlang.Parser;
 using Xunit;
 
 namespace Perlang.Tests.Interpreter
 {
     /// <summary>
     /// Test for <see cref="TypeValidator"/>.
+    ///
+    /// Note that the test methods in this test work on a very low level; as can be seen, tokens and expressions are
+    /// constructed manually in a very tedious way. This can be useful sometimes, but most of the time, it's much easier
+    /// to create integration tests where you just feed an entire Perlang program to the interpreter and let it
+    /// construct the data structures for you.
+    ///
+    /// For an example of the latter, see <see cref="Perlang.Tests.Integration.Assignment.AssignmentTests"/> and the
+    /// other tests in the `Perlang.Tests.Integration` project.
     /// </summary>
     public class TypeValidatorTest
     {
@@ -26,16 +35,19 @@ namespace Perlang.Tests.Interpreter
             };
 
             var typeValidationErrors = new List<TypeValidationError>();
+            var warnings = new List<CompilerWarning>();
 
             // Act
             TypeValidator.Validate(
                 new List<Stmt> { new Stmt.ExpressionStmt(callExpr) },
                 error => typeValidationErrors.Add(error),
-                expr => bindings[expr]
+                expr => bindings[expr],
+                warning => warnings.Add(warning)
             );
 
             // Assert
             Assert.Empty(typeValidationErrors);
+            Assert.Empty(warnings);
         }
 
         [Fact]
@@ -53,17 +65,21 @@ namespace Perlang.Tests.Interpreter
             };
 
             var typeValidationErrors = new List<TypeValidationError>();
+            var warnings = new List<CompilerWarning>();
 
             // Act
             TypeValidator.Validate(
                 new List<Stmt> { new Stmt.ExpressionStmt(getExpr) },
                 error => typeValidationErrors.Add(error),
-                expr => bindings[expr]
+                expr => bindings[expr],
+                warning => warnings.Add(warning)
             );
 
             // Assert
             Assert.Single(typeValidationErrors);
             Assert.Matches(typeValidationErrors.Single().Message, "Undefined identifier 'foo'");
+
+            Assert.Empty(warnings);
         }
 
         [Fact]
@@ -83,16 +99,19 @@ namespace Perlang.Tests.Interpreter
             };
 
             var typeValidationErrors = new List<TypeValidationError>();
+            var warnings = new List<CompilerWarning>();
 
             // Act
             TypeValidator.Validate(
                 new List<Stmt> { new Stmt.ExpressionStmt(getExpr) },
                 error => typeValidationErrors.Add(error),
-                expr => bindings[expr]
+                expr => bindings[expr],
+                warning => warnings.Add(warning)
             );
 
             // Assert
             Assert.Empty(typeValidationErrors);
+            Assert.Empty(warnings);
         }
     }
 }

--- a/src/Perlang.Tests/Perlang.Tests.csproj
+++ b/src/Perlang.Tests/Perlang.Tests.csproj
@@ -26,6 +26,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Perlang.ConsoleApp\Perlang.ConsoleApp.csproj" />
       <ProjectReference Include="..\Perlang.Interpreter\Perlang.Interpreter.csproj" />
+      <ProjectReference Include="..\Perlang.Tests.Integration\Perlang.Tests.Integration.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Extracting of most of the infrastructure code from #188, to make that PR clearer and more focused on the actual semantic changes.