### PR TITLE
(tests) Improve exceptions in EvalHelper

### DIFF
--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -82,6 +82,40 @@ namespace Perlang.Tests.Integration
         ///
         /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
         ///
+        /// This method will propagate all errors apart from  <see cref="ScanError"/> to the caller. Scan errors
+        /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
+        ///
+        /// If any warnings are emitted, they will be available in the returned <see
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
+        /// </summary>
+        /// <param name="source">A valid Perlang program.</param>
+        /// <returns>An <see cref="EvalResult{T}"/> with the <see cref="EvalResult{T}.Value"/> property set to the
+        /// result of the provided expression. If not provided a valid expression, <see cref="EvalResult{T}.Value"/>
+        /// will be set to `null`.</returns>
+        internal static EvalResult<ScanError> EvalWithScanErrorCatch(string source)
+        {
+            var result = new EvalResult<ScanError>();
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+
+            result.Value = interpreter.Eval(
+                source,
+                result.ErrorHandler,
+                AssertFailParseErrorHandler,
+                AssertFailNameResolutionErrorHandler,
+                AssertFailValidationErrorHandler,
+                AssertFailValidationErrorHandler,
+                result.WarningHandler
+            );
+
+            return result;
+        }
+
+        /// <summary>
+        /// Evaluates the provided expression or list of statements, returning an <see cref="EvalResult{T}"/> with <see
+        /// cref="EvalResult{T}.Value"/> set to the evaluated value.
+        ///
+        /// Output printed to the standard output stream will be available in <see cref="EvalResult{T}.Output"/>.
+        ///
         /// This method will propagate all errors apart from  <see cref="ParseError"/> to the caller. Parse errors
         /// will be available in the returned <see cref="EvalResult{T}.Errors"/> property.
         ///
@@ -268,32 +302,32 @@ namespace Perlang.Tests.Integration
 
         private static void AssertFailScanErrorHandler(ScanError scanError)
         {
-            throw scanError;
+            throw new Exception("ScanError occurred. See inner exception for details.", scanError);
         }
 
         private static void AssertFailParseErrorHandler(ParseError parseError)
         {
-            throw parseError;
+            throw new Exception("ParseError occurred. See inner exception for details.", parseError);
         }
 
         private static void AssertFailNameResolutionErrorHandler(NameResolutionError nameResolutionError)
         {
-            throw nameResolutionError;
+            throw new Exception("NameResolutionError occurred. See inner exception for details.", nameResolutionError);
         }
 
         private static void AssertFailRuntimeErrorHandler(RuntimeError runtimeError)
         {
-            throw runtimeError;
+            throw new Exception("RuntimeError occurred. See inner exception for details.", runtimeError);
         }
 
         private static void AssertFailValidationErrorHandler(ValidationError validationError)
         {
-            throw validationError;
+            throw new Exception("ValidationError occurred. See inner exception for details.", validationError);
         }
 
         private static bool AssertFailCompilerWarningHandler(CompilerWarning compilerWarning)
         {
-            throw compilerWarning;
+            throw new Exception("CompilerWarning occurred. See inner exception for details.", compilerWarning);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Division.cs
+++ b/src/Perlang.Tests.Integration/Operator/Division.cs
@@ -87,10 +87,9 @@ namespace Perlang.Tests.Integration.Operator
                 print ""hejhej"";
             ";
 
-            string result = null;
-            Assert.Throws<RuntimeError>(() => result = EvalReturningOutputString(source));
+            var result = EvalWithRuntimeErrorCatch(source);
 
-            Assert.DoesNotMatch("hejhej.", result);
+            Assert.Empty(result.OutputAsString);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Shebang.cs
+++ b/src/Perlang.Tests.Integration/Shebang.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Perlang.Parser;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -29,7 +28,11 @@ namespace Perlang.Tests.Integration
                 var b = 10;
             ".Trim();
 
-            Assert.Throws<ScanError>(() => EvalReturningOutput(source).SingleOrDefault());
+            var result = EvalWithScanErrorCatch(source);
+            var exception = result.Errors.FirstOrDefault();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("Unexpected character #", exception.Message);
         }
     }
 }


### PR DESCRIPTION
While working on a new language feature, I realized that the way we have been throwing exceptions in `EvalHelper` was not that great. More details in a separate thread.