### PR TITLE
(parser) Support integer literals larger than 64-bit

### DIFF
--- a/src/Perlang.Interpreter/Extensions/TypeExtensions.cs
+++ b/src/Perlang.Interpreter/Extensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 
 namespace Perlang.Interpreter.Extensions
 {
@@ -14,6 +15,7 @@ namespace Perlang.Interpreter.Extensions
                 { } when type == typeof(Double) => "double",
                 { } when type == typeof(Int32) => "int",
                 { } when type == typeof(Int64) => "long",
+                { } when type == typeof(BigInteger) => "BigInteger", // TODO: Should we make this bigint and support it as a special type as the others?
                 { } when type == typeof(NullObject) => "null",
                 { } when type == typeof(String) => "string",
                 null => "null",

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using static Perlang.TokenType;
 
 namespace Perlang.Parser
@@ -324,7 +325,7 @@ namespace Perlang.Parser
                 // the number as an unsigned value. However, we still try to coerce it to the smallest signed or
                 // unsigned integer type in which it will fit (but never smaller than 32-bit). This coincidentally
                 // follows the same semantics as how C# does it, for simplicity.
-                ulong value = UInt64.Parse(source[start..current]);
+                BigInteger value = BigInteger.Parse(source[start..current]);
 
                 if (value < Int32.MaxValue)
                 {
@@ -338,7 +339,11 @@ namespace Perlang.Parser
                 {
                     AddToken(NUMBER, (long)value);
                 }
-                else // ulong
+                else if (value < UInt64.MaxValue)
+                {
+                    AddToken(NUMBER, (ulong)value);
+                }
+                else // Anything else gets implicitly treated as BigInteger
                 {
                     AddToken(NUMBER, value);
                 }

--- a/src/Perlang.Tests.Integration/Typing/LongTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/LongTests.cs
@@ -33,10 +33,9 @@ namespace Perlang.Tests.Integration.Typing
                 print(l);
             ";
 
-            var result = EvalWithValidationErrorCatch(source);
+            var result = EvalReturningOutputString(source);
 
-            Assert.Empty(result.Errors);
-            Assert.Equal("8589934592", result.OutputAsString);
+            Assert.Equal("8589934592", result);
         }
 
         [Fact]
@@ -51,6 +50,22 @@ namespace Perlang.Tests.Integration.Typing
             var output = EvalReturningOutputString(source);
 
             Assert.Equal("8589934592", output);
+        }
+
+        [Fact]
+        public void long_variable_throws_expected_exception_on_overflow()
+        {
+            string source = @"
+                var l: long = 1231231230912839019312831232;
+
+                print(l);
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Cannot assign BigInteger to long variable", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
The simple fix for now is to just parse them as `BitInteger`. An interesting question is if we should support suffixes like L, U, UL etc,
as in C#. I think the simple answer is "we don't know", and we'll wait with implementing things like that until there's a good-enough
motivation for it.

Closes #205