### PR TITLE
(common) Extract ITypeReference interface

### DIFF
--- a/src/Perlang.Common/ITypeReference.cs
+++ b/src/Perlang.Common/ITypeReference.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System;
+
+namespace Perlang
+{
+    public interface ITypeReference
+    {
+        Token? TypeSpecifier { get; }
+
+        // TODO: Remove setter to make this interface and class be fully immutable, for debuggability.
+        Type? ClrType { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the type reference contains an explicit type specifier or not. If this is
+        /// false, the user is perhaps intending for the type to be inferred from the program context.
+        /// </summary>
+        bool ExplicitTypeSpecified { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the type reference has been successfully resolved to a (loaded) CLR type or
+        /// not.
+        /// </summary>
+        bool IsResolved { get; }
+    }
+}

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -8,7 +8,7 @@ namespace Perlang
     ///
     /// The object is mutable.
     /// </summary>
-    public class TypeReference
+    public class TypeReference : ITypeReference
     {
         public static TypeReference Bool { get; } = new TypeReference(typeof(bool));
 
@@ -46,16 +46,10 @@ namespace Perlang
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether the type reference contains an explicit type specifier or not. If this is
-        /// false, the user is perhaps intending for the type to be inferred from the program context.
-        /// </summary>
+        /// <inheritdoc/>
         public bool ExplicitTypeSpecified => TypeSpecifier != null;
 
-        /// <summary>
-        /// Gets a value indicating whether the type reference has been successfully resolved to a (loaded) CLR type or
-        /// not.
-        /// </summary>
+        /// <inheritdoc/>
         public bool IsResolved => ClrType != null;
 
         /// <summary>

--- a/src/Perlang.Interpreter/Resolution/Binding.cs
+++ b/src/Perlang.Interpreter/Resolution/Binding.cs
@@ -14,7 +14,7 @@ namespace Perlang.Interpreter.Resolution
         /// <summary>
         /// Gets the type reference of the declaring statement (typically a 'var' initializer or a function return type).
         /// </summary>
-        public TypeReference? TypeReference { get; }
+        public ITypeReference? TypeReference { get; }
 
         /// <summary>
         /// Gets an expression referring to the declaring statement's type reference. Note that multiple expressions can
@@ -52,7 +52,7 @@ namespace Perlang.Interpreter.Resolution
         /// </summary>
         public object ObjectTypeTitleized => ObjectType[0].ToString().ToUpper() + ObjectType.Substring(1);
 
-        protected Binding(TypeReference? typeReference, Expr referringExpr)
+        protected Binding(ITypeReference? typeReference, Expr referringExpr)
         {
             // We allow null references on this one to sneak through, since it allows this test to succeed:
             // Perlang.Tests.Integration.Classes.ClassesTests.can_call_static_method

--- a/src/Perlang.Interpreter/Resolution/VariableBinding.cs
+++ b/src/Perlang.Interpreter/Resolution/VariableBinding.cs
@@ -11,7 +11,7 @@ namespace Perlang.Interpreter.Resolution
         public override string ObjectType => "variable";
         public override bool IsMutable => true;
 
-        public VariableBinding(TypeReference? typeReference, int distance, Expr referringExpr)
+        public VariableBinding(ITypeReference? typeReference, int distance, Expr referringExpr)
             : base(typeReference, referringExpr)
         {
             Distance = distance;

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -30,7 +30,7 @@ namespace Perlang.Interpreter.Typing
         /// <param name="targetTypeReference">A reference to the target type.</param>
         /// <param name="sourceTypeReference">A reference to the source type.</param>
         /// <returns>`true` if a source value can be coerced into the target type, `false` otherwise.</returns>
-        public bool CanBeCoercedInto(Token token, TypeReference targetTypeReference, TypeReference sourceTypeReference)
+        public bool CanBeCoercedInto(Token token, ITypeReference targetTypeReference, ITypeReference sourceTypeReference)
         {
             return CanBeCoercedInto(token, targetTypeReference.ClrType, sourceTypeReference.ClrType);
         }

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -178,7 +178,7 @@ namespace Perlang.Interpreter.Typing
                 }
             }
 
-            TypeReference typeReference = getIdentifierCallback(expr)?.TypeReference;
+            ITypeReference typeReference = getIdentifierCallback(expr)?.TypeReference;
 
             if (typeReference == null)
             {
@@ -248,7 +248,7 @@ namespace Perlang.Interpreter.Typing
             }
             else
             {
-                TypeReference typeReference = binding?.TypeReference;
+                ITypeReference typeReference = binding?.TypeReference;
 
                 if (typeReference == null)
                 {
@@ -475,7 +475,7 @@ namespace Perlang.Interpreter.Typing
             }
         }
 
-        private static void ResolveExplicitTypes(TypeReference typeReference)
+        private static void ResolveExplicitTypes(ITypeReference typeReference)
         {
             if (typeReference.TypeSpecifier == null)
             {


### PR DESCRIPTION
Similar to #206, this PR lays the groundwork for more easily being able to swap out some of these method implementations when running tests.