### PR TITLE
(interpreter) Use ITypeReference in more places

### DIFF
--- a/src/Perlang.Common/Expr.cs
+++ b/src/Perlang.Common/Expr.cs
@@ -8,7 +8,7 @@ namespace Perlang
 {
     public abstract class Expr
     {
-        public TypeReference TypeReference { get; }
+        public ITypeReference TypeReference { get; }
 
         private Expr()
         {

--- a/src/Perlang.Common/ITypeReference.cs
+++ b/src/Perlang.Common/ITypeReference.cs
@@ -15,12 +15,17 @@ namespace Perlang
         /// Gets a value indicating whether the type reference contains an explicit type specifier or not. If this is
         /// false, the user is perhaps intending for the type to be inferred from the program context.
         /// </summary>
-        bool ExplicitTypeSpecified { get; }
+        bool ExplicitTypeSpecified => TypeSpecifier != null;
 
         /// <summary>
         /// Gets a value indicating whether the type reference has been successfully resolved to a (loaded) CLR type or
         /// not.
         /// </summary>
-        bool IsResolved { get; }
+        bool IsResolved => ClrType != null;
+
+        /// <summary>
+        /// Gets a value indicating whether this type reference refers to a `null` value.
+        /// </summary>
+        public bool IsNullObject => ClrType == typeof(NullObject);
     }
 }

--- a/src/Perlang.Common/Parameter.cs
+++ b/src/Perlang.Common/Parameter.cs
@@ -3,16 +3,16 @@ namespace Perlang
     public class Parameter
     {
         public Token Name { get; }
-        public TypeReference TypeReference { get; }
+        public ITypeReference TypeReference { get; }
 
         public Token TypeSpecifier => TypeReference.TypeSpecifier;
 
-        public Parameter(TypeReference typeReference)
+        public Parameter(ITypeReference typeReference)
         {
             TypeReference = typeReference;
         }
 
-        public Parameter(Token name, TypeReference typeReference)
+        public Parameter(Token name, ITypeReference typeReference)
         {
             Name = name;
             TypeReference = typeReference;

--- a/src/Perlang.Common/Stmt.cs
+++ b/src/Perlang.Common/Stmt.cs
@@ -73,7 +73,7 @@ namespace Perlang
             public Token Name { get; }
             public ImmutableList<Parameter> Parameters { get; }
             public ImmutableList<Stmt> Body { get; }
-            public TypeReference ReturnTypeReference { get; }
+            public ITypeReference ReturnTypeReference { get; }
 
             public Function(Token name, IEnumerable<Parameter> parameters, IEnumerable<Stmt> body, TypeReference returnTypeReference)
             {
@@ -150,7 +150,7 @@ namespace Perlang
         {
             public Token Name { get; }
             public Expr Initializer { get; }
-            public TypeReference TypeReference { get; }
+            public ITypeReference TypeReference { get; }
 
             public bool HasInitializer => Initializer != null;
 

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -46,17 +46,6 @@ namespace Perlang
             }
         }
 
-        /// <inheritdoc/>
-        public bool ExplicitTypeSpecified => TypeSpecifier != null;
-
-        /// <inheritdoc/>
-        public bool IsResolved => ClrType != null;
-
-        /// <summary>
-        /// Gets a value indicating whether this type reference refers to a `null` value.
-        /// </summary>
-        public bool IsNullObject => ClrType == typeof(NullObject);
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TypeReference"/> class, for a given type specifier. The type
         /// specifier can be null, in which case type inference will be attempted.
@@ -79,13 +68,15 @@ namespace Perlang
 
         public override string ToString()
         {
-            if (ExplicitTypeSpecified)
+            var typeReference = (ITypeReference)this;
+
+            if (typeReference.ExplicitTypeSpecified)
             {
-                return IsResolved ? $"Explicit: {ClrType}" : $"Explicit: {TypeSpecifier}";
+                return typeReference.IsResolved ? $"Explicit: {ClrType}" : $"Explicit: {TypeSpecifier}";
             }
             else
             {
-                return IsResolved ? $"Inferred: {ClrType}" : "Inferred, not yet resolved";
+                return typeReference.IsResolved ? $"Inferred: {ClrType}" : "Inferred, not yet resolved";
             }
         }
     }

--- a/src/Perlang.Interpreter/Resolution/FunctionBinding.cs
+++ b/src/Perlang.Interpreter/Resolution/FunctionBinding.cs
@@ -10,7 +10,7 @@ namespace Perlang.Interpreter.Resolution
 
         public override string ObjectType => "function";
 
-        public FunctionBinding(Stmt.Function function, TypeReference typeReference, int distance, Expr referringExpr)
+        public FunctionBinding(Stmt.Function function, ITypeReference typeReference, int distance, Expr referringExpr)
             : base(typeReference, referringExpr)
         {
             // Likewise, the Function property is permitted to be null for variable bindings (but not for Call

--- a/src/Perlang.Interpreter/Resolution/FunctionBindingFactory.cs
+++ b/src/Perlang.Interpreter/Resolution/FunctionBindingFactory.cs
@@ -2,12 +2,12 @@ namespace Perlang.Interpreter.Resolution
 {
     internal class FunctionBindingFactory : IBindingFactory
     {
-        public TypeReference TypeReference { get; }
+        public ITypeReference TypeReference { get; }
         public Stmt.Function Function { get; }
 
         public string ObjectType => "function";
 
-        public FunctionBindingFactory(TypeReference typeReference, Stmt.Function function)
+        public FunctionBindingFactory(ITypeReference typeReference, Stmt.Function function)
         {
             TypeReference = typeReference;
             Function = function;

--- a/src/Perlang.Interpreter/Resolution/Resolver.cs
+++ b/src/Perlang.Interpreter/Resolution/Resolver.cs
@@ -124,9 +124,9 @@ namespace Perlang.Interpreter.Resolution
         /// Defines a previously declared variable as initialized, available for use.
         /// </summary>
         /// <param name="name">The variable or function name.</param>
-        /// <param name="typeReference">A TypeReference describing the variable or function.</param>
+        /// <param name="typeReference">An `ITypeReference` describing the variable or function.</param>
         /// <exception cref="ArgumentException">`typeReference` is null.</exception>
-        private void Define(Token name, TypeReference typeReference)
+        private void Define(Token name, ITypeReference typeReference)
         {
             if (typeReference == null)
             {
@@ -150,9 +150,9 @@ namespace Perlang.Interpreter.Resolution
         /// Defines a previously declared function as defined, available for use.
         /// </summary>
         /// <param name="name">The variable or function name.</param>
-        /// <param name="typeReference">A TypeReference describing the variable or function.</param>
+        /// <param name="typeReference">An `ITypeReference` describing the variable or function.</param>
         /// <param name="function">The function statement should be provided here.</param>
-        private void DefineFunction(Token name, TypeReference typeReference, Stmt.Function function)
+        private void DefineFunction(Token name, ITypeReference typeReference, Stmt.Function function)
         {
             if (typeReference == null)
             {

--- a/src/Perlang.Interpreter/Resolution/VariableBindingFactory.cs
+++ b/src/Perlang.Interpreter/Resolution/VariableBindingFactory.cs
@@ -16,9 +16,9 @@ namespace Perlang.Interpreter.Resolution
 
         public string ObjectType => "variable";
 
-        public TypeReference TypeReference { get; }
+        public ITypeReference TypeReference { get; }
 
-        public VariableBindingFactory(TypeReference typeReference)
+        public VariableBindingFactory(ITypeReference typeReference)
         {
             TypeReference = typeReference;
         }

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -109,7 +109,7 @@ namespace Perlang.Interpreter.Typing
                         return VoidObject.Void;
                     }
 
-                    TypeReference typeReference = GreaterType(leftTypeReference, rightTypeReference);
+                    ITypeReference typeReference = GreaterType(leftTypeReference, rightTypeReference);
 
                     if (typeReference == null)
                     {
@@ -395,7 +395,7 @@ namespace Perlang.Interpreter.Typing
             return VoidObject.Void;
         }
 
-        private static TypeReference GreaterType(TypeReference leftTypeReference, TypeReference rightTypeReference)
+        private static ITypeReference GreaterType(ITypeReference leftTypeReference, ITypeReference rightTypeReference)
         {
             var leftMaxValue = GetMaxValue(leftTypeReference.ClrType);
             var rightMaxValue = GetMaxValue(rightTypeReference.ClrType);


### PR DESCRIPTION
Not all usages were covered by #207; this PR uses `ITypeReference` in more places. (There might still be some cases left.)