### PR TITLE
(scripts) Change -dev tag to have v prefix

### DIFF
--- a/scripts/update_common_constants.rb
+++ b/scripts/update_common_constants.rb
@@ -2,11 +2,11 @@
 
 SOLUTION_DIR = ARGV.pop or abort('Error: Solution directory must be provided')
 
-# Need to take -dev part out of e.g. 1.0.0-dev, since assembly versions must
-# adhere to the following format: major[.minor[.build[.revision]]]
-GIT_TAG_VERSION = `git describe --tags --abbrev=0 | sed s/-dev//`.rstrip
+# Need to take the v and -dev part out of e.g. v1.0.0-dev, since assembly
+# versions must adhere to the following format: major[.minor[.build[.revision]]]
+GIT_TAG_VERSION = `git describe --tags --abbrev=0 | sed s/v// | sed s/-dev//`.rstrip
 
-GIT_DESCRIBE_VERSION = `git describe --tags | sed s/-g.*$// | sed s/dev-/dev./`.rstrip
+GIT_DESCRIBE_VERSION = `git describe --tags | sed s/-g.*$// | sed s/v// | sed s/dev-/dev./`.rstrip
 GIT_COMMIT = `git describe --always`.rstrip
 
 common_constants = <<~EOF

--- a/src/Perlang.Stdlib/Stdlib/Libc.cs
+++ b/src/Perlang.Stdlib/Stdlib/Libc.cs
@@ -168,7 +168,7 @@ namespace Perlang.Stdlib
         /// to use it for constructing temporary file names. However, this is _NOT_ recommended since it is not secure.
         /// In C, `mkstemp` can be used for this purpose. `mkstemp` is not yet available to use from Perlang, though.
         ///
-        /// <see cref="getpid">getpid()</see> conform to ISO/IEC 9945-1:1990 (`POSIX.1`).
+        /// <see cref="getpid">getpid()</see> conforms to ISO/IEC 9945-1:1990 (`POSIX.1`).
         /// </summary>
         /// <returns>The process ID of the calling process.</returns>
         /// <seealso cref="Posix.getppid"/>


### PR DESCRIPTION
This is a preparational step for making the 0.1.0 release. Upon careful consideration and taking e.g. [this SO thread](https://stackoverflow.com/questions/21639437/git-flow-release-branches-and-tags-with-or-without-v-prefix) into consideration, I've decided to name the 0.1.0 tag `v0.1.0`. The argument about being able to tab-complete them, and also differentiate between e.g. `0.1` release branches easily, does make a certain bit of sense.

Doing this requires some changes in the way we generate the `src/Perlang.Common/CommonConstants.Generated.cs` file though, which is covered by this PR.