### PR TITLE
(consoleapp) Improve argument parsing

### DIFF
--- a/src/Perlang.ConsoleApp/CommandResultExtensions.cs
+++ b/src/Perlang.ConsoleApp/CommandResultExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace Perlang.ConsoleApp
+{
+    // TODO: Remove this class if/when https://github.com/dotnet/command-line-api/pull/1272 gets merged.
+    public static class CommandResultExtensions
+    {
+        public static bool HasOption(
+            this CommandResult commandResult,
+            IOption option)
+        {
+            if (commandResult is null)
+            {
+                throw new ArgumentNullException(nameof(commandResult));
+            }
+
+            return commandResult.FindResultFor(option) is { };
+        }
+
+        public static bool HasArgument(
+            this CommandResult commandResult,
+            IArgument argument)
+        {
+            if (commandResult is null)
+            {
+                throw new ArgumentNullException(nameof(commandResult));
+            }
+
+            return commandResult.FindResultFor(argument) is { };
+        }
+    }
+}

--- a/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup>
         <PackageReference Include="ReadLine" Version="2.0.1" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -241,7 +241,7 @@ namespace Perlang.Tests.ConsoleApp
             public void with_eval_parameter_outputs_expected_value()
             {
                 // Arrange & Act
-                Program.MainWithCustomConsole(new[] { "-e", "print", "10" }, testConsole);
+                Program.MainWithCustomConsole(new[] { "-e", "print 10" }, testConsole);
 
                 // Assert
                 Assert.Equal("10" + "\n", StdoutResult);


### PR DESCRIPTION
This is a nice by-product of #188. While working on that PR, I ran into some bugs in the way we did our command-line parsing. The full fix is available in #188, but to keep the history nice and tidy we'll extract the relevant parts to separate PR:s like this (this one and #190).