### PR TITLE
(interpreter) Include InnerException in RuntimeErrors

### DIFF
--- a/src/Perlang.Common/RuntimeError.cs
+++ b/src/Perlang.Common/RuntimeError.cs
@@ -8,10 +8,16 @@ namespace Perlang
     // some point anyway, at which point we should be able to completely get rid of this class altogether.
     public class RuntimeError : Exception
     {
-        public Token? Token { get; set; }
+        public Token? Token { get; }
 
         public RuntimeError(Token? token, string message)
             : base(message)
+        {
+            Token = token;
+        }
+
+        public RuntimeError(Token? token, string message, Exception innerException)
+            : base(message, innerException)
         {
             Token = token;
         }

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -889,13 +889,13 @@ namespace Perlang.Interpreter
                 // I guess it's best to take the unexpected into account and presume it can be null... :-)
                 string message = ex.InnerException?.Message ?? ex.Message;
 
-                throw new RuntimeError(token, message);
+                throw new RuntimeError(token, message, ex);
             }
             catch (SystemException ex)
             {
                 Token? token = (expr as ITokenAware)?.Token;
 
-                throw new RuntimeError(token, ex.Message);
+                throw new RuntimeError(token, ex.Message, ex);
             }
         }
 


### PR DESCRIPTION
This is an oversight on my part, which has made debugging these kind of errors way more complicated than it ought to be. You had to place a breakpoint, go digging in the exception, place another breakpoint etc...

Now, we should get all the details bubbling up all the way to the top-level `RuntimeError` handler => much better. :+1: 