### PR TITLE
(ci) Run tests on multiple locales

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,31 @@ jobs:
   test:
     runs-on: ${{ matrix.runner }}
 
+    env:
+      LANG: ${{ matrix.lang }}
+
     strategy:
       matrix:
         runner:
           - windows-2022
           - ubuntu-20.04
           - macos-11
+        # Ensure that the tests run cleanly on both default (US) and non-US
+        # locales; e.g. double.ToString() behaves different on different
+        # locales and there have been cases where our tests failed on the
+        # non-US locales.
+        #
+        # We only run these on Linux for now to keep complexity down; if we
+        # ever end up with a non-US-locale bug which is manifested only on
+        # Windows or macOS, we can reconsider this decision. :-)
+        lang:
+          - C
+          - sv_SE
+        exclude:
+          - runner: windows-2022
+            lang: sv_SE
+          - runner: macos-11
+            lang: sv_SE
 
     steps:
       - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # to force it to be regenerated.
 .PHONY: \
 	all auto-generated clean darkerfx-push docs docs-serve docs-test-examples \
-	install release run src/Perlang.Common/CommonConstants.Generated.cs
+	install release run test src/Perlang.Common/CommonConstants.Generated.cs
 
 # Enable fail-fast in case of errors
 SHELL=/bin/bash -e -o pipefail
@@ -57,3 +57,6 @@ run: auto-generated
 	# /p:SolutionDir=$(pwd)/ to it.
 	dotnet build
 	src/Perlang.ConsoleApp/bin/Debug/net6.0/perlang
+
+test:
+	dotnet test --configuration Release


### PR DESCRIPTION
The aim with these tests is to prevent regressions/bugs which are only present when a particular locale is used; there are currently some such bugs in our current `master` codebase.