### PR TITLE
(interpreter) Fix unary operator type bug

### DIFF
--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -114,7 +114,7 @@ namespace Perlang.Interpreter.Typing
 
                     if (typeReference == null)
                     {
-                        string message = $"Invalid arguments to {expr.Operator.Type.ToSourceString()} operator specified: " +
+                        string message = $"Unsupported {expr.Operator.Type.ToSourceString()} operands specified: " +
                                          $"{leftTypeReference.ClrType.ToTypeKeyword()} and {rightTypeReference.ClrType.ToTypeKeyword()}";
 
                         throw new TypeValidationError(expr.Operator, message);
@@ -130,7 +130,7 @@ namespace Perlang.Interpreter.Typing
 
                     if (leftMaxValue == null || rightMaxValue == null)
                     {
-                        string message = $"Invalid arguments to {expr.Operator.Type.ToSourceString()} operator specified: " +
+                        string message = $"Unsupported {expr.Operator.Type.ToSourceString()} operands specified: " +
                                          $"{leftTypeReference.ClrType.ToTypeKeyword()} and {rightTypeReference.ClrType.ToTypeKeyword()}";
 
                         throw new TypeValidationError(expr.Operator, message);

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -359,7 +359,7 @@ namespace Perlang.Parser
             if (isFractional)
             {
                 // TODO: This is a mess. We currently treat all floating point values as _double_, which is insane. We
-                // TODO: should probably have a "use smallest possible type" logic as below for integers, for flotaing point
+                // TODO: should probably have a "use smallest possible type" logic as below for integers, for floating point
                 // TODO: values as well. We could also consider supporting `decimal` while we're at it.
                 AddToken(NUMBER, Double.Parse(numberCharacters));
             }

--- a/src/Perlang.Tests.Integration/Operator/AdditionAssignment.cs
+++ b/src/Perlang.Tests.Integration/Operator/AdditionAssignment.cs
@@ -111,7 +111,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to += operator specified: string and int", exception.Message);
+            Assert.Equal("Unsupported += operands specified: string and int", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Division.cs
+++ b/src/Perlang.Tests.Integration/Operator/Division.cs
@@ -48,7 +48,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Invalid arguments to / operator specified", exception.Message);
+            Assert.Matches("Unsupported / operands specified", exception.Message);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Invalid arguments to / operator specified", exception.Message);
+            Assert.Matches("Unsupported / operands specified", exception.Message);
         }
 
         [Fact]

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -123,6 +123,30 @@ namespace Perlang.Tests.Integration.Operator
         }
 
         [Fact]
+        public void exponential_bigint_and_int()
+        {
+            string source = @"
+                1267650600228229401496703205376 ** 3
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(BigInteger.Parse("2037035976334486086268445688409378161051468393665936250636140449354381299763336706183397376"), result);
+        }
+
+        [Fact]
+        public void exponential_multiple_times()
+        {
+            string source = @"
+                (2 ** 100) ** 3
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(BigInteger.Parse("2037035976334486086268445688409378161051468393665936250636140449354381299763336706183397376"), result);
+        }
+
+        [Fact]
         public void exponential_integer_literal_and_function_return_value()
         {
             string source = @"
@@ -152,7 +176,7 @@ namespace Perlang.Tests.Integration.Operator
         }
 
         [Fact]
-        public void exponential_function_return_value_and_integer_literal()
+        public void exponential_function_return_value_and_int_literal()
         {
             string source = @"
                 fun foo(): int { return 4; }
@@ -163,6 +187,20 @@ namespace Perlang.Tests.Integration.Operator
             string result = EvalReturningOutputString(source);
 
             Assert.Equal("65536", result);
+        }
+
+        [Fact]
+        public void exponential_int_variable_and_int_literal()
+        {
+            string source = @"
+                var left = 2;
+
+                print left ** 8;
+            ";
+
+            string result = EvalReturningOutputString(source);
+
+            Assert.Equal("256", result);
         }
 
         [Fact]
@@ -191,7 +229,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to ** operator specified: string and int", exception.Message);
+            Assert.Equal("Unsupported ** operands specified: string and int", exception.Message);
         }
 
         [Fact]
@@ -205,7 +243,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to ** operator specified: int and string", exception.Message);
+            Assert.Equal("Unsupported ** operands specified: int and string", exception.Message);
         }
 
         [Fact]

--- a/src/Perlang.Tests.Integration/Operator/Modulo.cs
+++ b/src/Perlang.Tests.Integration/Operator/Modulo.cs
@@ -89,7 +89,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to % operator specified: string and int", exception.Message);
+            Assert.Equal("Unsupported % operands specified: string and int", exception.Message);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to % operator specified: int and string", exception.Message);
+            Assert.Equal("Unsupported % operands specified: int and string", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Multiplication.cs
+++ b/src/Perlang.Tests.Integration/Operator/Multiplication.cs
@@ -48,7 +48,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to * operator specified: string and int", exception.Message);
+            Assert.Equal("Unsupported * operands specified: string and int", exception.Message);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to * operator specified: int and string", exception.Message);
+            Assert.Equal("Unsupported * operands specified: int and string", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -24,6 +24,22 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(new[] { "-1" }, output);
         }
 
+        [Theory]
+        [InlineData("int", "1", "System.Int32")]
+        [InlineData("long", "4294967296", "System.Int64")]
+        public void decrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
+        {
+            string source = $@"
+                var i: {type} = {before};
+                i--;
+                print i.get_type();
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal(expectedClrType, output);
+        }
+
         [Fact]
         public void decrement_can_be_used_in_for_loops()
         {

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -10,46 +10,36 @@ namespace Perlang.Tests.Integration.Operator
         // "Positive" tests, testing for supported behavior
         //
 
-        [Fact]
-        public void incrementing_int_variable()
+        [Theory]
+        [InlineData("int", "0", "1")]
+        [InlineData("long", "4294967296", "4294967297")]
+        public void incrementing_variable_assigns_expected_value(string type, string before, string after)
         {
-            string source = @"
-                var i: int = 0;
+            string source = $@"
+                var i: {type} = {before};
                 i++;
                 print i;
             ";
 
             var output = EvalReturningOutputString(source);
 
-            Assert.Equal("1", output);
+            Assert.Equal(after, output);
         }
 
-        [Fact]
-        public void incrementing_long_variable()
+        [Theory]
+        [InlineData("int", "0", "System.Int32")]
+        [InlineData("long", "4294967296", "System.Int64")]
+        public void incrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
         {
-            string source = @"
-                var l: long = 4294967296;
-                l++;
-                print l;
+            string source = $@"
+                var i: {type} = {before};
+                i++;
+                print i.get_type();
             ";
 
-            var output = EvalReturningOutputString(source);
+            string output = EvalReturningOutputString(source);
 
-            Assert.Equal("4294967297", output);
-        }
-
-        [Fact]
-        public void incrementing_double_variable()
-        {
-            string source = @"
-                var d = 4294967296.123;
-                d++;
-                print d;
-            ";
-
-            var output = EvalReturningOutputString(source);
-
-            Assert.Equal("4294967297.123", output);
+            Assert.Equal(expectedClrType, output);
         }
 
         [Fact]

--- a/src/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
+++ b/src/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
@@ -111,7 +111,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Invalid arguments to -= operator specified: string and int", exception.Message);
+            Assert.Equal("Unsupported -= operands specified: string and int", exception.Message);
         }
     }
 }


### PR DESCRIPTION
While working on completing #225, I realized that the type of variables in statements like `var i: int = 1; i--;` would be changed; with the current `master` version, `i` will become a `double` value (!). This is because of some subtle semantics in the way C# _switch expressions_ (introduced in C# 8.0) works.

This PR reverts the semantics to what they ought to have been all the time, and adds test coverage to ensure this particular bug will never be able to reappear. :pray: 