### PR TITLE
(scripts) Handle tag `v`-prefix

### DIFF
--- a/.github/workflows/publish-release-packages.yml
+++ b/.github/workflows/publish-release-packages.yml
@@ -34,12 +34,8 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Get version from tag
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Create CommonConstants file
-        run: scripts/update_common_constants.rb $(echo ${{ steps.get_version.outputs.VERSION }} | sed s/^v//)
+      - name: Re-generate auto-generated files
+        run: make auto-generated
 
       #
       # Build releases
@@ -88,7 +84,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
-          draft: true # TODO: remove when done
           prerelease: true
           body_path: release-notes/${{ steps.get_version.outputs.VERSION }}.md
           files: "*-release/*.tar.gz"

--- a/scripts/update_common_constants.rb
+++ b/scripts/update_common_constants.rb
@@ -7,11 +7,13 @@ CUSTOM_VERSION = ARGV.pop
 # Need to take the dev/ part out of e.g. dev/0.1.0, since assembly versions must
 # adhere to the following format: major[.minor[.build[.revision]]]
 GIT_TAG_VERSION = CUSTOM_VERSION || `git describe --tags --abbrev=0 | sed s%^dev/%%`.rstrip
+GIT_TAG_VERSION.sub!(%r{^v}, '')
 
 # The input to these sed operations is something like `dev/0.1.0-224-g09f4704`.
 # The output is expected to produce a SemVer-compliant version number. For
 # snapshots, it will be something like 0.1.0-dev.224
 GIT_DESCRIBE_VERSION = CUSTOM_VERSION || `git describe --tags | sed s%^dev/%% | sed s/-g.*$// | sed -E "s/-([0-9]*)$/-dev.\\1/"`.rstrip
+GIT_DESCRIBE_VERSION.sub!(%r{^v}, '')
 
 GIT_COMMIT = `git describe --always`.rstrip
 


### PR DESCRIPTION
Since our SemVer tags are named things like `v0.1.0`, git describe will in these cases return a value with a `v`-prefix. This change makes the script generate valid Assembly Versions (`x.y.z`) in such scenarios, which would otherwise cause the build to fail.

Related issue: #287.