### PR TITLE
(interpreter) Move away from relying on 'dynamic' for unary prefix/postfix operators

### DIFF
--- a/src/Perlang.Common/Extensions/TypeExtensions.cs
+++ b/src/Perlang.Common/Extensions/TypeExtensions.cs
@@ -18,8 +18,6 @@ namespace Perlang.Extensions
                 { } when type == typeof(BigInteger) => "BigInteger", // TODO: Should we make this bigint and support it as a special type as the others?
                 { } when type == typeof(NullObject) => "null",
                 { } when type == typeof(String) => "string",
-
-                // TODO: How to handle this if/when moving this to Perlang.Common? It doesn't have any notion of PerlangFunction or other
                 { } when type.IsAssignableTo(typeof(IPerlangFunction)) => "function",
                 null => "null",
                 _ => type.ToString()

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -62,7 +62,7 @@ namespace Perlang.Parser
                 { "decimal", RESERVED_WORD },
                 { "char", RESERVED_WORD },
 
-                // // Visibility, static/instance, etc
+                // Visibility, static/instance, etc
                 { "public", RESERVED_WORD },
                 { "private", RESERVED_WORD },
                 { "protected", RESERVED_WORD },
@@ -356,6 +356,9 @@ namespace Perlang.Parser
 
             if (isFractional)
             {
+                // TODO: This is a mess. We currently treat all floating point values as _double_, which is insane. We
+                // TODO: should probably have a "use smallest possible type" logic as below for integers, for flotaing point
+                // TODO: values as well. We could also consider supporting `decimal` while we're at it.
                 AddToken(NUMBER, Double.Parse(numberCharacters));
             }
             else

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -219,7 +219,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Operands must be numbers, not PerlangFunction and Int32", exception.Message);
+            Assert.Matches("Operands must be numbers, not function and int", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -11,10 +11,10 @@ namespace Perlang.Tests.Integration.Operator
         //
 
         [Fact]
-        public void incrementing_defined_variable()
+        public void incrementing_int_variable()
         {
             string source = @"
-                var i = 0;
+                var i: int = 0;
                 i++;
                 print i;
             ";
@@ -22,6 +22,34 @@ namespace Perlang.Tests.Integration.Operator
             var output = EvalReturningOutputString(source);
 
             Assert.Equal("1", output);
+        }
+
+        [Fact]
+        public void incrementing_long_variable()
+        {
+            string source = @"
+                var l: long = 4294967296;
+                l++;
+                print l;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("4294967297", output);
+        }
+
+        [Fact]
+        public void incrementing_double_variable()
+        {
+            string source = @"
+                var d = 4294967296.123;
+                d++;
+                print d;
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("4294967297.123", output);
         }
 
         [Fact]


### PR DESCRIPTION
This is a first step towards resolving #225. The MR fixes the `-` unary prefix and the `--`/`++` postfix operators to manually handle all types instead.