### PR TITLE
(ci) Drop ubuntu-16.04 support for perlang-install CI job

### DIFF
--- a/.github/workflows/perlang-install.yml
+++ b/.github/workflows/perlang-install.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-16.04
           - ubuntu-18.04
           - ubuntu-20.04
           - macos-10.15


### PR DESCRIPTION
I'm [seeing some failures](https://github.com/perlang-org/perlang/pull/201/checks?check_run_id=3270514111) on Ubuntu 16.04, and I also just learned that it will be dropped soon anyway:

> Ubuntu 16.04 has been deprecated and will be removed on September 20, 2021. Its usage is limited to current customers, no new onboardings are accepted.
Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubuntu 18.04`

Let's just kill it. We can still support `perlang-install` on Ubuntu 16.04 is we like, but .NET is likely to drop support for it upstream anyway at some point:

> These versions remain supported until either the version of .NET reaches end-of-support or the version of Ubuntu reaches end-of-life.

Expecting to be able to run current software on a five-year old distribution is perhaps hoping for too much these days... :grimacing: :innocent: 