### PR TITLE
(interpreter) Support platform-specific global classes

### DIFF
--- a/src/Perlang.Common/Attributes/GlobalClassAttribute.cs
+++ b/src/Perlang.Common/Attributes/GlobalClassAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 
 namespace Perlang.Attributes
@@ -23,5 +24,22 @@ namespace Perlang.Attributes
         /// Gets or sets an optional custom name for the class. If not provided, the short-name of the class will be used.
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets a collection of all the platforms on which the class should be registered. If empty, the class should
+        /// be registered on all platforms.
+        /// </summary>
+        public IEnumerable<PlatformID> Platforms { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GlobalClassAttribute"/> class.
+        /// </summary>
+        /// <param name="platforms">An optional list of platform IDs for which the given global class should be
+        /// registered. If no platform IDs are provided, the global class is presumed to be platform-agnostic and
+        /// registered on all supported platforms.</param>
+        public GlobalClassAttribute(params PlatformID[] platforms)
+        {
+            Platforms = platforms;
+        }
     }
 }

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -124,7 +124,9 @@ namespace Perlang.Interpreter
                     Type = t,
                     ClassAttribute = t.GetCustomAttribute<GlobalClassAttribute>()
                 })
-                .Where(t => t.ClassAttribute != null);
+                .Where(t => t.ClassAttribute != null && (
+                    !t.ClassAttribute.Platforms.Any() || t.ClassAttribute.Platforms.Contains(Environment.OSVersion.Platform)
+                ));
 
             foreach (var globalClass in globalClassesQueryable)
             {


### PR DESCRIPTION
We will likely never get full POSIX support on Winodws; this is simply a fact that we'll have to live with. Different languages and runtimes take different approaches to this:

- Java and .NET try to abstract away the fact that operating systems   differ, to various degrees. Java sometimes takes this to rather absurd lengths, by even making it impossible to do simple things like calling  `getuid`. "Write once, run anywhere" definitely comes at a price.

- .NET have traditionally done it slightly differently, given that it   was originally very tied to Windows. Relying heavily on Windows-only APIs like GDI+ and DirectX was not a problem in this context. Now that .NET is cross-platform, things are indeed a bit different and perhaps moving slightly more towards Java (while still providing Windows-specifics _for apps that need it_).

Perlang is likely to land more close to the .NET position on this. I really like the idea of providing a `Posix` module/class, with things like `getgid`, `getuid`, `getpid` and so forth readily available. When we support imports, I even imagine being able to do something like `import Posix.*` or `import static Posix.*`, to be able to call these methods pretty much exactly the same as in C.

Imagine this for a moment. Something that "feels like C" (in a positive sense), but still can run in a managed context, even in interpreted mode, doesn't that sound pretty awesome to you? (Someone will probably soon start saying "you're reinventing Python, you know that?" to me soon; I will do my very best to not pay any attention to those voices at all. :grin:)