### PR TITLE
(interpreter) Allow assignment from `int` to `double`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ NEXT_RELEASE_TAG=v$(NEXT_RELEASE_VERSION)
 
 prepare-new-dev-version:
 	git tag dev/$(NEXT_RELEASE_VERSION) && git push origin dev/$(NEXT_RELEASE_VERSION)
+	touch release-notes/$(NEXT_RELEASE_TAG).md
 
 publish-release:
 	echo $(NEXT_RELEASE_TAG) > .metadata/latest-release.txt

--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -1,0 +1,9 @@
+## [0.2.0] - Unreleased
+
+### Addded
+- Allow assignment from `int` to `double` [[#300][300]]
+
+### Changed
+- This release does not contain any breaking changes.
+
+[300]: https://github.com/perlang-org/perlang/pull/300

--- a/src/Perlang.ConsoleApp/Program.cs
+++ b/src/Perlang.ConsoleApp/Program.cs
@@ -377,7 +377,7 @@ namespace Perlang.ConsoleApp
 
             standardOutputHandler(
                 "For more information on the Perlang language, please consult this web page:\n" +
-                "https://perlang.org/learn. Thanks for your interest in the project! 🙏"
+                "https://perlang.org/learn. Thank you for your interest in the project! 🙏"
             );
             standardOutputHandler(String.Empty);
         }

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -16,6 +16,9 @@ namespace Perlang.Interpreter.Typing
             { typeof(Int32), 32 },
             { typeof(Int64), 64 },
 
+            // Double-precision values are 64-bit but can only save 53-bit integers with exact precision
+            { typeof(Double), 32 },
+
             // In practice, even larger numbers should be possible. For the time being, I think it's quite fine if
             // bigints in Perlang are limited to 2 billion digits. :)
             { typeof(BigInteger), Int32.MaxValue }
@@ -81,9 +84,9 @@ namespace Perlang.Interpreter.Typing
                 return false;
             }
 
-            // Expansions are fine; in other words, as long as the target type is wider (number of bits) than the source
-            // type, the conversion will always work.
-            if (targetSize > sourceSize)
+            // Expansions are fine; in other words, as long as the target type is wider (number of bits) or than or
+            // equal to the source type, the conversion will always work.
+            if (targetSize >= sourceSize)
             {
                 return true;
             }

--- a/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
@@ -1,0 +1,100 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Typing;
+
+public class DoubleTests
+{
+    [Fact]
+    public void double_variable_can_be_printed()
+    {
+        string source = @"
+                var d: double = 103.1;
+
+                print(d);
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        Assert.Equal("103.1", output);
+    }
+
+    [Fact]
+    public void double_variable_can_be_reassigned()
+    {
+        string source = @"
+                var d: double = 103;
+                d = 104;
+
+                print(d);
+            ";
+
+        var result = EvalReturningOutputString(source);
+
+        Assert.Equal("104", result);
+    }
+
+    [Fact]
+    public void double_variable_throws_expected_exception_on_constant_overflow()
+    {
+        // 64-bit integers cannot be reliably stored in a double, since IEEE 754 double-precision floating point only
+        // represent exactly the range -2^53 to 2^53. More details:
+        // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values
+        string source = @"
+                var d: double = 1231231230912839019312831232;
+            ";
+
+        var result = EvalWithValidationErrorCatch(source);
+        var exception = result.Errors.First();
+
+        Assert.Single(result.Errors);
+        Assert.Matches("Cannot assign bigint to double variable", exception.Message);
+    }
+
+    [Fact]
+    public void double_variable_has_expected_type_when_initialized_to_8bit_value()
+    {
+        // An 8-bit integer (sbyte) should be expanded to 64-bit when the assignment target is of the 'long' type.
+        string source = @"
+                var d: double = 103;
+
+                print(d.get_type());
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        Assert.Equal("System.Double", output);
+    }
+
+    [Fact]
+    public void double_variable_has_expected_type_when_assigned_8bit_value_from_another_variable()
+    {
+        // An 8-bit integer (sbyte) should be expanded to 64-bit when the assignment target is of the 'long' type.
+        string source = @"
+                var d: double = 103;
+                var e = d;
+
+                print(e.get_type());
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        Assert.Equal("System.Double", output);
+    }
+
+    // The value becomes a uint in this case, but uints are not fully supported in the language yet.
+    [Fact(Skip = "Pending https://github.com/perlang-org/perlang/issues/70")]
+    public void double_variable_has_expected_type_for_large_value()
+    {
+        string source = @"
+                var d: double = 2147483647;
+
+                print(d.get_type());
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        Assert.Equal("System.Double", output);
+    }
+}

--- a/src/Perlang.Tests.Integration/Typing/LongTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/LongTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
@@ -53,7 +54,7 @@ namespace Perlang.Tests.Integration.Typing
         }
 
         [Fact]
-        public void long_variable_throws_expected_exception_on_overflow()
+        public void long_variable_throws_expected_exception_on_constant_overflow()
         {
             string source = @"
                 var l: long = 1231231230912839019312831232;


### PR DESCRIPTION
Because of how IEEE 754 floating point works, all values up to 53-bit integers can be exactly represented in a `double` (note, this does _not_ hold true for single-precision floating point values which can only safely store 24-bit integers).