### PR TITLE
(tests) Run locale-dependent tests on multiple locales

### DIFF
--- a/src/Perlang.Tests.Integration/Number/NumberTests.cs
+++ b/src/Perlang.Tests.Integration/Number/NumberTests.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -95,9 +97,12 @@ namespace Perlang.Tests.Integration.Number
             Assert.Equal(-123, result);
         }
 
-        [Fact]
-        public void literal_float()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task literal_float(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 123.456
             ";
@@ -107,9 +112,12 @@ namespace Perlang.Tests.Integration.Number
             Assert.Equal(123.456, result);
         }
 
-        [Fact]
-        public void literal_negative_float()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task literal_negative_float(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 -0.001
             ";
@@ -119,9 +127,12 @@ namespace Perlang.Tests.Integration.Number
             Assert.Equal(-0.001, result);
         }
 
-        [Fact]
-        public void literal_float_with_underscore_in_integer_part()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task literal_float_with_underscore_in_integer_part(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 123_45.678
             ";
@@ -131,9 +142,12 @@ namespace Perlang.Tests.Integration.Number
             Assert.Equal(12345.678, result);
         }
 
-        [Fact]
-        public void literal_float_with_underscore_in_fractional_part()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task literal_float_with_underscore_in_fractional_part(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 123.45_678
             ";

--- a/src/Perlang.Tests.Integration/Operator/Addition.cs
+++ b/src/Perlang.Tests.Integration/Operator/Addition.cs
@@ -1,3 +1,7 @@
+#pragma warning disable CS1998
+
+using System.Globalization;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -69,9 +73,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("abc123", result);
         }
 
-        [Fact]
-        public void addition_of_float_and_string_coerces_number_to_string()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task addition_of_float_and_string_coerces_number_to_string(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 var i = 123.45;
                 var s = ""abc"";
@@ -83,9 +90,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("123.45abc", result);
         }
 
-        [Fact]
-        public void addition_of_string_and_float_coerces_number_to_string()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task addition_of_string_and_float_coerces_number_to_string(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 var s = ""abc"";
                 var i = 123.45;

--- a/src/Perlang.Tests.Integration/Operator/Comparison.cs
+++ b/src/Perlang.Tests.Integration/Operator/Comparison.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -261,9 +263,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(false, output);
         }
 
-        [Fact]
-        public void zero_less_than_negative_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task zero_less_than_negative_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 0.0 < -0.0
             ";
@@ -273,9 +278,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(false, output);
         }
 
-        [Fact]
-        public void negative_zero_less_than_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task negative_zero_less_than_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 -0.0 < 0.0
             ";
@@ -285,9 +293,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(false, output);
         }
 
-        [Fact]
-        public void zero_greater_than_negative_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task zero_greater_than_negative_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 0.0 > -0.0
             ";
@@ -297,9 +308,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(false, output);
         }
 
-        [Fact]
-        public void negative_zero_greater_than_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task negative_zero_greater_than_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 -0.0 > 0.0
             ";
@@ -309,9 +323,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(false, output);
         }
 
-        [Fact]
-        public void zero_less_than_or_equals_negative_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task zero_less_than_or_equals_negative_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 0.0 <= -0.0
             ";
@@ -321,9 +338,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(true, output);
         }
 
-        [Fact]
-        public void negative_zero_less_than_or_equals_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task negative_zero_less_than_or_equals_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 -0.0 <= 0.0
             ";
@@ -333,9 +353,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(true, output);
         }
 
-        [Fact]
-        public void zero_greater_than_or_equals_negative_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task zero_greater_than_or_equals_negative_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 0.0 >= -0.0
             ";
@@ -345,9 +368,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(true, output);
         }
 
-        [Fact]
-        public void negative_zero_greater_than_or_equals_zero_is_false()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task negative_zero_greater_than_or_equals_zero_is_false(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 -0.0 >= 0.0
             ";

--- a/src/Perlang.Tests.Integration/Operator/Division.cs
+++ b/src/Perlang.Tests.Integration/Operator/Division.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -25,9 +27,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(4, result);
         }
 
-        [Fact]
-        public void dividing_doubles_returns_double()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task dividing_doubles_returns_double(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 24.68 / 12.34
             ";

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -86,9 +88,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(new BigInteger(59049), result);
         }
 
-        [Fact]
-        public void exponential_integer_and_float_literals()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task exponential_integer_and_float_literals(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 10 ** 3.5
             ";
@@ -98,9 +103,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(3162.2776601683795, result);
         }
 
-        [Fact]
-        public void exponential_integer_and_float_literals_infers_to_expected_type()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task exponential_integer_and_float_literals_infers_to_expected_type(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 var v = 10 ** 3.5;
                 print v.get_type();
@@ -111,9 +119,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal("System.Double", result);
         }
 
-        [Fact]
-        public void exponential_integer_and_negative_float_literals()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task exponential_integer_and_negative_float_literals(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 10 ** -3.5
             ";
@@ -174,10 +185,14 @@ namespace Perlang.Tests.Integration.Operator
         }
 
         [Theory]
-        [InlineData("2", "12", "4096")]
-        [InlineData("10", "3.5", "3162.2776601683795")]
-        public void exponential_integer_literals_as_variable_initializer(string left, string right, string expectedResult)
+        [InlineData("2", "12", "4096", "sv-SE")]
+        [InlineData("2", "12", "4096", "en-US")]
+        [InlineData("10", "3.5", "3162.2776601683795", "sv-SE")]
+        [InlineData("10", "3.5", "3162.2776601683795", "en-US")]
+        public async Task exponential_integer_literals_as_variable_initializer(string left, string right, string expectedResult, string cultureName)
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
             string source = $@"
                 var x = {left} ** {right};
                 print x;

--- a/src/Perlang.Tests.Integration/Operator/Modulo.cs
+++ b/src/Perlang.Tests.Integration/Operator/Modulo.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -25,9 +27,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(2, result);
         }
 
-        [Fact]
-        public void modulo_operation_on_doubles_returns_double()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task modulo_operation_on_doubles_returns_double(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 12.34 % 0.3
             ";
@@ -38,9 +43,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(0.04000000000000031, result);
         }
 
-        [Fact]
-        public void modulo_operation_combined_with_others_without_grouping()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task modulo_operation_combined_with_others_without_grouping(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 2 * 5 / 10 * 4 % 2.1
             ";
@@ -50,9 +58,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(1.9, result);
         }
 
-        [Fact]
-        public void modulo_operation_combined_with_others_with_grouping_first_operators()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task modulo_operation_combined_with_others_with_grouping_first_operators(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 (2 * 5 / 10 * 4) % 2.1
             ";
@@ -62,9 +73,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(1.9, result);
         }
 
-        [Fact]
-        public void modulo_operation_combined_with_others_with_grouping_last_operators()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task modulo_operation_combined_with_others_with_grouping_last_operators(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 2 * 5 / 10 * (4 % 2.1)
             ";

--- a/src/Perlang.Tests.Integration/Operator/Multiplication.cs
+++ b/src/Perlang.Tests.Integration/Operator/Multiplication.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -25,9 +27,12 @@ namespace Perlang.Tests.Integration.Operator
             Assert.Equal(15, result);
         }
 
-        [Fact]
-        public void multiplying_doubles_returns_double()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task multiplying_doubles_returns_double(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 12.34 * 0.3
             ";

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -10,9 +12,12 @@ namespace Perlang.Tests.Integration.Operator
         // "Positive" tests, testing for supported behavior
         //
 
-        [Fact]
-        public void decrementing_defined_variable()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task decrementing_defined_variable(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 var i = 0;
                 i--;
@@ -25,12 +30,18 @@ namespace Perlang.Tests.Integration.Operator
         }
 
         [Theory]
-        [InlineData("int", "1", "System.Int32")]
-        [InlineData("long", "4294967296", "System.Int64")]
-        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger")]
-        [InlineData("double", "4294967296.123", "System.Double")]
-        public void decrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
+        [InlineData("int", "1", "System.Int32", "en-US")]
+        [InlineData("int", "1", "System.Int32", "sv-SE")]
+        [InlineData("long", "4294967296", "System.Int64", "en-US")]
+        [InlineData("long", "4294967296", "System.Int64", "sv-SE")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger", "en-US")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger", "sv-SE")]
+        [InlineData("double", "4294967296.123", "System.Double", "en-US")]
+        [InlineData("double", "4294967296.123", "System.Double", "sv-SE")]
+        public async Task decrementing_variable_retains_expected_type(string type, string before, string expectedClrType, string cultureName)
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
             string source = $@"
                 var i: {type} = {before};
                 i--;

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -11,12 +13,18 @@ namespace Perlang.Tests.Integration.Operator
         //
 
         [Theory]
-        [InlineData("int", "0", "1")]
-        [InlineData("long", "4294967296", "4294967297")]
-        [InlineData("bigint", "1267650600228229401496703205376", "1267650600228229401496703205377")]
-        [InlineData("double", "4294967296.123", "4294967297.123")]
-        public void incrementing_variable_assigns_expected_value(string type, string before, string after)
+        [InlineData("int", "0", "1", "en-US")]
+        [InlineData("int", "0", "1", "sv-SE")]
+        [InlineData("long", "4294967296", "4294967297", "en-US")]
+        [InlineData("long", "4294967296", "4294967297", "sv-SE")]
+        [InlineData("bigint", "1267650600228229401496703205376", "1267650600228229401496703205377", "en-US")]
+        [InlineData("bigint", "1267650600228229401496703205376", "1267650600228229401496703205377", "sv-SE")]
+        [InlineData("double", "4294967296.123", "4294967297.123", "en-US")]
+        [InlineData("double", "4294967296.123", "4294967297.123", "sv-SE")]
+        public async Task incrementing_variable_assigns_expected_value(string type, string before, string after, string cultureName)
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
             string source = $@"
                 var i: {type} = {before};
                 i++;
@@ -29,12 +37,18 @@ namespace Perlang.Tests.Integration.Operator
         }
 
         [Theory]
-        [InlineData("int", "0", "System.Int32")]
-        [InlineData("long", "4294967296", "System.Int64")]
-        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger")]
-        [InlineData("double", "4294967296.123", "System.Double")]
-        public void incrementing_variable_retains_expected_type(string type, string before, string expectedClrType)
+        [InlineData("int", "0", "System.Int32", "en-US")]
+        [InlineData("int", "0", "System.Int32", "sv-SE")]
+        [InlineData("long", "4294967296", "System.Int64", "en-US")]
+        [InlineData("long", "4294967296", "System.Int64", "sv-SE")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger", "en-US")]
+        [InlineData("bigint", "1267650600228229401496703205376", "System.Numerics.BigInteger", "sv-SE")]
+        [InlineData("double", "4294967296.123", "System.Double", "en-US")]
+        [InlineData("double", "4294967296.123", "System.Double", "sv-SE")]
+        public async Task incrementing_variable_retains_expected_type(string type, string before, string expectedClrType, string cultureName)
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
             string source = $@"
                 var i: {type} = {before};
                 i++;

--- a/src/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
+++ b/src/Perlang.Tests.Integration/Operator/SubtractionAssignment.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -8,9 +10,12 @@ namespace Perlang.Tests.Integration.Operator
     {
         // "Positive" tests, testing for supported behavior
 
-        [Fact]
-        public void subtraction_assignment_defined_variable()
+        [Theory]
+        [ClassData(typeof(TestCultures))]
+        public async Task subtraction_assignment_defined_variable(CultureInfo cultureInfo)
         {
+            CultureInfo.CurrentCulture = cultureInfo;
+
             string source = @"
                 var i = 0;
                 i -= 1;

--- a/src/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
+++ b/src/Perlang.Tests.Integration/Perlang.Tests.Integration.csproj
@@ -7,11 +7,11 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Tests.Integration.xml</DocumentationFile>
         <WarningsAsErrors>;NU1605;NS1004</WarningsAsErrors>
-      <NoWarn>SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
+      <NoWarn>CS1998;SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <NoWarn>SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
+      <NoWarn>CS1998;SA1116;SA1117;SA1300;SA1401;S3881;S3887;1591;1701;1702</NoWarn>
       <DocumentationFile>bin\Release\Perlang.Tests.Integration.xml</DocumentationFile>
     </PropertyGroup>
 

--- a/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
@@ -145,7 +145,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         public void reserved_keyword_float_cannot_be_used_as_variable_name()
         {
             string source = @"
-                var float = 123.45;
+                var float = 123;
             ";
 
             var result = EvalWithParseErrorCatch(source);
@@ -160,7 +160,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         public void reserved_keyword_double_cannot_be_used_as_variable_name()
         {
             string source = @"
-                var double = 123.45;
+                var double = 123;
             ";
 
             var result = EvalWithParseErrorCatch(source);
@@ -357,7 +357,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): byte {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -373,7 +373,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): sbyte {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -389,7 +389,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): short {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -405,7 +405,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): ushort {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -421,7 +421,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): uint {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -437,7 +437,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): ulong {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -453,7 +453,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): float {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -469,7 +469,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): decimal {
-                    return 123.45;
+                    return 123;
                 }
             ";
 
@@ -485,7 +485,7 @@ namespace Perlang.Tests.Integration.ReservedKeywords
         {
             string source = @"
                 fun foo(): char {
-                    return 123.45;
+                    return 123;
                 }
             ";
 

--- a/src/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
+++ b/src/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
@@ -39,12 +39,12 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_decode_with_a_numeric_argument_throws_the_expected_exception()
         {
-            var result = EvalWithValidationErrorCatch("Base64.decode(123.45)");
+            var result = EvalWithValidationErrorCatch("Base64.decode(123)");
             var runtimeError = result.Errors.First();
 
             Assert.Single(result.Errors);
 
-            Assert.Equal("Cannot pass double argument as string parameter to decode()", runtimeError.Message);
+            Assert.Equal("Cannot pass int argument as string parameter to decode()", runtimeError.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
+++ b/src/Perlang.Tests.Integration/Stdlib/Base64EncodeTests.cs
@@ -45,12 +45,12 @@ namespace Perlang.Tests.Integration.Stdlib
         [Fact]
         public void Base64_encode_with_a_numeric_argument_throws_the_expected_exception()
         {
-            var result = EvalWithValidationErrorCatch("Base64.encode(123.45)");
+            var result = EvalWithValidationErrorCatch("Base64.encode(123)");
             var runtimeError = result.Errors.First();
 
             Assert.Single(result.Errors);
 
-            Assert.Equal("Cannot pass double argument as string parameter to encode()", runtimeError.Message);
+            Assert.Equal("Cannot pass int argument as string parameter to encode()", runtimeError.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/TestCultures.cs
+++ b/src/Perlang.Tests.Integration/TestCultures.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Perlang.Tests.Integration
+{
+    public class TestCultures : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // A culture which uses 123.45 number format. Resembles the C locale in POSIX systems, which is the default
+            // unless a locale is explicitly specified. (See https://man7.org/linux/man-pages/man7/locale.7.html for
+            // more details)
+            yield return new object[] { CultureInfo.GetCultureInfo("en-US") };
+
+            // A culture which uses 123,45 number format.
+            yield return new object[] { CultureInfo.GetCultureInfo("sv-SE") };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
This provides an alternative approach to #262. Instead of running _the whole test suite_ on multiple locales, we run the particular tests which was seen to fail before #261 got merged, on those locales.

(For the curious ones, the way this was made was to make a temporary commit & branch on top of cdaed13, i.e. the parent commit of https://github.com/perlang-org/perlang/commit/b384c74bf20d7d0c9f42d94d6f8b0d97ebb7f370 / #261. That way, I could reproduce the previous failures quite easily to be able to tailor-fit these locale-specific changes by switching from `[Fact]` to `[Theory]`/data-driven tests for these test methods only.)

This does involve a certain cost in terms of more test code and slightly added complexity in that regard. The pros:

- _Slightly simpler CI config_
- _Potentially slightly faster CI_ (I haven't timed this, but we at least have 1 less job to run for each PR)
- _Can customize more as needed_. If we ever run into some edge cases which are only failing on a particular locale (God forbid), we could potentially add more parameterized tests for _that particular test only_, which could be useful.
