### PR TITLE
(parser) Fix broken support for certain negative integer literals

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -6,4 +6,8 @@
 ### Changed
 - This release does not contain any breaking changes.
 
+### Fixed
+- Fix broken support for certain negative integer literals. [[#302][302]]
+
 [300]: https://github.com/perlang-org/perlang/pull/300
+[302]: https://github.com/perlang-org/perlang/issues/302

--- a/src/Perlang.Common/NumericToken.cs
+++ b/src/Perlang.Common/NumericToken.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+
+namespace Perlang;
+
+public class NumericToken : Token
+{
+    public bool IsFractional { get; }
+    public Base NumberBase { get; }
+    public NumberStyles NumberStyles { get; }
+
+    public NumericToken(string lexeme, int line, string numberCharacters, bool isFractional, Base numberBase, NumberStyles numberStyles)
+        : base(TokenType.NUMBER, lexeme, numberCharacters, line)
+    {
+        IsFractional = isFractional;
+        NumberBase = numberBase;
+        NumberStyles = numberStyles;
+    }
+
+    public enum Base
+    {
+        BINARY = 2,
+        OCTAL = 8,
+        DECIMAL = 10,
+        HEXADECIMAL = 16,
+    }
+}

--- a/src/Perlang.Parser/NumberParser.cs
+++ b/src/Perlang.Parser/NumberParser.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+using Perlang.Extensions;
+
+#nullable enable
+namespace Perlang.Parser;
+
+internal static class NumberParser
+{
+    public static object Parse(NumericToken numericToken)
+    {
+        string numberCharacters = (string)numericToken.Literal!;
+
+        if (numericToken.IsFractional)
+        {
+            // TODO: This is a mess. We currently treat all floating point values as _double_, which is insane. We
+            // TODO: should probably have a "use smallest possible type" logic as below for integers, for floating point
+            // TODO: values as well. We could also consider supporting `decimal` while we're at it.
+
+            // The explicit IFormatProvider is required to ensure we use 123.45 format, regardless of host OS
+            // language/region settings. See #263 for more details.
+            return Double.Parse(numberCharacters, CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            // Any potential preceding '-' character has already been taken care of at this stage => we can treat
+            // the number as an unsigned value. However, we still try to coerce it to the smallest signed or
+            // unsigned integer type in which it will fit (but never smaller than 32-bit). This coincidentally
+            // follows the same semantics as how C# does it, for simplicity.
+
+            BigInteger value = numericToken.NumberBase switch
+            {
+                NumericToken.Base.DECIMAL =>
+                    BigInteger.Parse(numberCharacters, numericToken.NumberStyles),
+
+                NumericToken.Base.BINARY =>
+                    Convert.ToUInt64(numberCharacters, 2),
+
+                NumericToken.Base.OCTAL =>
+                    Convert.ToUInt64(numberCharacters, 8),
+
+                NumericToken.Base.HEXADECIMAL =>
+
+                    // Quoting from
+                    // https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger.parse?view=net-5.0#System_Numerics_BigInteger_Parse_System_ReadOnlySpan_System_Char__System_Globalization_NumberStyles_System_IFormatProvider_
+                    //
+                    // If value is a hexadecimal string, the Parse(String, NumberStyles) method interprets value as a
+                    // negative number stored by using two's complement representation if its first two hexadecimal
+                    // digits are greater than or equal to 0x80. In other words, the method interprets the highest-order
+                    // bit of the first byte in value as the sign bit. To make sure that a hexadecimal string is
+                    // correctly interpreted as a positive number, the first digit in value must have a value of zero.
+                    //
+                    // We presume that all hexadecimals should be treated as positive numbers for now.
+                    BigInteger.Parse('0' + numberCharacters, numericToken.NumberStyles),
+
+                _ =>
+                    throw new InvalidOperationException($"Base {(int)numericToken.NumberBase} not supported")
+            };
+
+            if (value <= Int32.MaxValue)
+            {
+                return (int)value;
+            }
+            else if (value <= UInt32.MaxValue)
+            {
+                return (uint)value;
+            }
+            else if (value <= Int64.MaxValue)
+            {
+                return (long)value;
+            }
+            else if (value <= UInt64.MaxValue)
+            {
+                return (ulong)value;
+            }
+            else // Anything else remains a BigInteger
+            {
+                return value;
+            }
+        }
+    }
+
+    public static object MakeNegative(object value)
+    {
+        if (value is double doubleValue)
+        {
+            return -doubleValue;
+        }
+        else if (value is int doubleInt)
+        {
+            return -doubleInt;
+        }
+        else if (value is uint doubleUint)
+        {
+            long negativeValue = -doubleUint;
+
+            // This is a special hack to ensure that the value -2147483648 gets returned as an `int` and not a `long`.
+            // Some details available in #302, summarized here in brief:
+            //
+            // The value 2147483648 is too large for an `int` => gets parsed into a `ulong` where it will fit. Once it
+            // has been made negative, the value -2147483648 is again small enough to fit in an `int` => the code below
+            // will narrow it down to comply with the "smallest type possible" design principle.
+            //
+            // Rationale: Two's complement: https://en.wikipedia.org/wiki/Two%27s_complement
+            if (negativeValue >= Int32.MinValue)
+            {
+                return (int)negativeValue;
+            }
+            else
+            {
+                return negativeValue;
+            }
+        }
+        else if (value is long longValue)
+        {
+            return -longValue;
+        }
+        else if (value is ulong ulongValue)
+        {
+            // Again, this needs to be handled specially to ensure that numbers that fit in a `long` doesn't use
+            // BigInteger unnecessarily.
+            BigInteger negativeValue = -new BigInteger(ulongValue);
+
+            if (negativeValue >= Int64.MinValue)
+            {
+                return (long)negativeValue;
+            }
+            else
+            {
+                // All negative numbers that are too big to fit in any of the smaller signed integer types will go
+                // through this code path.
+                return negativeValue;
+            }
+        }
+        else
+        {
+            throw new ArgumentException($"Type {value.GetType().ToTypeKeyword()} not supported");
+        }
+    }
+}

--- a/src/Perlang.Tests.Integration/Number/NumberTests.cs
+++ b/src/Perlang.Tests.Integration/Number/NumberTests.cs
@@ -1,12 +1,29 @@
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using Perlang.Tests.Integration.Typing;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Number
 {
-    // Based on https://github.com/munificent/craftinginterpreters/blob/master/test/number
+    /// <summary>
+    /// Based on https://github.com/munificent/craftinginterpreters/blob/master/test/number
+    ///
+    /// Note that not all number-related tests are located in this class. See the other related classes for more
+    /// specific tests for particular data types:
+    ///
+    /// <list type="bullet">
+    /// <item><description><see cref="BigintTests"/></description></item>
+    /// <item><description><see cref="DoubleTests"/></description></item>
+    /// <item><description><see cref="IntTests"/></description></item>
+    /// <item><description><see cref="LongTests"/></description></item>
+    /// </list>
+    ///
+    /// The rationale is basically this: Tests which specify explicit variable tests belong in the "specific" test
+    /// classes for that data type. Tests which exercise the "find the smallest suitable integer/floating-point type"
+    /// fit better in <see cref="NumberTests"/>.
+    /// </summary>
     public class NumberTests
     {
         [Fact]
@@ -95,6 +112,18 @@ namespace Perlang.Tests.Integration.Number
             object result = Eval(source);
 
             Assert.Equal(-123, result);
+        }
+
+        [Fact]
+        public void literal_negative_larger_integer()
+        {
+            string source = @"
+                -2147483648
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(-2147483648, result);
         }
 
         [Theory]

--- a/src/Perlang.Tests.Integration/Operator/Exponential.cs
+++ b/src/Perlang.Tests.Integration/Operator/Exponential.cs
@@ -7,13 +7,13 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator
 {
+    /// <summary>
+    /// Tests for the ** (exponential) operator. The operator works pretty much like in Ruby.
+    ///
+    /// The type of the returned value is varies depending on the input types.
+    /// </summary>
     public class Exponential
     {
-        //
-        // Tests for the ** (exponential) operator. The operator works pretty much like in Ruby. An interesting detail
-        // about it is that the returned value is a BigInteger, regardless of the size of the input operands. This
-        // may sometimes be impractical, but for simple/REPL scenarios it is still basically useful.
-        //
         [Fact]
         public void exponential_integer_literals()
         {

--- a/src/Perlang.Tests.Integration/Operator/PrefixNegation.cs
+++ b/src/Perlang.Tests.Integration/Operator/PrefixNegation.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.Operator;
+
+/// <summary>
+/// Tests for the unary prefix - (negation) operator.
+/// </summary>
+public class PrefixNegation
+{
+    [Fact]
+    public void negation_of_negative_int()
+    {
+        string source = @"
+                - -100
+            ";
+
+        object result = Eval(source);
+
+        result.Should()
+            .Be(100);
+    }
+
+    [Fact]
+    public void negation_of_positive_int()
+    {
+        // Note: there is a certain logic in the parsing of the unary prefix operator, converting "- 123" into a single
+        // literal expression. To ensure that this logic is circumvented, we add grouping parentheses.
+        string source = @"
+                -(123)
+            ";
+
+        object result = Eval(source);
+
+        result.Should()
+            .Be(-123);
+    }
+
+    [Fact]
+    public void negation_of_negative_int_without_space_throws_expected_error()
+    {
+        string source = @"
+                --100
+            ";
+
+        var result = EvalWithParseErrorCatch(source);
+
+        result.Errors.Should()
+            .ContainSingle().Which
+            .Message.Should().Contain("Expect expression");
+    }
+}


### PR DESCRIPTION
This commit changes the logic to do the parsing of numeric literals at parse-time instead of scan-time, where we have better access to the actual context of how the literal is being used. This makes it possible to avoid making expressions like "-100" be `Expr.UnaryPrefix` and instead be a simple `Expr.Literal` with the value of the expected type, even for the edge cases described in #302.

Fixes #302