### PR TITLE
(consoleapp) Remove winpty hack

### DIFF
--- a/src/Perlang.ConsoleApp/Program.cs
+++ b/src/Perlang.ConsoleApp/Program.cs
@@ -205,7 +205,7 @@ namespace Perlang.ConsoleApp
                             replMode: true,
                             standardOutputHandler: console.Out.WriteLine,
                             disabledWarningsAsErrors: disabledWarningsAsErrorsList
-                        ).RunPrompt(args);
+                        ).RunPrompt();
 
                         return Task.FromResult(0);
                     }
@@ -332,20 +332,8 @@ namespace Perlang.ConsoleApp
             return (int)ExitCodes.SUCCESS;
         }
 
-#pragma warning disable S1172 // Remove this unused method parameter 'args'.
-        private void RunPrompt(string[] args)
+        private void RunPrompt()
         {
-#if _WINDOWS
-            if (Console.IsInputRedirected)
-            {
-                Console.WriteLine("Input redirection detected, relaunching with winpty");
-                var process = Process.Start("winpty", Environment.ProcessPath! + String.Join(' ', args));
-                process!.WaitForExit();
-
-                return;
-            }
-#endif
-
             PrintBanner();
             ReadLine.HistoryEnabled = true;
             ReadLine.AutoCompletionHandler = new AutoCompletionHandler();
@@ -370,7 +358,6 @@ namespace Perlang.ConsoleApp
                 Run(command, CompilerWarningAsWarning);
             }
         }
-#pragma warning restore S1172
 
         private void ShowHelp()
         {


### PR DESCRIPTION
@mintty [pointed out](https://github.com/rprichard/winpty/issues/140#issuecomment-1046641874) that running things through winpty shouldn't be needed any more. It's much better to just rely on ConPTY (part of the new terminal functionality introduced in recent versions of Windows which provides more Unix-resembling semantics).

We should perhaps update the docs/website a bit to mention that "experimental support for pseudo consoles" should be enabled when running Perlang or Windows. Or perhaps just recommend running Git Bash in Windows Terminal altogether, since it's probably the most reasonable way to get Perlang installed on Windows right now.

Related issue: #285 