### PR TITLE
(interpreter) Fix integer expansions to bigint

### DIFF
--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using Perlang.Attributes;
 using Perlang.Exceptions;
+using Perlang.Extensions;
 using Perlang.Interpreter.Immutability;
 using Perlang.Interpreter.Internals;
 using Perlang.Interpreter.NameResolution;
@@ -1226,9 +1227,22 @@ namespace Perlang.Interpreter
                 {
                     return Convert.ToDouble(value);
                 }
+                else if (targetTypeReference.ClrType == typeof(BigInteger))
+                {
+                    return value switch
+                    {
+                        int intValue => new BigInteger(intValue),
+                        long longValue => new BigInteger(longValue),
+                        float floatValue => new BigInteger(floatValue),
+                        double doubleValue => new BigInteger(doubleValue),
+
+                        // TODO: Might need to revisit this to support more types as we implement #70.
+                        _ => throw new IllegalStateException($"Unsupported conversion from {value.GetType().ToTypeKeyword()} to {targetTypeReference.ClrType.ToTypeKeyword()}")
+                    };
+                }
                 else
                 {
-                    throw new IllegalStateException($"Unsupported target type {targetTypeReference.ClrType}");
+                    throw new IllegalStateException($"Unsupported target type {targetTypeReference.ClrType.ToTypeKeyword()}");
                 }
             }
 

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -136,17 +136,19 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("65536", result);
         }
 
-        [Fact]
-        public void exponential_integer_literals_as_variable_initializer()
+        [Theory]
+        [InlineData("2", "12", "4096")]
+        [InlineData("10", "3.5", "3162")] // TODO: Fix this once the `dynamic` PR gets merged. This is incorrectly coerced to BigInteger in the current implementation.
+        public void exponential_integer_literals_as_variable_initializer(string left, string right, string expectedResult)
         {
-            string source = @"
-                var x = 2 ** 12;
+            string source = $@"
+                var x = {left} ** {right};
                 print x;
             ";
 
             string result = EvalReturningOutputString(source);
 
-            Assert.Equal("4096", result);
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]


### PR DESCRIPTION
While working on #225, I discovered that some semantics here was essentially broken. The exponential operator only worked properly with `int` + `int` or `bigint` + `int` operands. When one of the operands was a `float`, it was impossible to assign the result to a variable.

```
$ perlang
Perlang Interactive REPL Console (0.1.0-dev.181, built from git commit 9480f21)
> var v = 2 ** 3.5
[line unknown] Unsupported target type System.Numerics.BigInteger
```