### PR TITLE
(parser) Support octal literals

### DIFF
--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -307,12 +307,16 @@ namespace Perlang.Parser
 
             char currentChar = Char.ToLower(Peek());
 
-            if (currentChar is 'b' or 'x')
+            if (currentChar is 'b' or 'o' or 'x')
             {
                 switch (currentChar)
                 {
                     case 'b':
                         numberBase = Base.BINARY;
+                        break;
+
+                    case 'o':
+                        numberBase = Base.OCTAL;
                         break;
 
                     case 'x':
@@ -366,6 +370,9 @@ namespace Perlang.Parser
 
                     Base.BINARY =>
                         Convert.ToUInt64(numberCharacters, 2),
+
+                    Base.OCTAL =>
+                        Convert.ToUInt64(numberCharacters, 8),
 
                     Base.HEXADECIMAL =>
                         // Quoting from
@@ -523,6 +530,7 @@ namespace Perlang.Parser
         private enum Base
         {
             BINARY = 2,
+            OCTAL = 8,
             DECIMAL = 10,
             HEXADECIMAL = 16,
         }

--- a/src/Perlang.Tests.Integration/Number/NumberTests.cs
+++ b/src/Perlang.Tests.Integration/Number/NumberTests.cs
@@ -120,6 +120,18 @@ namespace Perlang.Tests.Integration.Number
         }
 
         [Fact]
+        public void literal_octal()
+        {
+            string source = @"
+                0o755
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(493, result);
+        }
+
+        [Fact]
         public void literal_hexadecimal()
         {
             string source = @"

--- a/src/Perlang.Tests/Interpreter/Typing/TypeResolverTest.cs
+++ b/src/Perlang.Tests/Interpreter/Typing/TypeResolverTest.cs
@@ -42,6 +42,19 @@ namespace Perlang.Tests.Interpreter.Typing
         }
 
         [Fact]
+        public void Resolve_implicitly_typed_var_initialized_from_octal_literal_has_expected_ClrType()
+        {
+            (Stmt singleStatement, NameResolver resolver) = ScanParseResolveAndTypeResolveSingleStatement(@"
+                var v = 0o755;
+            ");
+
+            // Assert
+            Assert.IsType<Stmt.Var>(singleStatement);
+            Assert.True(resolver.Globals.ContainsKey("v"));
+            Assert.Equal(typeof(Int32), ((Stmt.Var)singleStatement).TypeReference.ClrType);
+        }
+
+        [Fact]
         public void Resolve_implicitly_typed_var_initialized_from_hexadecimal_literal_has_expected_ClrType()
         {
             (Stmt singleStatement, NameResolver resolver) = ScanParseResolveAndTypeResolveSingleStatement(@"


### PR DESCRIPTION
Closes #69. (This is the last step, building on top of #217 and #219)