### PR TITLE
(many) Extract binding-related code to separate class

### DIFF
--- a/src/Perlang.ConsoleApp/Program.cs
+++ b/src/Perlang.ConsoleApp/Program.cs
@@ -293,6 +293,7 @@ namespace Perlang.ConsoleApp
             interpreter = new PerlangInterpreter(
                 runtimeErrorHandler ?? RuntimeError,
                 this.standardOutputHandler,
+                null,
                 arguments ?? new List<string>(),
                 replMode: replMode
             );

--- a/src/Perlang.Interpreter/Internals/BindingHandler.cs
+++ b/src/Perlang.Interpreter/Internals/BindingHandler.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Perlang.Interpreter.Resolution;
+
+namespace Perlang.Interpreter.Internals
+{
+    /// <summary>
+    /// Class responsible for handling global and local bindings.
+    /// </summary>
+    internal class BindingHandler : IBindingHandler
+    {
+        /// <summary>
+        /// Map from referring expression to global binding (variable or function).
+        /// </summary>
+        private readonly IDictionary<Expr, Binding> globalBindings = new Dictionary<Expr, Binding>();
+
+        /// <summary>
+        /// Map from referring expression to local binding (i.e. in a local scope) for variable or function.
+        /// </summary>
+        private readonly IDictionary<Expr, Binding> localBindings = new Dictionary<Expr, Binding>();
+
+        public void AddGlobalExpr(Binding binding)
+        {
+            globalBindings[binding.ReferringExpr] = binding;
+        }
+
+        public void AddLocalExpr(Binding binding)
+        {
+            localBindings[binding.ReferringExpr] = binding;
+        }
+
+        public bool GetLocalBinding(Expr expr, out Binding? binding)
+        {
+            return localBindings.TryGetValue(expr, out binding);
+        }
+
+        public Binding? GetVariableOrFunctionBinding(Expr expr)
+        {
+            if (localBindings.ContainsKey(expr))
+            {
+                return localBindings[expr];
+            }
+
+            if (globalBindings.ContainsKey(expr))
+            {
+                return globalBindings[expr];
+            }
+
+            // The variable does not exist, neither in the list of local nor global bindings.
+            return null;
+        }
+    }
+}

--- a/src/Perlang.Interpreter/Internals/IBindingHandler.cs
+++ b/src/Perlang.Interpreter/Internals/IBindingHandler.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using Perlang.Interpreter.Resolution;
+
+namespace Perlang.Interpreter.Internals
+{
+    public interface IBindingHandler
+    {
+        bool GetLocalBinding(Expr expr, out Binding? binding);
+        Binding? GetVariableOrFunctionBinding(Expr expr);
+
+        /// <summary>
+        /// Adds an expression to the global scope.
+        /// </summary>
+        /// <param name="binding">The binding to add.</param>
+        void AddGlobalExpr(Binding binding);
+
+        /// <summary>
+        /// Adds an expression to a local scope at a given depth away from the call site. One level of nesting = one
+        /// extra level of depth. The depth is tracked in e.g. <see cref="VariableBinding.Distance"/> for variable
+        /// bindings.
+        /// </summary>
+        /// <param name="binding">The binding to add.</param>
+        void AddLocalExpr(Binding binding);
+    }
+}

--- a/src/Perlang.Interpreter/Resolution/Binding.cs
+++ b/src/Perlang.Interpreter/Resolution/Binding.cs
@@ -9,7 +9,7 @@ namespace Perlang.Interpreter.Resolution
     /// Different types of bindings (=subclasses) provide slightly different mechanisms to retrieve information about
     /// the variable, function or class being bound to.
     /// </summary>
-    internal abstract class Binding
+    public abstract class Binding
     {
         /// <summary>
         /// Gets the type reference of the declaring statement (typically a 'var' initializer or a function return type).

--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -60,7 +60,7 @@ namespace Perlang.Tests.Integration
             var result = new EvalResult<RuntimeError>();
 
             var interpreter = new PerlangInterpreter(
-                result.ErrorHandler, result.OutputHandler, arguments
+                result.ErrorHandler, result.OutputHandler, null, arguments
             );
 
             result.Value = interpreter.Eval(
@@ -196,7 +196,7 @@ namespace Perlang.Tests.Integration
         internal static EvalResult<Exception> EvalWithResult(string source, params string[] arguments)
         {
             var result = new EvalResult<Exception>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler, arguments);
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler, null, arguments);
 
             result.Value = interpreter.Eval(
                 source,


### PR DESCRIPTION
The end-goal here is to improve testability, by being able to mock the `IBindingHandler` and/or the `Binding` objects it keeps track of. Unfortunately, `Binding` instances unfortunately allow a certain level of mutability, making them exceptionally annoying to work with.