### PR TITLE
(tests) Add data-driven tests for comparison operators

### DIFF
--- a/docs/js/highlightjs-perlang.js
+++ b/docs/js/highlightjs-perlang.js
@@ -7,7 +7,7 @@ hljs.registerLanguage('perlang', function(hljs) {
             'and else for fun if nil or print return super this var while ' +
 
             // Reserved keywords
-            'class byte sbyte short long ushort uint ulong float double decimal ' +
+            'class byte sbyte short ushort uint ulong float double decimal ' +
             'char public private protected internal static volatile printf switch ' +
             'break continue try catch finally async await lock synchronized new ' +
             'mut let const struct enum sizeof nameof typeof asm',

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -23,6 +23,8 @@ namespace Perlang.Parser
     /// </remarks>
     public class Scanner
     {
+        // NOTE: When making changes here, remember to adjust highlightjs-perlang.js also to ensure syntax highlighting
+        // on the website matches the real set of keywords in the language.
         public static readonly IDictionary<string, TokenType> ReservedKeywords =
             new Dictionary<string, TokenType>
             {

--- a/src/Perlang.Tests.Integration/Operator/Comparison.cs
+++ b/src/Perlang.Tests.Integration/Operator/Comparison.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
@@ -7,15 +8,26 @@ namespace Perlang.Tests.Integration.Operator
     // Tests based on https://github.com/munificent/craftinginterpreters/blob/master/test/operator/comparison.lox
     public class Comparison
     {
+        public static readonly List<object[]> ComparisonTypes = new()
+        {
+            new object[] { "int", "int" },
+            new object[] { "int", "long" },
+            new object[] { "long", "int" },
+            new object[] { "long", "long" }
+        };
+
         //
         // Tests for the < (less than) operator
         //
 
-        [Fact]
-        public void less_than_greater_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_greater_is_true(string left, string right)
         {
-            string source = @"
-                var b = 1 < 2;
+            string source = $@"
+                var left: {left} = 1;
+                var right: {right} = 2;
+                var b = left < right;
                 print b;
             ";
 
@@ -24,11 +36,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("True", output);
         }
 
-        [Fact]
-        public void less_than_same_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_same_is_false(string left, string right)
         {
-            string source = @"
-                var b = 2 < 2;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 2;
+                var b = left < right;
                 print b;
             ";
 
@@ -37,11 +52,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("False", output);
         }
 
-        [Fact]
-        public void less_than_smaller_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_smaller_is_false(string left, string right)
         {
-            string source = @"
-                var b = 2 < 1;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 1;
+                var b = left < right;
                 print b;
             ";
 
@@ -54,11 +72,14 @@ namespace Perlang.Tests.Integration.Operator
         // Tests for the <= (less than or equals) operator
         //
 
-        [Fact]
-        public void less_than_or_equals_greater_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_or_equals_greater_is_true(string left, string right)
         {
-            string source = @"
-                var b = 1 <= 2;
+            string source = $@"
+                var left: {left} = 1;
+                var right: {right} = 2;
+                var b = left <= right;
                 print b;
             ";
 
@@ -67,11 +88,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("True", output);
         }
 
-        [Fact]
-        public void less_than_or_equals_same_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_or_equals_same_is_true(string left, string right)
         {
-            string source = @"
-                var b = 2 <= 2;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 2;
+                var b = left <= right;
                 print b;
             ";
 
@@ -80,11 +104,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("True", output);
         }
 
-        [Fact]
-        public void less_than_or_equals_smaller_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void less_than_or_equals_smaller_is_false(string left, string right)
         {
-            string source = @"
-                var b = 2 <= 1;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 1;
+                var b = left <= right;
                 print b;
             ";
 
@@ -97,11 +124,14 @@ namespace Perlang.Tests.Integration.Operator
         // Tests for the > (greater than) operator
         //
 
-        [Fact]
-        public void greater_than_smaller_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_smaller_is_false(string left, string right)
         {
-            string source = @"
-                var b = 1 > 2;
+            string source = $@"
+                var left: {left} = 1;
+                var right: {right} = 2;
+                var b = left > right;
                 print b;
             ";
 
@@ -110,11 +140,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("False", output);
         }
 
-        [Fact]
-        public void greater_than_same_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_same_is_false(string left, string right)
         {
-            string source = @"
-                var b = 2 > 2;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 2;
+                var b = left > right;
                 print b;
             ";
 
@@ -123,11 +156,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("False", output);
         }
 
-        [Fact]
-        public void greater_than_smaller_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_smaller_is_true(string left, string right)
         {
-            string source = @"
-                var b = 2 > 1;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 1;
+                var b = left > right;
                 print b;
             ";
 
@@ -139,11 +175,14 @@ namespace Perlang.Tests.Integration.Operator
         //
         // Tests for the >= (greater than or equals) operator
         //
-        [Fact]
-        public void greater_than_or_equals_smaller_is_false()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_or_equals_larger_is_false(string left, string right)
         {
-            string source = @"
-                var b = 1 >= 2;
+            string source = $@"
+                var left: {left} = 1;
+                var right: {right} = 2;
+                var b = left >= right;
                 print b;
             ";
 
@@ -152,11 +191,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("False", output);
         }
 
-        [Fact]
-        public void greater_than_or_equals_same_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_or_equals_same_is_true(string left, string right)
         {
-            string source = @"
-                var b = 2 >= 2;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 2;
+                var b = left >= right;
                 print b;
             ";
 
@@ -165,11 +207,14 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("True", output);
         }
 
-        [Fact]
-        public void greater_than_or_equals_smaller_is_true()
+        [Theory]
+        [MemberData(nameof(ComparisonTypes))]
+        public void greater_than_or_equals_smaller_is_true(string left, string right)
         {
-            string source = @"
-                var b = 2 >= 1;
+            string source = $@"
+                var left: {left} = 2;
+                var right: {right} = 1;
+                var b = left >= right;
                 print b;
             ";
 

--- a/src/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
+++ b/src/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
@@ -7,11 +7,11 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Tests.Integration.xml</DocumentationFile>
         <WarningsAsErrors>;NU1605;NS1004</WarningsAsErrors>
-      <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <NoWarn>SA1116;SA1117;SA1300;S3881;1591;1701;1702</NoWarn>
+      <NoWarn>SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.Integration.xml</DocumentationFile>
     </PropertyGroup>
 


### PR DESCRIPTION
While working on #227, I noted that there are many different permutations of operations (`>`, `<`, `<=`, `>=` and so forth) and types where we only had test coverage of the `int` + `int` scenarios. It's much better to try and (as far as is reasonably possible) cover all supported combinations of types, especially if/when we start handling these manually instead of letting `dynamic` work it out for us.

For the record, similar work could be done elsewhere as well:

- `Addition`
- `AdditionAssignment`
- `Division`
- `Exponential`
- `Modulo`
- `Multiplication`
- `PostfixDecrement`
- `PostfixIncrement`
- `SubtractionAssignment`

I think I'll add an issue for that once this is merged.