### PR TITLE
(scripts) Change dev tag format again

### DIFF
--- a/scripts/update_common_constants.rb
+++ b/scripts/update_common_constants.rb
@@ -2,11 +2,15 @@
 
 SOLUTION_DIR = ARGV.pop or abort('Error: Solution directory must be provided')
 
-# Need to take the v and -dev part out of e.g. v1.0.0-dev, since assembly
-# versions must adhere to the following format: major[.minor[.build[.revision]]]
-GIT_TAG_VERSION = `git describe --tags --abbrev=0 | sed s/v// | sed s/-dev//`.rstrip
+# Need to take the dev/ part out of e.g. dev/0.1.0, since assembly versions must
+# adhere to the following format: major[.minor[.build[.revision]]]
+GIT_TAG_VERSION = `git describe --tags --abbrev=0 | sed s%^dev/%%`.rstrip
 
-GIT_DESCRIBE_VERSION = `git describe --tags | sed s/-g.*$// | sed s/v// | sed s/dev-/dev./`.rstrip
+# The input to these sed operations is something like `dev/0.1.0-224-g09f4704`.
+# The output is expected to produce a SemVer-compliant version number. For
+# snapshots, it will be something like 0.1.0-dev.224
+GIT_DESCRIBE_VERSION = `git describe --tags | sed s%^dev/%% | sed s/-g.*$// | sed -E "s/-([0-9]*)$/-dev.\\1/"`.rstrip
+
 GIT_COMMIT = `git describe --always`.rstrip
 
 common_constants = <<~EOF


### PR DESCRIPTION
Upon careful consideration (well, thinking about it for half a day since #282 got merged this morning...), I decided to switch the tag format for `dev` tags once more. Instead of `v0.1.0-dev`, I want something that:

- Is unambiguous so you can `git checkout v<TAB>` without seeing any `dev` version tags.
- Is also unambiguous compared to any release branches. While it's not yet decided what these would be called, it could be either `0.1` or `0.1.x`, or something like `rel/0.1` or `release/0.1`. Either way, I would _not_ want the dev tags to be just `0.1.0-dev` again.

How about using another prefix for them? That makes them nicely grouped in tab completion etc. Said and done, let's go with `dev/0.1.0` for now.