### PR TITLE
(interpreter) Make boolean operators and keywords perform type-checking

### DIFF
--- a/src/Perlang.Interpreter/Typing/BooleanOperandsValidator.cs
+++ b/src/Perlang.Interpreter/Typing/BooleanOperandsValidator.cs
@@ -1,0 +1,73 @@
+using System;
+using Perlang.Extensions;
+using Perlang.Interpreter.NameResolution;
+
+namespace Perlang.Interpreter.Typing
+{
+    /// <summary>
+    /// Visitor which ensures that all expressions which expect boolean operands have been passed values which can be
+    /// coerced to `bool`.
+    /// </summary>
+    internal class BooleanOperandsValidator : Validator
+    {
+        public BooleanOperandsValidator(
+            Func<Expr, Binding> getVariableOrFunctionCallback,
+            Action<TypeValidationError> typeValidationErrorCallback)
+            : base(getVariableOrFunctionCallback, typeValidationErrorCallback)
+        {
+        }
+
+        public override VoidObject VisitLogicalExpr(Expr.Logical expr)
+        {
+            base.VisitLogicalExpr(expr);
+
+            if (expr.Left.TypeReference.ClrType != typeof(bool))
+            {
+                TypeValidationErrorCallback(new TypeValidationError(
+                    expr.Token,
+                    $"'{expr.Left.TypeReference.ClrType.ToTypeKeyword()}' is not a valid {expr.Operator.Lexeme} operand."
+                ));
+            }
+
+            if (expr.Right.TypeReference.ClrType != typeof(bool))
+            {
+                TypeValidationErrorCallback(new TypeValidationError(
+                    expr.Token,
+                    $"'{expr.Right.TypeReference.ClrType.ToTypeKeyword()}' is not a valid {expr.Operator.Lexeme} operand."
+                ));
+            }
+
+            return VoidObject.Void;
+        }
+
+        public override VoidObject VisitIfStmt(Stmt.If stmt)
+        {
+            base.VisitIfStmt(stmt);
+
+            if (stmt.Condition.TypeReference.ClrType != typeof(bool))
+            {
+                TypeValidationErrorCallback(new TypeValidationError(
+                    (stmt.Condition as ITokenAware)?.Token,
+                    $"'{stmt.Condition.TypeReference.ClrType.ToTypeKeyword()}' is not a valid 'if' condition."
+                ));
+            }
+
+            return VoidObject.Void;
+        }
+
+        public override VoidObject VisitWhileStmt(Stmt.While stmt)
+        {
+            base.VisitWhileStmt(stmt);
+
+            if (stmt.Condition.TypeReference.ClrType != typeof(bool))
+            {
+                TypeValidationErrorCallback(new TypeValidationError(
+                    (stmt.Condition as ITokenAware)?.Token,
+                    $"'{stmt.Condition.TypeReference.ClrType.ToTypeKeyword()}' is not a valid 'while' condition."
+                ));
+            }
+
+            return VoidObject.Void;
+        }
+    }
+}

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -269,6 +269,17 @@ namespace Perlang.Interpreter.Typing
             return VoidObject.Void;
         }
 
+        public override VoidObject VisitLogicalExpr(Expr.Logical expr)
+        {
+            base.VisitLogicalExpr(expr);
+
+            // All logical expressions return a `bool` value. The validation of the operands are handled by the
+            // BooleanOperandsValidator class.
+            expr.TypeReference.ClrType = typeof(bool);
+
+            return VoidObject.Void;
+        }
+
         public override VoidObject VisitUnaryPrefixExpr(Expr.UnaryPrefix expr)
         {
             base.VisitUnaryPrefixExpr(expr);

--- a/src/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -92,6 +92,16 @@ namespace Perlang.Interpreter.Typing
             // is expanded to a larger type (e.g. `long`).
             new TypeAssignmentValidator(getVariableOrFunctionCallback, typeValidationErrorCallback)
                 .ReportErrors(statements);
+
+            //
+            // Phase 4: Ensure that all expressions involving boolean operands have operands of `bool`.
+            //
+
+            // These expressions are things like `foo && bar`, `if (baz) { ... }` and `while (zot) { ... }`. All of
+            // these require proper, boolean operands and should trigger a compile-time error if used with any other
+            // types of operands.
+            new BooleanOperandsValidator(getVariableOrFunctionCallback, typeValidationErrorCallback)
+                .ReportErrors(statements);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/Or.cs
@@ -4,71 +4,15 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.LogicalOperator
 {
-    // Tests based on Lox test suite:
+    // Tests originally based on Lox test suite:
     // https://github.com/munificent/craftinginterpreters/blob/master/test/logical_operator/or.lox
     // https://github.com/munificent/craftinginterpreters/blob/master/test/logical_operator/or_truth.lox
+    //
+    // ...but eventually most of those tests were removed, as our semantics started to diverge from those of Lox. (no
+    // longer return the first truthy argument if true, or the last argument if false, etc. In general, provide a much
+    // more C#/Java:esque experience than Lox.)
     public class Or
     {
-        [Fact]
-        public void returns_the_first_true_argument_1_or_true()
-        {
-            string source = @"
-                print 1 || true;
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("1", output);
-        }
-
-        [Fact]
-        public void returns_the_first_true_argument_false_or_1()
-        {
-            string source = @"
-                print false || 1;
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("1", output);
-        }
-
-        [Fact]
-        public void returns_the_first_true_argument_false_or_false_or_true()
-        {
-            string source = @"
-                print false || false || true;
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("True", output);
-        }
-
-        [Fact]
-        public void returns_the_last_argument_if_all_are_false_false_or_false()
-        {
-            string source = @"
-                print false || false;
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("False", output);
-        }
-
-        [Fact]
-        public void returns_the_last_argument_if_all_are_false_false_or_false_false()
-        {
-            string source = @"
-                print false || false || false;
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("False", output);
-        }
-
         [Fact]
         public void short_circuits_at_the_first_true_argument()
         {
@@ -93,38 +37,12 @@ namespace Perlang.Tests.Integration.LogicalOperator
             }, output);
         }
 
-        // Note: we might want to tighten the semantics here so that 'bool or non-bool' throws a compile-time error.
-        // These semantics were inherited from Lox, which is dynamically typed with no compile-time typechecking
-        // whatsoever.
-        [Fact]
-        public void false_is_falsy()
-        {
-            string source = @"
-                print false || ""ok"";
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("ok", output);
-        }
-
-        [Fact]
-        public void null_is_falsy()
-        {
-            string source = @"
-                print null || ""ok"";
-            ";
-
-            string output = EvalReturningOutput(source).SingleOrDefault();
-
-            Assert.Equal("ok", output);
-        }
-
         [Fact]
         public void true_is_truthy()
         {
+            // In fact, true is the _only_ truthy value in Perlang. :-)
             string source = @"
-                print true || ""ok"";
+                print true || false;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
@@ -133,27 +51,73 @@ namespace Perlang.Tests.Integration.LogicalOperator
         }
 
         [Fact]
-        public void zero_is_truthy()
+        public void false_is_falsy()
         {
+            // Just like with 'true', 'false' is the _only_ falsy value we accept. Anything else is a compile-time
+            // error, just like we believe it ought to be.
             string source = @"
-                print 0 || ""ok"";
+                print false || false;
             ";
 
             string output = EvalReturningOutput(source).SingleOrDefault();
 
-            Assert.Equal("0", output);
+            Assert.Equal("False", output);
         }
 
         [Fact]
-        public void strings_are_truthy()
+        public void null_is_not_a_valid_or_operand()
         {
             string source = @"
-                print ""s"" || ""ok"";
+                print null || true;
             ";
 
-            string output = EvalReturningOutput(source).SingleOrDefault();
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
 
-            Assert.Equal("s", output);
+            Assert.Single(result.Errors);
+            Assert.Matches("'null' is not a valid || operand", exception.Message);
+        }
+
+        [Fact]
+        public void integer_is_not_a_valid_and_operand()
+        {
+            string source = @"
+                print 0 || false;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("'int' is not a valid || operand", exception.Message);
+        }
+
+        [Fact]
+        public void string_is_not_a_valid_and_operand()
+        {
+            string source = @"
+                print ""s"" || false;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+            var exception = result.Errors.First();
+
+            Assert.Single(result.Errors);
+            Assert.Matches("'string' is not a valid || operand", exception.Message);
+        }
+
+        [Fact]
+        public void result_of_or_is_boolean()
+        {
+            string source = @"
+                var v = true || false;
+
+                print(v.get_type());
+            ";
+
+            var output = EvalReturningOutputString(source);
+
+            Assert.Equal("System.Boolean", output);
         }
     }
 }


### PR DESCRIPTION
This commit addresses the following issues:

- Lox had a fairly relaxed (or if you will, non-conforming) way of handling boolean operators like `and` and `or`. (These operators were renamed to `&&` and `||` in #253, to make the language feel more like our friends in C# and Java.)

  The way these operators worked was to try and coalesce pretty much everything to a "truthy" or "falsy" value, much like languages like Ruby and JavaScript operate. This makes sense in a dynamic language context, but Perlang strives to have a rich type checker and we consider static typing a feature. Hence, it makes sense to be more explicit when it comes to boolean operator operands.

- The result from the `and` and `or` operators also followed a certain pattern, described in detail here:  https://craftinginterpreters.com/control-flow.html#logical-operators. We want these methods to always return a `bool` value. Hence, the `TypeResolver` is amended in this commit to make the CLR type of all `Expr.Logical` instances be `bool`.

The end result is something closer to the semantics we are aiming for in issue #245.

Related ticket: #245
Related ticket: #43