### PR TITLE
(interpreter) Fix incorrect error message

### DIFF
--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -144,7 +144,7 @@ namespace Perlang.Interpreter.Typing
         {
             try
             {
-                base.VisitCallExpr(expr);
+                Visit(expr.Callee);
             }
             catch (NameResolutionError)
             {
@@ -156,6 +156,11 @@ namespace Perlang.Interpreter.Typing
                 {
                     throw;
                 }
+            }
+
+            foreach (Expr argument in expr.Arguments)
+            {
+                Visit(argument);
             }
 
             if (expr.Callee is Expr.Get get)

--- a/src/Perlang.Tests.Integration/Function/Arguments.cs
+++ b/src/Perlang.Tests.Integration/Function/Arguments.cs
@@ -215,5 +215,24 @@ namespace Perlang.Tests.Integration.Function
             Assert.Single(result.Errors);
             Assert.Matches("Expect '\\)' after parameters.", exception.Message);
         }
+
+        [Fact]
+        public void referring_to_undefined_variable_in_function_call_expects_type_validation_error()
+        {
+            string source = @"
+                fun foo(s: String): void {
+                    print(s);
+                }
+
+                // `bar` is undefined
+                foo(bar);
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Undefined identifier 'bar'", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
The problem was an invalid assumption when a `NameResolutionError` was thrown. By extracting the code from the base class method and inlining it instead, we could add more specific error handling error to do the Right Thing<sup>&trade;</sup> when this error occurs.

Closes #196