### PR TITLE
(consoleapp) Fix -Wno-error and script argument handling

### DIFF
--- a/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -361,7 +361,7 @@ namespace Perlang.Tests.ConsoleApp
                 );
             }
 
-            [Fact(DisplayName = "with -Wno-error=null-usage parameter: emits no warning on null assignment")]
+            [Fact(DisplayName = "with -Wno-error=null-usage parameter: emits warning on null assignment")]
             public void with_Wno_error_null_usage_parameter_emits_warning_on_null_assignment()
             {
                 Program.MainWithCustomConsole(new[] { "-Wno-error=null-usage", "-e", "var s: string; s = null;" }, testConsole);
@@ -373,7 +373,7 @@ namespace Perlang.Tests.ConsoleApp
                 StderrContent.Should().BeEmpty();
             }
 
-            [Fact(DisplayName = "with -Wno-error=null-usage parameter: emits no warning when initializing to null")]
+            [Fact(DisplayName = "with -Wno-error=null-usage parameter: emits warning when initializing to null")]
             public void with_Wno_error_null_usage_parameter_emits_warning_when_initializing_to_null()
             {
                 Program.MainWithCustomConsole(new[] { "-Wno-error=null-usage", "-e", "var s: string = null;" }, testConsole);
@@ -383,6 +383,34 @@ namespace Perlang.Tests.ConsoleApp
                 );
 
                 StderrContent.Should().BeEmpty();
+            }
+
+            [Fact(DisplayName = "with -Wno-error=null-usage parameter: emits warning for usage of null")]
+            public void with_no_error_null_usage_parameter_emits_warning_for_usage_of_null()
+            {
+                int exitCode = Program.MainWithCustomConsole(new[] { "-Wno-error", "null-usage", "test/fixtures/null_usage.per" }, testConsole);
+
+                StderrContent.Should().BeEmpty();
+
+                StdoutContent.Should().Contain(
+                    "Initializing variable to null detected"
+                );
+
+                exitCode.Should().Be(0);
+            }
+
+            [Fact(DisplayName = "with -Wno-error=null-usage parameter: can be combined with script argument")]
+            public void with_no_error_null_usage_parameter_can_be_combined_with_script_argument()
+            {
+                int exitCode = Program.MainWithCustomConsole(new[] { "-Wno-error", "null-usage", "test/fixtures/argv_pop.per", "hello, world" }, testConsole);
+
+                StderrContent.Should().BeEmpty();
+
+                StdoutContent.Should().Contain(
+                    "hello, world"
+                );
+
+                exitCode.Should().Be(0);
             }
 
             [Fact]

--- a/src/Perlang.Tests/Perlang.Tests.csproj
+++ b/src/Perlang.Tests/Perlang.Tests.csproj
@@ -49,6 +49,10 @@
       <Content Include="test\fixtures\argv_pop.per">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <None Remove="test\fixtures\null_usage.per" />
+      <Content Include="test\fixtures\null_usage.per">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>

--- a/src/Perlang.Tests/test/fixtures/null_usage.per
+++ b/src/Perlang.Tests/test/fixtures/null_usage.per
@@ -1,0 +1,3 @@
+// Should fail if executed without any special -Wno-error flags; should only emit a warning when -Wno-error=null-usage
+// is provided.
+var s: string = null;


### PR DESCRIPTION
This was broken in multiple ways:

- `perlang -Wno-error null-usage src/Perlang.Tests/test/fixtures/null_usage.per`   would give you `Error: File -Wno-error not found`

- Even after fixing the above, `perlang -Wno-error null-usage src/Perlang.Tests/test/fixtures/argv_pop.per hello, world`  would pass `null-usage` as the parameter to the script

This commit fixes both of the above issues.