### PR TITLE
(common) Move TypeExtensions to Perlang.Common, use it more generally

### DIFF
--- a/src/Perlang.Common/Extensions/TypeExtensions.cs
+++ b/src/Perlang.Common/Extensions/TypeExtensions.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Numerics;
 
-namespace Perlang.Interpreter.Extensions
+namespace Perlang.Extensions
 {
     /// <summary>
     /// Extension methods for <see cref="Type"/>.
     /// </summary>
-    internal static class TypeExtensions
+    public static class TypeExtensions
     {
         public static string ToTypeKeyword(this Type type)
         {
@@ -18,6 +18,9 @@ namespace Perlang.Interpreter.Extensions
                 { } when type == typeof(BigInteger) => "BigInteger", // TODO: Should we make this bigint and support it as a special type as the others?
                 { } when type == typeof(NullObject) => "null",
                 { } when type == typeof(String) => "string",
+
+                // TODO: How to handle this if/when moving this to Perlang.Common? It doesn't have any notion of PerlangFunction or other
+                { } when type.IsAssignableTo(typeof(IPerlangFunction)) => "function",
                 null => "null",
                 _ => type.ToString()
             };

--- a/src/Perlang.Common/IPerlangFunction.cs
+++ b/src/Perlang.Common/IPerlangFunction.cs
@@ -1,0 +1,9 @@
+namespace Perlang
+{
+    /// <summary>
+    /// Interface for Perlang function implementations.
+    /// </summary>
+    public interface IPerlangFunction
+    {
+    }
+}

--- a/src/Perlang.Common/Utils.cs
+++ b/src/Perlang.Common/Utils.cs
@@ -1,3 +1,5 @@
+using Perlang.Extensions;
+
 namespace Perlang
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Perlang
                 return "null";
             }
 
-            return @object.GetType().Name;
+            return @object.GetType().ToTypeKeyword();
         }
     }
 }

--- a/src/Perlang.Interpreter/PerlangFunction.cs
+++ b/src/Perlang.Interpreter/PerlangFunction.cs
@@ -5,7 +5,7 @@ namespace Perlang.Interpreter
     /// <summary>
     /// Callable implementation for user-defined functions.
     /// </summary>
-    internal class PerlangFunction : ICallable
+    internal class PerlangFunction : ICallable, IPerlangFunction
     {
         private readonly Stmt.Function declaration;
         private readonly IEnvironment closure;

--- a/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Perlang.Interpreter.Extensions;
+using Perlang.Extensions;
 using Perlang.Interpreter.NameResolution;
 
 namespace Perlang.Interpreter.Typing

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using Humanizer;
+using Perlang.Extensions;
 using Perlang.Interpreter.Extensions;
 using Perlang.Interpreter.NameResolution;
 

--- a/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using Perlang.Interpreter.Extensions;
+using Perlang.Extensions;
 using Perlang.Interpreter.NameResolution;
 using Perlang.Parser;
 

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -104,7 +104,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("can only be used to decrement numbers, not String", exception.Message);
+            Assert.Matches("can only be used to decrement numbers, not string", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -104,7 +104,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("can only be used to increment numbers, not String", exception.Message);
+            Assert.Matches("can only be used to increment numbers, not string", exception.Message);
         }
     }
 }


### PR DESCRIPTION
The new extension method `ToTypeKeyword()` is useful; we want to use it in more places. This PR does just that.