### PR TITLE
(many) Implement 'double' type

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="all" />
         <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
 
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.29.0.36737" />
     </ItemGroup>
 
     <!--

--- a/docs/js/highlightjs-perlang.js
+++ b/docs/js/highlightjs-perlang.js
@@ -7,7 +7,7 @@ hljs.registerLanguage('perlang', function(hljs) {
             'and else for fun if nil or print return super this var while ' +
 
             // Reserved keywords
-            'class byte sbyte short ushort uint ulong float double decimal ' +
+            'class byte sbyte short ushort uint ulong float decimal ' +
             'char public private protected internal static volatile printf switch ' +
             'break continue try catch finally async await lock synchronized new ' +
             'mut let const struct enum sizeof nameof typeof asm',

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -258,7 +258,7 @@ namespace Perlang.Parser
             if (Check(RESERVED_WORD))
             {
                 // Special-case to provide a more helpful error message when e.g. 'byte' is being used as a variable name.
-                throw Error(Advance(), "Reserved word encountered");
+                throw Error(Advance(), "Reserved keyword encountered");
             }
 
             Token name = Consume(IDENTIFIER, "Expecting variable name.");
@@ -334,7 +334,7 @@ namespace Perlang.Parser
                     {
                         // Special-case to provide a more helpful error message when e.g. 'byte' is being used as
                         // parameter name.
-                        throw Error(Advance(), "Reserved word encountered");
+                        throw Error(Advance(), "Reserved keyword encountered");
                     }
 
                     Token parameterName = Consume(IDENTIFIER, "Expect parameter name.");
@@ -784,10 +784,10 @@ namespace Perlang.Parser
         }
 
         /// <summary>
-        /// Throws a ParseError if the given token represents a reserved keyword.
+        /// Throws an <see cref="Error"/> if the given token represents a reserved keyword.
         /// </summary>
         /// <param name="token">A token with the name of an identifier.</param>
-        /// <exception cref="InternalParseError">The given token represents a reserved keyword.</exception>
+        /// <exception cref="Error">The given token represents a reserved keyword.</exception>
         private void BlockReservedIdentifiers(Token token)
         {
             // "Reserved for future use". These are not currently supported in Perlang, but we reserve them for
@@ -809,6 +809,7 @@ namespace Perlang.Parser
             {
                 case "int":
                 case "long":
+                case "double":
                 case "string":
                     throw Error(token, "Reserved keyword encountered", ParseErrorType.RESERVED_WORD_ENCOUNTERED);
             }

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -49,9 +49,16 @@ namespace Perlang.Parser
 
                 // Type names
                 //
-                // NOTE: only types not supported by
-                // Perlang.Interpreter.Typing.TypeValidator.TypeResolver.ResolveExplicitTypes should be listed here.
-                // Otherwise, we make it impossible to use them for variable declarations, return types etc.
+                // NOTE: types supported by Perlang.Interpreter.Typing.TypeValidator.TypeResolver.ResolveExplicitTypes()
+                // should not be listed here. Otherwise, we make it impossible to use them for variable declarations,
+                // return types etc.
+                //
+                // When adding types to that method, there is also a list in
+                // Perlang.Parser.PerlangParser.BlockReservedIdentifiers() that needs to be maintained. (This is indeed
+                // a rather unpleasant mess. It is done this way to allow `int`, `long` and similar to be used as
+                // variable/parameter types, but forbid their usage as identifier names. One way to fix this would by by
+                // defining INT, LONG etc as dedicated token types. Another way would be to add some other flag here in
+                // addition to TokenType, to be able to more elegantly special-case it elsewhere.)
                 //
                 { "byte", RESERVED_WORD },
                 { "sbyte", RESERVED_WORD },
@@ -60,7 +67,6 @@ namespace Perlang.Parser
                 { "uint", RESERVED_WORD },
                 { "ulong", RESERVED_WORD },
                 { "float", RESERVED_WORD },
-                { "double", RESERVED_WORD },
                 { "decimal", RESERVED_WORD },
                 { "char", RESERVED_WORD },
 

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -160,21 +160,6 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("65536", result);
         }
 
-        [Theory]
-        [InlineData("2", "12", "4096")]
-        [InlineData("10", "3.5", "3162")] // TODO: Fix this once the `dynamic` PR gets merged. This is incorrectly coerced to BigInteger in the current implementation.
-        public void exponential_integer_literals_as_variable_initializer(string left, string right, string expectedResult)
-        {
-            string source = $@"
-                var x = {left} ** {right};
-                print x;
-            ";
-
-            string result = EvalReturningOutputString(source);
-
-            Assert.Equal(expectedResult, result);
-        }
-
         [Fact]
         public void exponential_function_return_value_and_int_literal()
         {

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -27,6 +27,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "1", "System.Int32")]
         [InlineData("long", "4294967296", "System.Int64")]
+        [InlineData("double", "4294967296.123", "System.Double")]
         public void decrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -13,6 +13,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "0", "1")]
         [InlineData("long", "4294967296", "4294967297")]
+        [InlineData("double", "4294967296.123", "4294967297.123")]
         public void incrementing_variable_assigns_expected_value(string type, string before, string after)
         {
             string source = $@"
@@ -29,6 +30,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "0", "System.Int32")]
         [InlineData("long", "4294967296", "System.Int64")]
+        [InlineData("double", "4294967296.123", "System.Double")]
         public void incrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
@@ -35,7 +35,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches($"Error at '{reservedWord}': Reserved word encountered", exception.ToString());
+            Assert.Matches($"Error at '{reservedWord}': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'public': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'public': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'private': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'private': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'protected': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'protected': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'internal': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'internal': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'static': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'static': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'volatile': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'volatile': Reserved keyword encountered", exception.ToString());
         }
 
         //
@@ -153,7 +153,22 @@ namespace Perlang.Tests.Integration.ReservedKeywords
 
             Assert.Single(result.Errors);
 
-            Assert.Matches("Error at 'float': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'float': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_double_cannot_be_used_as_variable_name()
+        {
+            string source = @"
+                var double = 123.45;
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+
+            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -221,6 +236,21 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         }
 
         [Fact]
+        public void reserved_keyword_double_cannot_be_used_as_function_name()
+        {
+            string source = @"
+                fun double(): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
         public void reserved_keyword_string_cannot_be_used_as_function_name()
         {
             string source = @"
@@ -281,7 +311,22 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Error at 'float': Reserved word encountered", exception.ToString());
+            Assert.Matches("Error at 'float': Reserved keyword encountered", exception.ToString());
+        }
+
+        [Fact]
+        public void reserved_keyword_double_cannot_be_used_as_function_parameter_name()
+        {
+            string source = @"
+                fun foo(double: double): void {
+                }
+            ";
+
+            var result = EvalWithParseErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
         }
 
         [Fact]
@@ -417,22 +462,6 @@ namespace Perlang.Tests.Integration.ReservedKeywords
 
             Assert.Single(result.Errors);
             Assert.Matches("Error at 'float': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_double()
-        {
-            string source = @"
-                fun foo(): double {
-                    return 123.45;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'double': Expecting type name", exception.ToString());
         }
 
         [Fact]

--- a/src/Perlang.Tests/Interpreter/Typing/TypeResolverTest.cs
+++ b/src/Perlang.Tests/Interpreter/Typing/TypeResolverTest.cs
@@ -146,7 +146,7 @@ namespace Perlang.Tests.Interpreter.Typing
                 AssertFailValidationErrorHandler
             );
 
-            typeResolver.Resolve(scanAndParseResult.Statements);
+            typeResolver.Resolve(scanAndParseResult.Statements ?? new List<Stmt>());
 
             return (scanAndParseResult.Statements!, nameResolver);
         }


### PR DESCRIPTION
We already had support for floating-point literals; they are always converted to `double` at the moment. There was just no way to explicitly specify a variable or parameter as `double`.

(This PR is one step towards closing #70)