### PR TITLE
(docs) Fix broken affix content

### DIFF
--- a/docs/templates/darkerfx/partials/affix.tmpl.partial
+++ b/docs/templates/darkerfx/partials/affix.tmpl.partial
@@ -33,7 +33,8 @@
     </div>
 
     <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
-    <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+      <h5>{{__global.inThisArticle}}</h5>
+      <div></div>
     </nav>
   </div>
 </div>

--- a/docs/templates/override/styles/override.css
+++ b/docs/templates/override/styles/override.css
@@ -8,6 +8,12 @@ body {
     font-size: 16px;
 }
 
+.affix ul ul > li > a:before {
+    font-size: 16px;
+    top: 0px;
+    left: 3px;
+}
+
 /* Makes the $ prefix for code blocks not be selectable, to make it easier to
   copy-paste the curl oneliner for installation from the "download" page. */
 pre code.lang-shell span.hljs-meta {


### PR DESCRIPTION
While working on #140, I discovered that this was broken. The upstream problem here is more carefully described in
https://github.com/perlun/darkerfx/issues/3.