### PR TITLE
(many) Change `and` to `&&` and `or` to `||`

### DIFF
--- a/docs/js/highlightjs-perlang.js
+++ b/docs/js/highlightjs-perlang.js
@@ -4,7 +4,7 @@ hljs.registerLanguage('perlang', function(hljs) {
     var KEYWORDS = {
         keyword:
             // Currently implemented
-            'and else for fun if nil or print return super this var while ' +
+            'else for fun if nil print return super this var while ' +
 
             // Reserved keywords
             'class byte sbyte short ushort uint ulong float decimal ' +

--- a/src/Perlang.Common/TokenType.cs
+++ b/src/Perlang.Common/TokenType.cs
@@ -20,10 +20,8 @@ namespace Perlang
         SEMICOLON,
         COLON,
         SLASH,
-        AMPERSAND,
         QUESTION_MARK,
         CARET,
-        VERTICAL_BAR,
 
         // One or two character tokens.
         BANG,
@@ -36,6 +34,10 @@ namespace Perlang
         LESS,
         LESS_EQUAL,
         LESS_LESS,
+        AMPERSAND,
+        AMPERSAND_AMPERSAND,
+        PIPE,
+        PIPE_PIPE,
         PLUS_PLUS,
         MINUS_MINUS,
         PLUS_EQUAL,
@@ -49,14 +51,12 @@ namespace Perlang
         NUMBER,
 
         // Keywords.
-        AND,
         ELSE,
         FALSE,
         FUN,
         FOR,
         IF,
         NULL,
-        OR,
         PRINT,
         RETURN,
         SUPER,

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -573,14 +573,14 @@ namespace Perlang.Interpreter
         {
             object? left = Evaluate(expr.Left);
 
-            if (expr.Operator.Type == OR)
+            if (expr.Operator.Type == PIPE_PIPE)
             {
                 if (IsTruthy(left))
                 {
                     return left;
                 }
             }
-            else if (expr.Operator.Type == AND)
+            else if (expr.Operator.Type == AMPERSAND_AMPERSAND)
             {
                 if (!IsTruthy(left))
                 {

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -478,7 +478,7 @@ namespace Perlang.Parser
         {
             Expr expr = And();
 
-            while (Match(OR))
+            while (Match(PIPE_PIPE))
             {
                 Token @operator = Previous();
                 Expr right = And();
@@ -492,7 +492,7 @@ namespace Perlang.Parser
         {
             Expr expr = Equality();
 
-            while (Match(AND))
+            while (Match(AMPERSAND_AMPERSAND))
             {
                 Token @operator = Previous();
                 Expr right = Equality();

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -28,14 +28,12 @@ namespace Perlang.Parser
         public static readonly IDictionary<string, TokenType> ReservedKeywords =
             new Dictionary<string, TokenType>
             {
-                { "and", AND },
                 { "else", ELSE },
                 { "false", FALSE },
                 { "for", FOR },
                 { "fun", FUN },
                 { "if", IF },
                 { "null", NULL },
-                { "or", OR },
                 { "print", PRINT },
                 { "return", RETURN },
                 { "super", SUPER },
@@ -169,6 +167,10 @@ namespace Perlang.Parser
             char c = Advance();
 
             // Note: case values are sorted in ASCII order, for predictability.
+            //
+            // (Hmm, I'm having second thoughts about this... It actually makes it harder to find things in the code,
+            // since things logically connected together like && and || end up being far apart. Might have to revisit
+            // this again.)
             switch (c)
             {
                 // Regular whitespace characters are ignored.
@@ -196,7 +198,7 @@ namespace Perlang.Parser
                     AddToken(PERCENT);
                     break;
                 case '&':
-                    AddToken(AMPERSAND);
+                    AddToken(Match('&') ? AMPERSAND_AMPERSAND : AMPERSAND);
                     break;
                 case '\'':
                     AddToken(SINGLE_QUOTE);
@@ -338,7 +340,7 @@ namespace Perlang.Parser
                     AddToken(LEFT_BRACE);
                     break;
                 case '|':
-                    AddToken(VERTICAL_BAR);
+                    AddToken(Match('|') ? PIPE_PIPE : PIPE);
                     break;
                 case '}':
                     AddToken(RIGHT_BRACE);

--- a/src/Perlang.Tests.Integration/LogicalOperator/And.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/And.cs
@@ -13,7 +13,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_falsy_argument_false_and_1()
         {
             string source = @"
-                print false and 1;
+                print false && 1;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -25,7 +25,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_falsy_argument_true_and_1()
         {
             string source = @"
-                print true and 1;
+                print true && 1;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -37,7 +37,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_falsy_argument_1_and_2_and_false()
         {
             string source = @"
-                print 1 and 2 and false;
+                print 1 && 2 && false;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -49,7 +49,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_last_argument_if_all_are_truthy_1_and_true()
         {
             string source = @"
-                print 1 and true;
+                print 1 && true;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -61,7 +61,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_last_argument_if_all_are_truthy_1_and_2_and_3()
         {
             string source = @"
-                print 1 and 2 and 3;
+                print 1 && 2 && 3;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -76,8 +76,8 @@ namespace Perlang.Tests.Integration.LogicalOperator
                 var a = false;
                 var b = true;
 
-                (a = true) and
-                    (b = false) and
+                (a = true) &&
+                    (b = false) &&
                     (a = false);
 
                 print a;
@@ -100,7 +100,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void false_is_falsy()
         {
             string source = @"
-                print false and ""bad"";
+                print false && ""bad"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -112,7 +112,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void null_is_falsy()
         {
             string source = @"
-                print null and ""bad"";
+                print null && ""bad"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -124,7 +124,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void true_is_truthy()
         {
             string source = @"
-                print true and ""ok"";
+                print true && ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -136,7 +136,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void zero_is_truthy()
         {
             string source = @"
-                print 0 and ""ok"";
+                print 0 && ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -148,7 +148,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void empty_string_is_truthy()
         {
             string source = @"
-                print """" and ""ok"";
+                print """" && ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();

--- a/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
@@ -13,7 +13,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_true_argument_1_or_true()
         {
             string source = @"
-                print 1 or true;
+                print 1 || true;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -25,7 +25,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_true_argument_false_or_1()
         {
             string source = @"
-                print false or 1;
+                print false || 1;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -37,7 +37,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_first_true_argument_false_or_false_or_true()
         {
             string source = @"
-                print false or false or true;
+                print false || false || true;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -49,7 +49,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_last_argument_if_all_are_false_false_or_false()
         {
             string source = @"
-                print false or false;
+                print false || false;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -61,7 +61,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void returns_the_last_argument_if_all_are_false_false_or_false_false()
         {
             string source = @"
-                print false or false or false;
+                print false || false || false;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -76,8 +76,8 @@ namespace Perlang.Tests.Integration.LogicalOperator
                 var a = true;
                 var b = false;
 
-                (a = false) or
-                    (b = true) or
+                (a = false) ||
+                    (b = true) ||
                     (a = true);
                 
                 print a;
@@ -100,7 +100,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void false_is_falsy()
         {
             string source = @"
-                print false or ""ok"";
+                print false || ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -112,7 +112,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void null_is_falsy()
         {
             string source = @"
-                print null or ""ok"";
+                print null || ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -124,7 +124,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void true_is_truthy()
         {
             string source = @"
-                print true or ""ok"";
+                print true || ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -136,7 +136,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void zero_is_truthy()
         {
             string source = @"
-                print 0 or ""ok"";
+                print 0 || ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -148,7 +148,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
         public void strings_are_truthy()
         {
             string source = @"
-                print ""s"" or ""ok"";
+                print ""s"" || ""ok"";
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();

--- a/src/Perlang.Tests.Integration/ReservedTokens/ReservedTokensTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedTokens/ReservedTokensTests.cs
@@ -24,9 +24,9 @@ namespace Perlang.Tests.Integration.ReservedTokens
         [Fact]
         public void ampersand_throws_expected_error()
         {
-            // Ampersands will be used for bitwise and boolean AND operators.
+            // Singe-ampersands will be used for bitwise AND operator.
             string source = @"
-                var c = true && false;
+                var c = 127 & 63;
             ";
 
             var result = EvalWithParseErrorCatch(source);
@@ -54,11 +54,11 @@ namespace Perlang.Tests.Integration.ReservedTokens
         }
 
         [Fact]
-        public void vertical_bar_throws_expected_error()
+        public void pipe_throws_expected_error()
         {
-            // The vertical bar (pipe) character wil be used for bitwise and boolean AND operators.
+            // The single-pipe (vertical bar) character will be used for bitwise OR operator.
             string source = @"
-                var c = 123 | 456;
+                var c = 127 | 255;
             ";
 
             var result = EvalWithParseErrorCatch(source);


### PR DESCRIPTION
First step towards resolving #245.