### PR TITLE
(tests) Add ResolverTest + refactor Eval() to support its work

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="all" />
         <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
 
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.14.0.22654" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580" />
     </ItemGroup>
 
     <!--

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -172,52 +172,22 @@ namespace Perlang.Interpreter
                 return null;
             }
 
-            //
-            // Scanning phase
-            //
-
-            bool hasScanErrors = false;
-            var scanner = new Scanner(source, scanError =>
-            {
-                hasScanErrors = true;
-                scanErrorHandler(scanError);
-            });
-
-            var tokens = scanner.ScanTokens();
-
-            if (hasScanErrors)
-            {
-                // Something went wrong as early as the "scan" stage. Abort the rest of the processing.
-                return null;
-            }
-
-            //
-            // Parsing phase
-            //
-
-            bool hasParseErrors = false;
-            var parser = new PerlangParser(
-                tokens,
-                parseError =>
-                {
-                    hasParseErrors = true;
-                    parseErrorHandler(parseError);
-                },
-                allowSemicolonElision: replMode
+            ScanAndParseResult result = ScanAndParse(
+                source,
+                scanErrorHandler,
+                parseErrorHandler
             );
 
-            object syntax = parser.ParseExpressionOrStatements();
-
-            if (hasParseErrors)
+            if (result == ScanAndParseResult.ScanErrorOccurred ||
+                result == ScanAndParseResult.ParseErrorEncountered)
             {
-                // One or more parse errors were encountered. They have been reported upstream, so we just abort
-                // the evaluation at this stage.
+                // These errors have already been propagated to the caller; we can simply return a this point.
                 return null;
             }
 
-            if (syntax is List<Stmt> statements)
+            if (result.HasStatements)
             {
-                var previousAndNewStatements = previousStatements.Concat(statements).ToImmutableList();
+                var previousAndNewStatements = previousStatements.Concat(result.Statements!).ToImmutableList();
 
                 //
                 // Resolving names phase
@@ -304,7 +274,7 @@ namespace Perlang.Interpreter
 
                 try
                 {
-                    Interpret(statements);
+                    Interpret(result.Statements!);
                 }
                 catch (RuntimeError e)
                 {
@@ -314,13 +284,13 @@ namespace Perlang.Interpreter
 
                 return null;
             }
-            else if (syntax is Expr expr)
+            else if (result.HasExpr)
             {
                 // Even though this is an expression, we need to make it a statement here so we can run the various
                 // validation steps on the complete program now (all the statements executed up to now + the expression
                 // we just received).
                 var previousAndNewStatements = previousStatements
-                    .Concat(ImmutableList.Create(new Stmt.ExpressionStmt(expr)))
+                    .Concat(ImmutableList.Create(new Stmt.ExpressionStmt(result.Expr)))
                     .ToImmutableList();
 
                 //
@@ -400,7 +370,7 @@ namespace Perlang.Interpreter
 
                 try
                 {
-                    return Evaluate(expr);
+                    return Evaluate(result.Expr!);
                 }
                 catch (RuntimeError e)
                 {
@@ -411,6 +381,81 @@ namespace Perlang.Interpreter
             else
             {
                 throw new IllegalStateException("syntax was neither Expr nor list of Stmt");
+            }
+        }
+
+        /// <summary>
+        /// Scans and parses the given program, to prepare for evaluation.
+        ///
+        /// This method is useful for inspecting the AST or perform other validation of the internal state after
+        /// parsing a given program.
+        /// </summary>
+        /// <param name="source">The source code to a Perlang program (typically a single line of Perlang code).</param>
+        /// <param name="scanErrorHandler">A handler for scanner errors.</param>
+        /// <param name="parseErrorHandler">A handler for parse errors.</param>
+        /// <returns>A <see cref="ScanAndParseResult"/> instance.</returns>
+        internal ScanAndParseResult ScanAndParse(
+            string source,
+            ScanErrorHandler scanErrorHandler,
+            ParseErrorHandler parseErrorHandler)
+        {
+            //
+            // Scanning phase
+            //
+
+            bool hasScanErrors = false;
+            var scanner = new Scanner(source, scanError =>
+            {
+                hasScanErrors = true;
+                scanErrorHandler(scanError);
+            });
+
+            var tokens = scanner.ScanTokens();
+
+            if (hasScanErrors)
+            {
+                // Something went wrong as early as the "scan" stage. Abort the rest of the processing.
+                return ScanAndParseResult.ScanErrorOccurred;
+            }
+
+            //
+            // Parsing phase
+            //
+
+            bool hasParseErrors = false;
+            var parser = new PerlangParser(
+                tokens,
+                parseError =>
+                {
+                    hasParseErrors = true;
+                    parseErrorHandler(parseError);
+                },
+                allowSemicolonElision: replMode
+            );
+
+            object syntax = parser.ParseExpressionOrStatements();
+
+            if (hasParseErrors)
+            {
+                // One or more parse errors were encountered. They have been reported upstream, so we just abort
+                // the evaluation at this stage.
+                return ScanAndParseResult.ParseErrorEncountered;
+            }
+
+            // TODO: Should we return here (and change PrepareForEvalResult to something like ScanAndParseResult) or
+            // should we continue with moving more of the code in eval into this method? Given that we want to inspect
+            // the result from Resolver, maybe doing more work here would be completely fine...
+            if (syntax is Expr expr)
+            {
+                return ScanAndParseResult.OfExpr(expr);
+            }
+            else if (syntax is List<Stmt> stmts)
+            {
+                return ScanAndParseResult.OfStmts(stmts);
+            }
+            else
+            {
+                throw new IllegalStateException($"syntax expected to be Expr or List<Stmt>, not {syntax}");
             }
         }
 
@@ -1095,6 +1140,45 @@ namespace Perlang.Interpreter
 
                 default:
                     throw new RuntimeError(expr.Paren, $"Can only call functions, classes and native methods, not {callee}.");
+            }
+        }
+
+        /// <summary>
+        /// Contains the result of the <see cref="PerlangInterpreter.ScanAndParse"/> method.
+        /// </summary>
+        internal class ScanAndParseResult
+        {
+            public static ScanAndParseResult ScanErrorOccurred { get; } = new();
+            public static ScanAndParseResult ParseErrorEncountered { get; } = new();
+
+            public Expr? Expr { get; }
+            public IList<Stmt>? Statements { get; }
+
+            public bool HasExpr => Expr != null;
+            public bool HasStatements => Statements != null;
+
+            private ScanAndParseResult()
+            {
+            }
+
+            private ScanAndParseResult(Expr expr)
+            {
+                Expr = expr;
+            }
+
+            private ScanAndParseResult(IList<Stmt> statements)
+            {
+                Statements = statements;
+            }
+
+            public static ScanAndParseResult OfExpr(Expr expr)
+            {
+                return new ScanAndParseResult(expr);
+            }
+
+            public static ScanAndParseResult OfStmts(List<Stmt> stmts)
+            {
+                return new ScanAndParseResult(stmts);
             }
         }
     }

--- a/src/Perlang.Interpreter/Resolution/Resolver.cs
+++ b/src/Perlang.Interpreter/Resolution/Resolver.cs
@@ -30,6 +30,8 @@ namespace Perlang.Interpreter.Resolution
         /// </summary>
         private readonly IDictionary<string, IBindingFactory> globals = new Dictionary<string, IBindingFactory>();
 
+        internal IDictionary<string, IBindingFactory> Globals => globals;
+
         private FunctionType currentFunction = FunctionType.NONE;
 
         /// <summary>

--- a/src/Perlang.Tests/Interpreter/Resolution/ResolverTest.cs
+++ b/src/Perlang.Tests/Interpreter/Resolution/ResolverTest.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Perlang.Interpreter;
+using Perlang.Interpreter.Resolution;
+using Perlang.Parser;
+using Xunit;
+
+namespace Perlang.Tests.Interpreter.Resolution
+{
+    public class ResolverTest
+    {
+        [Fact(Skip = "Known to be broken, will be fixed shortly on another branch")]
+        public void VisitVarStmt_defines_variable_with_correct_TypeReference()
+        {
+            // Act
+            (Stmt singleStatement, Resolver resolver) = ScanParseAndResolveSingleStatement(@"
+                var i: int = 123456;
+            ");
+
+            // Assert. We want to ensure that the proper TypeReference is being used in the VariableBindingFactory
+            // which has been created at this point, since using the TypeReference from the initializer instead of the
+            // variable will work incorrectly with e.g. integer expansion (`var l: long = 123` - it's critical that
+            // TypeReference becomes `long` here and not `int` or `short`)
+            Assert.IsType<Stmt.Var>(singleStatement);
+            Assert.True(resolver.Globals.ContainsKey("i"));
+            Assert.Equal(((Stmt.Var)singleStatement).TypeReference, ((VariableBindingFactory)resolver.Globals["i"]).TypeReference);
+        }
+
+        private static (Stmt Stmt, Resolver Resolver) ScanParseAndResolveSingleStatement(string program)
+        {
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, s => throw new ApplicationException(s));
+
+            var scanAndParseResult = interpreter.ScanAndParse(
+                program,
+                AssertFailScanErrorHandler,
+                AssertFailParseErrorHandler
+            );
+
+            Assert.True(scanAndParseResult.HasStatements);
+            Assert.Equal(1, scanAndParseResult.Statements!.Count);
+
+            Stmt singleStatement = scanAndParseResult.Statements.Single();
+
+            var resolver = new Resolver(
+                ImmutableDictionary<string, Type>.Empty,
+                ImmutableDictionary<string, Type>.Empty,
+                null,
+                null,
+                AssertFailResolveErrorHandler
+            );
+
+            resolver.Resolve(scanAndParseResult.Statements);
+
+            return (singleStatement, resolver);
+        }
+
+        private static void AssertFailScanErrorHandler(ScanError scanError)
+        {
+            throw scanError;
+        }
+
+        private static void AssertFailParseErrorHandler(ParseError parseError)
+        {
+            throw parseError;
+        }
+
+        private static void AssertFailResolveErrorHandler(ResolveError resolveError)
+        {
+            throw resolveError;
+        }
+
+        private static void AssertFailRuntimeErrorHandler(RuntimeError runtimeError)
+        {
+            throw runtimeError;
+        }
+    }
+}

--- a/src/Perlang.Tests/Interpreter/Typing/TypeValidatorTest.cs
+++ b/src/Perlang.Tests/Interpreter/Typing/TypeValidatorTest.cs
@@ -5,7 +5,7 @@ using Perlang.Interpreter.Typing;
 using Perlang.Parser;
 using Xunit;
 
-namespace Perlang.Tests.Interpreter
+namespace Perlang.Tests.Interpreter.Typing
 {
     /// <summary>
     /// Test for <see cref="TypeValidator"/>.


### PR DESCRIPTION
Previously, tests which wanted to inspect the AST or other internal work of the interpreter needed to manually create a bunch of data structures and then call the appropriate method (like `TypeValidator.Validate()`; see `TypeValidatorTest` for an example of how awkward this is).

While the approach described above _does_ have an advantage in that it requires a less functional interpreter/compiler to be able to run the tests, it does come with a significant disadvantage as well: it's tedious, it's manual work, and it's boring. It's very unlikely that any significant amount of tests would be added when the process is so painful.

The approach introduced in this PR makes things significantly better. We now have appropriate tooling in place (the `ScanParseAndResolveSingleStatement` method) to help in writing tests like this.

----

While full E2E/integration tests (which execute a full Perlang interpreter and inspect the result or makes assertions on certain kind
of errors) are useful for many aspects of the life of an interpreter/compiler, there are particular areas where it also makes
sense to be able to "straightjacket" your code a bit more. These tests are in other words not intented to replace full integration tests but to complement them.