### PR TITLE
(many) Implement bigint type

### DIFF
--- a/src/Perlang.Common/Extensions/TypeExtensions.cs
+++ b/src/Perlang.Common/Extensions/TypeExtensions.cs
@@ -15,7 +15,7 @@ namespace Perlang.Extensions
                 { } when type == typeof(Double) => "double",
                 { } when type == typeof(Int32) => "int",
                 { } when type == typeof(Int64) => "long",
-                { } when type == typeof(BigInteger) => "BigInteger", // TODO: Should we make this bigint and support it as a special type as the others?
+                { } when type == typeof(BigInteger) => "bigint",
                 { } when type == typeof(NullObject) => "null",
                 { } when type == typeof(String) => "string",
                 { } when type.IsAssignableTo(typeof(IPerlangFunction)) => "function",

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -709,6 +709,14 @@ namespace Perlang.Interpreter
                         _ => throw new RuntimeError(expr.Operator, $"Unsupported operator encountered: {expr.Operator.Type}")
                     };
                     break;
+                case BigInteger previousBigIntegerValue:
+                    value = expr.Operator.Type switch
+                    {
+                        PLUS_PLUS => previousBigIntegerValue + 1,
+                        MINUS_MINUS => previousBigIntegerValue - 1,
+                        _ => throw new RuntimeError(expr.Operator, $"Unsupported operator encountered: {expr.Operator.Type}")
+                    };
+                    break;
                 case double previousDoubleValue:
                     value = expr.Operator.Type switch
                     {

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Numerics;
 using Perlang.Interpreter.Extensions;
 
 namespace Perlang.Interpreter.Typing
@@ -13,7 +14,11 @@ namespace Perlang.Interpreter.Typing
         private static ImmutableDictionary<Type, int?> SignedIntegerLengthByType => new Dictionary<Type, int?>
         {
             { typeof(Int32), 32 },
-            { typeof(Int64), 64 }
+            { typeof(Int64), 64 },
+
+            // In practice, even larger numbers should be possible. For the time being, I think it's quite fine if
+            // bigints in Perlang are limited to 2 billion digits. :)
+            { typeof(BigInteger), Int32.MaxValue }
         }.ToImmutableDictionary();
 
         /// <summary>

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -540,6 +540,10 @@ namespace Perlang.Interpreter.Typing
                     typeReference.ClrType = typeof(long);
                     break;
 
+                case "bigint" or "BigInteger":
+                    typeReference.ClrType = typeof(BigInteger);
+                    break;
+
                 case "double" or "Double":
                     typeReference.ClrType = typeof(double);
                     break;

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -809,6 +809,7 @@ namespace Perlang.Parser
             {
                 case "int":
                 case "long":
+                case "bigint":
                 case "double":
                 case "string":
                     throw Error(token, "Reserved keyword encountered", ParseErrorType.RESERVED_WORD_ENCOUNTERED);

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -420,7 +420,7 @@ namespace Perlang.Parser
                 {
                     AddToken(NUMBER, (ulong)value);
                 }
-                else // Anything else gets implicitly treated as BigInteger
+                else // Anything else remains a BigInteger
                 {
                     AddToken(NUMBER, value);
                 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -27,6 +27,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "1", "System.Int32")]
         [InlineData("long", "4294967296", "System.Int64")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger")]
         [InlineData("double", "4294967296.123", "System.Double")]
         public void decrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
         {

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -13,6 +13,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "0", "1")]
         [InlineData("long", "4294967296", "4294967297")]
+        [InlineData("bigint", "1267650600228229401496703205376", "1267650600228229401496703205377")]
         [InlineData("double", "4294967296.123", "4294967297.123")]
         public void incrementing_variable_assigns_expected_value(string type, string before, string after)
         {
@@ -30,6 +31,7 @@ namespace Perlang.Tests.Integration.Operator
         [Theory]
         [InlineData("int", "0", "System.Int32")]
         [InlineData("long", "4294967296", "System.Int64")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger")]
         [InlineData("double", "4294967296.123", "System.Double")]
         public void incrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
         {

--- a/src/Perlang.Tests.Integration/Typing/BigintTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/BigintTests.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Typing
+{
+    /// <summary>
+    /// Tests for the `long` data type.
+    /// </summary>
+    public class BigintTests
+    {
+        [Fact]
+        public void bigint_variable_can_be_printed()
+        {
+            string source = @"
+                var v: bigint = 103;
+
+                print(v);
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("103", output);
+        }
+
+        [Fact]
+        public void bigint_variable_can_be_reassigned()
+        {
+            string source = @"
+                var v: bigint = 103;
+                v = 8589934592;
+
+                print(v);
+            ";
+
+            var result = EvalReturningOutputString(source);
+
+            Assert.Equal("8589934592", result);
+        }
+
+        [Fact]
+        public void bigint_variable_can_contain_numbers_larger_than_32_bits()
+        {
+            string source = @"
+                var v: bigint = 8589934592;
+
+                print(v);
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("8589934592", output);
+        }
+
+        [Fact]
+        public void bigint_variable_can_contain_numbers_larger_than_64_bits()
+        {
+            string source = @"
+                var v: bigint = 1231231230912839019312831232;
+
+                print(v);
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("1231231230912839019312831232", output);
+        }
+
+        [Fact]
+        public void bigint_variable_has_expected_type_when_initialized_to_8bit_value()
+        {
+            // An 8-bit integer (sbyte) should be expanded to bigint when the assignment target is of the 'bigint' type.
+            string source = @"
+                var v: bigint = 103;
+
+                print(v.get_type());
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("System.Numerics.BigInteger", output);
+        }
+
+        [Fact]
+        public void bigint_variable_has_expected_type_when_assigned_8bit_value_from_another_variable()
+        {
+            // An 8-bit integer (sbyte) should be expanded to bigint when the assignment target is of the 'bigint' type.
+            string source = @"
+                var v: bigint = 103;
+                var x = v;
+
+                print(x.get_type());
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("System.Numerics.BigInteger", output);
+        }
+
+        [Fact]
+        public void bigint_variable_has_expected_type_for_large_value()
+        {
+            string source = @"
+                var v: bigint = 8589934592;
+
+                print(v.get_type());
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("System.Numerics.BigInteger", output);
+        }
+
+        [Fact]
+        public void bigint_variable_with_32bit_value_emits_expected_error_when_initializer_assigned_to_int_variable()
+        {
+            // Expansions are fine (103 to bigint), but the other way around is not supported with implicit conversions.
+            // Attempting to initialize an int variable with this value is expected to fail.
+            string source = @"
+                var v: bigint = 103;
+                var i: int = v;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Cannot assign bigint to int variable", exception.Message);
+        }
+    }
+}

--- a/src/Perlang.Tests.Integration/Typing/LongTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/LongTests.cs
@@ -65,7 +65,7 @@ namespace Perlang.Tests.Integration.Typing
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Cannot assign BigInteger to long variable", exception.Message);
+            Assert.Matches("Cannot assign bigint to long variable", exception.Message);
         }
 
         [Fact]
@@ -116,8 +116,8 @@ namespace Perlang.Tests.Integration.Typing
         [Fact]
         public void long_variable_with_32bit_value_emits_expected_error_when_initializer_assigned_to_int_variable()
         {
-            // An 8-bit integer (sbyte) should be expanded to 64-bit when the assignment target is of the 'long' type,
-            // and attempting to initialize an integer with this value is expected to fail.
+            // Expansions are fine (103 to long), but the other way around is not supported with implicit conversions.
+            // Attempting to initialize an int variable with this value is expected to fail.
             string source = @"
                 var l: long = 103;
                 var i: int = l;


### PR DESCRIPTION
A large part of this was already in place:

- The result of the expontential operator with int operands produced a  `BigInteger` value.
- The `Scanner` would create a `BigInteger` if a constant expression was encountered where the value would not fit into `int` or `long`
- Implementation of arithmetic operators (-, + etc) was mostly in place already.

What this PR adds:

- Support for explicitly declaring variables of `bigint` type.
- Integration tests to ensure the new type works in various scenarios