### PR TITLE
(parser) Support underscores in integer literals

### DIFF
--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using static Perlang.TokenType;
 
 namespace Perlang.Parser
@@ -332,7 +333,7 @@ namespace Perlang.Parser
                 startOffset = 2;
             }
 
-            while (IsDigit(Peek(), numberBase))
+            while (IsDigit(Peek(), numberBase) || Peek() == '_')
             {
                 Advance();
             }
@@ -357,6 +358,14 @@ namespace Perlang.Parser
             else
             {
                 string numberCharacters = source[(start + startOffset)..current];
+                var sb = new StringBuilder();
+
+                foreach (char c in numberCharacters.Where(c => c != '_'))
+                {
+                    sb.Append(c);
+                }
+
+                numberCharacters = sb.ToString();
 
                 // Any potential preceding '-' character has already been taken care of at this stage => we can treat
                 // the number as an unsigned value. However, we still try to coerce it to the smallest signed or
@@ -366,7 +375,7 @@ namespace Perlang.Parser
                 BigInteger value = numberBase switch
                 {
                     Base.DECIMAL =>
-                        BigInteger.Parse(source[(start + startOffset)..current], numberStyles),
+                        BigInteger.Parse(numberCharacters, numberStyles),
 
                     Base.BINARY =>
                         Convert.ToUInt64(numberCharacters, 2),

--- a/src/Perlang.Tests.Integration/Number/NumberTests.cs
+++ b/src/Perlang.Tests.Integration/Number/NumberTests.cs
@@ -48,6 +48,18 @@ namespace Perlang.Tests.Integration.Number
         }
 
         [Fact]
+        public void literal_integer_with_underscores()
+        {
+            string source = @"
+                123_456
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(123456, result);
+        }
+
+        [Fact]
         public void literal_zero()
         {
             string source = @"
@@ -120,6 +132,18 @@ namespace Perlang.Tests.Integration.Number
         }
 
         [Fact]
+        public void literal_binary_with_underscores()
+        {
+            string source = @"
+                0b0010_1010
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
         public void literal_octal()
         {
             string source = @"
@@ -136,6 +160,18 @@ namespace Perlang.Tests.Integration.Number
         {
             string source = @"
                 0xC0CAC01A
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(3234512922, result);
+        }
+
+        [Fact]
+        public void literal_hexadecimal_with_underscores()
+        {
+            string source = @"
+                0xC0_CA_C0_1A
             ";
 
             object result = Eval(source);


### PR DESCRIPTION
This is really "syntactic sugar" at its finest. No sensible person could claim that this is a _required_ language feature, but it sure is nice to have stuff like this when you need it (perhaps especially when working with many integer literals).

(Btw, the PR probably supports underscore in floating-point literals as well, I haven't tried. :grin:)