### PR TITLE
(consoleapp) Fix exception in mintty-based shells on Windows

### DIFF
--- a/docs/download/index.md
+++ b/docs/download/index.md
@@ -20,10 +20,6 @@ If you have a previous build installed and want to overwrite it, use the followi
 <pre><code class="lang-shell hljs"><span class="hljs-meta">$ </span><span class="bash">curl -sSL https://perlang.org/install.sh | sh -s -- --force</span>
 </code></pre>
 
-**Note**: If you are running the installer in Git Bash on Windows, running `perlang` after installation will unfortunately not work in the Bash shell (because of limitations preventing us from reading individual keystrokes in Git Bash). Please close the `bash` session after installation and open a plain `cmd` shell instead (Command Prompt on the Start menu). In that shell, `cd %userprofile%\.perlang\nightly\bin`. You should then be able to run `perlang` to open up the Perlang REPL.
-
-For more details about this bug, please see https://github.com/perlang-org/perlang/issues/107.
-
 ## Video tutorial
 
 For those of you who prefer to learn by watching videos, here's a short screencast (courtesy of [Asciinema](https://asciinema.org/)) which shows what the installer looks like when you run it:


### PR DESCRIPTION
I had thought about this for some day(s), and decided to give it a look. The fact that `winpty` exists surely makes this a whole lot easier to "fix", even though it's a bit of a workaround. It does make Perlang much more accessible for people who are locked inside their Windows, so that makes this a noteworthy fix. 😛 

Closes #107