### PR TITLE
(interpreter) Warn on ambiguous combination of boolean operators

### DIFF
--- a/src/Perlang.Interpreter/CodeAnalysis/CodeAnalysisValidator.cs
+++ b/src/Perlang.Interpreter/CodeAnalysis/CodeAnalysisValidator.cs
@@ -1,0 +1,79 @@
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using Perlang.Parser;
+using static Perlang.TokenType;
+
+namespace Perlang.Interpreter.CodeAnalysis
+{
+    /// <summary>
+    /// Validator which performs various forms of "code-analysis"-related validation.
+    ///
+    /// One example of such validation is "valid combinations of expressions". Sometimes, expressions are combined in a
+    /// way which is "semantically permitted" by our <see cref="PerlangParser"/> class, but the result is still
+    /// "logically forbidden" or discouraged because of e.g. undesired ambiguity that it forces upon the reader of the
+    /// code.
+    ///
+    /// Some of these checks could easily be done in the <see cref="PerlangParser"/> class, but doing so would have the
+    /// disadvantage of cluttering that class with things not strictly related to the parsing. Even though it does incur
+    /// a certain overhead, keeping these validations in a separate class feels worthwhile. It also has another
+    /// advantage: the validation here can presume that a full, already-parsed syntax tree is already available at this
+    /// point.
+    /// </summary>
+    internal class CodeAnalysisValidator : VisitorBase
+    {
+        private readonly Action<CompilerWarning> compilerWarningCallback;
+
+        public static void Validate(
+            ImmutableList<Stmt> statements,
+            Action<CompilerWarning> compilerWarningCallback)
+        {
+            // Moving forward, this validation could be split into multiple classes that get called at this point, like
+            // the TypeValidator does its work. For now, it would just be overkill though.
+            new CodeAnalysisValidator(compilerWarningCallback)
+                .Visit(statements);
+        }
+
+        private CodeAnalysisValidator(Action<CompilerWarning> compilerWarningCallback)
+        {
+            this.compilerWarningCallback = compilerWarningCallback;
+        }
+
+        public override VoidObject VisitLogicalExpr(Expr.Logical expr)
+        {
+            base.VisitLogicalExpr(expr);
+
+            if (expr.Operator.Type is AMPERSAND_AMPERSAND or PIPE_PIPE)
+            {
+                if (expr.Left is Expr.Logical logicalLeftExpr &&
+                    logicalLeftExpr.Operator.Type != expr.Operator.Type)
+                {
+                    compilerWarningCallback(
+                        new CompilerWarning(
+                            $"Invalid combination of boolean operators: {logicalLeftExpr.Operator.Lexeme} and " +
+                            $"{expr.Operator.Lexeme}. To avoid ambiguity for the reader, grouping parentheses () must " +
+                            "be used.",
+                            expr.Token,
+                            WarningType.AMBIGUOUS_COMBINATION_OF_BOOLEAN_OPERATORS
+                        )
+                    );
+                }
+                else if (expr.Right is Expr.Logical logicalRightExpr &&
+                         expr.Operator.Type != logicalRightExpr.Operator.Type)
+                {
+                    compilerWarningCallback(
+                        new CompilerWarning(
+                            $"Invalid combination of boolean operators: {expr.Operator.Lexeme} and " +
+                            $"{logicalRightExpr.Operator.Lexeme}. To avoid ambiguity for the reader, grouping parentheses () " +
+                            "must be used.",
+                            expr.Token,
+                            WarningType.AMBIGUOUS_COMBINATION_OF_BOOLEAN_OPERATORS
+                        )
+                    );
+                }
+            }
+
+            return VoidObject.Void;
+        }
+    }
+}

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Perlang.Attributes;
 using Perlang.Exceptions;
 using Perlang.Extensions;
+using Perlang.Interpreter.CodeAnalysis;
 using Perlang.Interpreter.Immutability;
 using Perlang.Interpreter.Internals;
 using Perlang.Interpreter.NameResolution;
@@ -269,6 +270,30 @@ namespace Perlang.Interpreter
                     return null;
                 }
 
+                //
+                // "Code analysis" validation
+                //
+
+                bool codeAnalysisValidationFailed = false;
+
+                CodeAnalysisValidator.Validate(
+                    previousAndNewStatements,
+                    compilerWarning =>
+                    {
+                        bool result = compilerWarningHandler(compilerWarning);
+
+                        if (result)
+                        {
+                            codeAnalysisValidationFailed = true;
+                        }
+                    }
+                );
+
+                if (codeAnalysisValidationFailed)
+                {
+                    return null;
+                }
+
                 // All validation was successful => add these statements to the list of "previous statements". Recording
                 // them like this is necessary to be able to declare a variable in one REPL line and refer to it in
                 // another.
@@ -358,6 +383,30 @@ namespace Perlang.Interpreter
                     },
                     BindingHandler.GetVariableOrFunctionBinding
                 );
+
+                //
+                // "Code analysis" validation
+                //
+
+                bool codeAnalysisValidationFailed = false;
+
+                CodeAnalysisValidator.Validate(
+                    previousAndNewStatements,
+                    compilerWarning =>
+                    {
+                        bool result = compilerWarningHandler(compilerWarning);
+
+                        if (result)
+                        {
+                            codeAnalysisValidationFailed = true;
+                        }
+                    }
+                );
+
+                if (codeAnalysisValidationFailed)
+                {
+                    return null;
+                }
 
                 // All validation was successful, but unlike for statements, there is no need to mutate the
                 // previousStatements field in this case. Think about it for a moment. We know that the line being

--- a/src/Perlang.Parser/WarningType.cs
+++ b/src/Perlang.Parser/WarningType.cs
@@ -21,6 +21,15 @@ namespace Perlang.Parser
         /// </summary>
         public static readonly WarningType NULL_USAGE = new("null-usage");
 
+        /// <summary>
+        /// An ambiguous combination of boolean operators was encountered. This can be things like `false &amp;&amp;
+        /// false || true`. An expression like this is valid in most languages, and in many of them the `&amp;&amp;`
+        /// operator has a higher precedence than `||`. However, remembering the operator precedence rules by heart is
+        /// not always easy. We want to help people write code which is unambiguous to the reader, which is why we are
+        /// strongly encouraging the use of grouping parentheses in expressions like the above.
+        /// </summary>
+        public static readonly WarningType AMBIGUOUS_COMBINATION_OF_BOOLEAN_OPERATORS = new("ambigous-combination-of-boolean-operators");
+
         private static readonly IReadOnlyDictionary<string, WarningType> AllWarnings = new[]
         {
             NULL_USAGE

--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -220,7 +220,8 @@ namespace Perlang.Tests.Integration
         ///
         /// This method will propagate all kinds of errors to the caller, throwing an exception on the first error
         /// encountered. If any warnings are emitted, they will be available in the returned <see
-        /// cref="EvalResult{T}.CompilerWarnings"/> property. "Warnings as errors" will be disabled for all warnings.
+        /// cref="EvalResult{T}.CompilerWarnings"/> property. This can be seen as "warnings as errors" is disabled
+        /// for all warnings; the caller need to explicitly check for warnings and fail if appropriate.
         /// </summary>
         /// <param name="source">A valid Perlang program.</param>
         /// <param name="arguments">Zero or more arguments to be passed to the program.</param>

--- a/src/Perlang.Tests.Integration/LogicalOperator/AmbiguousCombinationOfOperators.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/AmbiguousCombinationOfOperators.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.LogicalOperator
+{
+    public class AmbiguousCombinationOfOperators
+    {
+        [Fact]
+        public void combined_and_and_or_operators_emits_expected_warning_for_statement()
+        {
+            // The following program is valid in many other languages. In Perlang, however, we want to prevent users
+            // from writing code like this since it is potentially very ambiguous to the reader. The example below is
+            // a seemingly trivial and harmless example; however, real-world scenarios can be more complex and delicate.
+            //
+            // Given that this design decision is potentially a source of controversy, it felt most reasonable to make
+            // this a compilation warning (and warnings are errors by default, as they ought to be) that could
+            // potentially be disabled for potential users which strongly oppose this decision.
+            string source = @"
+                var a = false && false || true;
+            ";
+
+            var result = EvalWithResult(source);
+            var compilerWarning = result.CompilerWarnings.FirstOrDefault();
+
+            Assert.Single(result.CompilerWarnings);
+            Assert.Matches("Invalid combination of boolean operators: && and ||", compilerWarning.Message);
+        }
+
+        [Fact]
+        public void combined_and_and_or_operators_emits_expected_warning_for_expression()
+        {
+            // Like the above, but for programs which consist of a single expression. (We should really unify these code
+            // paths at some point, to make tests like this irrelevant.)
+            string source = @"
+                false && false || true
+            ";
+
+            var result = EvalWithResult(source);
+            var compilerWarning = result.CompilerWarnings.FirstOrDefault();
+
+            Assert.Single(result.CompilerWarnings);
+            Assert.Matches("Invalid combination of boolean operators: && and ||", compilerWarning.Message);
+        }
+
+        [Fact]
+        public void grouped_and_and_or_operators_does_not_emit_warnings()
+        {
+            // Adding some parentheses () for grouping makes the above example perfectly legitimate.
+            //
+            // Note that the example has deliberately been selected to have a different value than the example above. &&
+            // has higher precedence than || in most languages, meaning that the first example will evaluate to `true`.
+            // It is precisely this distinction between `(false && false) || true` and `false && (false || true)` that we
+            // want to highlight and force the user to pay extra attention to, especially since boolean operators with
+            // implicit precedence are hard for some people to use correctly; they can easily be a source of subtle
+            // bugs.
+            string source = @"
+                var a = false && (false || true);
+                print a;
+            ";
+
+            string output = EvalReturningOutput(source).SingleOrDefault();
+
+            Assert.Equal("False", output);
+        }
+    }
+}


### PR DESCRIPTION
This has been an idea of mine since a long time. Quoting #245:

> Doing things which are considered "hard-to-from" from an ambiguity should produce a compile-time error. I am thinking about expressions like this:
>
> `true && false || false`
>
> Without digging up a book/Internet resource, can you _by heart_ say what the above will produce in the language you use everyday?
>
> (The right answer is typically _`false`_ since `||` has higher precedence than `&&`. In other words, the above should be read as `true && (false || false)`.)
>
> ### What Perlang aims to do here
>
> We want to make it _impossible_ to write the above, ambiguous code. The compiler should complain and enforce the usage of clarifying parentheses in this case.

Closes #245.