### PR TITLE
(solution) Upgrade SonarAnalyzer.CSharp

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="all" />
         <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
 
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.29.0.36737" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.1.44192" />
     </ItemGroup>
 
     <!--

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # to force it to be regenerated.
 .PHONY: \
 	all auto-generated clean darkerfx-push docs docs-serve docs-test-examples \
-	install install-latest-snapshot publish-release release run \
+	install install-latest-snapshot publish-release release run test \
 	src/Perlang.Common/CommonConstants.Generated.cs
 
 RELEASE_PERLANG=src/Perlang.ConsoleApp/bin/Release/net6.0/linux-x64/publish/perlang

--- a/global.ruleset
+++ b/global.ruleset
@@ -38,6 +38,8 @@
         <Rule Id="S125" Action="None"/>
         <Rule Id="S1134" Action="None"/>
         <Rule Id="S1135" Action="None"/>
+        <Rule Id="S3260" Action="None"/>        <!-- Private classes or records which are not derived in the current assembly should be marked as 'sealed' -->
+        <Rule Id="S3267" Action="None"/>        <!-- Loops should be simplified with "LINQ" expressions -->
         <Rule Id="S3376" Action="None"/>
         <Rule Id="S3925" Action="None"/>
     </Rules>


### PR DESCRIPTION
This brings in support for file-scoped namespaces, supported in .NET 6: https://github.com/SonarSource/sonar-dotnet/issues/4731

Required for #300 to build successfully.