### PR TITLE
(consoleapp) #199 Add missing TrimmerRootAssembly

### DIFF
--- a/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -24,6 +24,7 @@
         <!-- Assemblies implicitly referenced via reflection must be listed here, to be included in the trimmed result.
              If you get an error about 'Could not load type 'Foo' from assembly 'Bar', add the assembly for the _Foo_
              type to this list. -->
+        <TrimmerRootAssembly Include="System.ComponentModel.TypeConverter" />
         <TrimmerRootAssembly Include="System.Runtime.Extensions" />
         <TrimmerRootAssembly Include="System.Runtime.InteropServices" />
 


### PR DESCRIPTION
This adds the missing assembly, which has caused published releases to be broken for a few months. Since we don't currenty have any actual _users_ using Perlang, no-one has noticed until now. :wink: 

For reference, I used this diff to be able to nail down this problem. The last assembly listed is the one that is likely to be causing the issue. Adding it to `TrimmerRootAssembly` makes it work, but it _might_ mean that we lose the chance of some trimming by doing so. :grimacing: Nonetheless, for now, "working" is much more valuable than "slightly smaller, but not working".

```diff
diff --git src/Perlang.Interpreter/PerlangInterpreter.cs src/Perlang.Interpreter/PerlangInterpreter.cs
index 0e52edf..e05ee6c 100644
--- src/Perlang.Interpreter/PerlangInterpreter.cs
+++ src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Text;
-using Perlang.Attributes;
 using Perlang.Exceptions;
 using Perlang.Interpreter.Immutability;
 using Perlang.Interpreter.Internals;
@@ -119,28 +118,13 @@ namespace Perlang.Interpreter
         /// <exception cref="PerlangInterpreterException">Multiple classes with the same name was encountered.</exception>
         private void RegisterGlobalClasses()
         {
-            var globalClassesQueryable = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(a => a.GetTypes())
-                .Select(t => new
-                {
-                    Type = t,
-                    ClassAttribute = t.GetCustomAttribute<GlobalClassAttribute>()
-                })
-                .Where(t => t.ClassAttribute != null);
-
-            foreach (var globalClass in globalClassesQueryable)
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                string name = globalClass.ClassAttribute!.Name ?? globalClass.Type.Name;
-
-                if (globals.Get(name) != null)
-                {
-                    throw new PerlangInterpreterException(
-                        $"Attempted to define global class '{name}', but another identifier with the same name already exists"
-                    );
-                }
-
-                globalClasses[name] = globalClass.Type;
+                Console.WriteLine($"Loading types for {assembly.FullName}");
+                assembly.GetTypes();
             }
+
+            throw new NotImplementedException();
         }
 
         /// <summary>
```

Closes #199
