### PR TITLE
(interpreter) Fix invalid line numbers in warning and runtime errors

### DIFF
--- a/src/Perlang.Common/Expr.cs
+++ b/src/Perlang.Common/Expr.cs
@@ -112,6 +112,7 @@ namespace Perlang
         public class Call : Expr, ITokenAware
         {
             public Expr Callee { get; }
+            public ITokenAware TokenAwareCallee => (ITokenAware)Callee;
             public Token Paren { get; }
             public List<Expr> Arguments { get; }
 
@@ -136,6 +137,15 @@ namespace Perlang
 
             public Call(Expr callee, Token paren, List<Expr> arguments)
             {
+                // TODO: This would much more rightfully be a compile-time check. This is hard to achieve though, but we
+                // might be able to make it somewhat better by introducing a TokenAwareExpr of some form (see also
+                // #189). What is challenging here though is that the PerlangParser.Call() method is inherently dynamic
+                // in nature (given that Primary() can return any kind of Expr). #189 will remove the need for this.
+                if (callee is not ITokenAware)
+                {
+                    throw new ArgumentException("callee must be ITokenAware");
+                }
+
                 Callee = callee;
                 Paren = paren;
                 Arguments = arguments;

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -1834,7 +1834,8 @@ namespace Perlang.Interpreter
                     }
                     else
                     {
-                        // TODO: "Operands must be numbers" isn't completely correct here.
+                        // TODO: "Operands must be numbers" isn't completely correct here. The operands may very well
+                        // _be_ valid numbers, but just not an accepted combination of number types.
                         throw new RuntimeError(expr.Operator, $"Operands must be numbers, not {StringifyType(left)} and {StringifyType(right)}");
                     }
 
@@ -1868,6 +1869,12 @@ namespace Perlang.Interpreter
                     try
                     {
                         return callable.Call(this, arguments);
+                    }
+                    catch (RuntimeError)
+                    {
+                        // This kind of exception already has the most-adjacent token available in it already, to
+                        // provide the approximate source location in the error message.
+                        throw;
                     }
                     catch (Exception e)
                     {

--- a/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
@@ -201,7 +201,7 @@ namespace Perlang.Interpreter.Typing
 
                 if (argument.TypeReference.IsNullObject)
                 {
-                    compilerWarningCallback(new CompilerWarning("Null parameter detected", parameter.Name, WarningType.NULL_USAGE));
+                    compilerWarningCallback(new CompilerWarning($"Null parameter detected for '{parameter.Name.Lexeme}'", expr.TokenAwareCallee.Token, WarningType.NULL_USAGE));
                 }
 
                 // FIXME: expr.Token is an approximation here as well (see other similar comments in this file)

--- a/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -399,6 +399,24 @@ namespace Perlang.Tests.ConsoleApp
                 exitCode.Should().Be(0);
             }
 
+            [Fact]
+            public void with_no_error_null_usage_parameter_includes_correct_line_numbers_in_errors()
+            {
+                int exitCode = Program.MainWithCustomConsole(new[] { "-Wno-error", "null-usage", "test/fixtures/defining-and-calling-a-function-with-null-parameter.per" }, testConsole);
+
+                StderrContent.Should().BeEmpty();
+
+                // There used to be a bug with the reporting of both of these warnings and errors, where the line number
+                // was messed up (#276)
+                StdoutLines.Should().Contain(
+                        "[line 6] Warning at 'greet': Null parameter detected for 'name'")
+                    .And.Contain(
+                        "[line 2] Operands must be numbers, not string and null"
+                    );
+
+                exitCode.Should().Be((int)Program.ExitCodes.RUNTIME_ERROR);
+            }
+
             [Fact(DisplayName = "with -Wno-error=null-usage parameter: can be combined with script argument")]
             public void with_no_error_null_usage_parameter_can_be_combined_with_script_argument()
             {

--- a/src/Perlang.Tests/Perlang.Tests.csproj
+++ b/src/Perlang.Tests/Perlang.Tests.csproj
@@ -53,6 +53,10 @@
       <Content Include="test\fixtures\null_usage.per">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <None Remove="test\fixtures\defining-and-calling-a-function-with-null-parameter.per" />
+      <Content Include="test\fixtures\defining-and-calling-a-function-with-null-parameter.per">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>

--- a/src/Perlang.Tests/test/fixtures/defining-and-calling-a-function-with-null-parameter.per
+++ b/src/Perlang.Tests/test/fixtures/defining-and-calling-a-function-with-null-parameter.per
@@ -1,0 +1,6 @@
+fun greet(name: string, age: int): void {
+  print "Hello " + name + ". Your age is " + age;
+}
+
+// Expected warning: [line 6] Warning at 'name': Null parameter detected
+greet(null, 42);


### PR DESCRIPTION
The incorrect token was being used to produce the warning/`RuntimeError` instances in both of these cases, leading to invalid line numbers being displayed to the user.

Fixes #276.