### PR TITLE
(many) Refactor number parsing to use `*Literal` types

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -4,10 +4,11 @@
 - Allow assignment from `int` to `double` [[#300][300]]
 
 ### Changed
-- This release does not contain any breaking changes.
+- Refactor number parsing to use *Literal types [[#308][308]]
 
 ### Fixed
 - Fix broken support for certain negative integer literals. [[#302][302]]
 
 [300]: https://github.com/perlang-org/perlang/pull/300
 [302]: https://github.com/perlang-org/perlang/issues/302
+[308]: https://github.com/perlang-org/perlang/issues/308

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -610,6 +610,7 @@ namespace Perlang.Interpreter
                 }
                 catch (SystemException ex)
                 {
+                    // TODO: Include the original stack trace in the exception being thrown here, to simplify debugging.
                     throw new RuntimeError(null, ex.Message);
                 }
             }
@@ -617,7 +618,14 @@ namespace Perlang.Interpreter
 
         public object? VisitLiteralExpr(Expr.Literal expr)
         {
-            return expr.Value;
+            if (expr.Value is INumericLiteral parsedNumber)
+            {
+                return parsedNumber.Value;
+            }
+            else
+            {
+                return expr.Value;
+            }
         }
 
         public object VisitLogicalExpr(Expr.Logical expr)

--- a/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using Perlang.Extensions;
 using Perlang.Interpreter.NameResolution;
+using Perlang.Parser;
 
 namespace Perlang.Interpreter.Typing
 {
@@ -39,8 +40,14 @@ namespace Perlang.Interpreter.Typing
 
             var targetTypeReference = variableBinding.TypeReference;
             var sourceTypeReference = expr.Value.TypeReference;
+            long? sourceConstantValueSize = null;
 
-            if (!TypeCoercer.CanBeCoercedInto(targetTypeReference, sourceTypeReference))
+            if (expr.Value is Expr.Literal { Value: INumericLiteral parsedNumber })
+            {
+                sourceConstantValueSize = parsedNumber.BitsUsed;
+            }
+
+            if (!TypeCoercer.CanBeCoercedInto(targetTypeReference, sourceTypeReference, sourceConstantValueSize))
             {
                 TypeValidationErrorCallback(new TypeValidationError(
                     expr.Token,

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -40,10 +40,12 @@ namespace Perlang.Interpreter.Typing
         /// </summary>
         /// <param name="targetTypeReference">A reference to the target type.</param>
         /// <param name="sourceTypeReference">A reference to the source type.</param>
+        /// <param name="sourceConstantValueSize">If the source is a constant value (e.g. integer literal), this
+        /// parameter will contain the size of the constant (in bits).</param>
         /// <returns>`true` if a source value can be coerced into the target type, `false` otherwise.</returns>
-        public static bool CanBeCoercedInto(ITypeReference targetTypeReference, ITypeReference sourceTypeReference)
+        public static bool CanBeCoercedInto(ITypeReference targetTypeReference, ITypeReference sourceTypeReference, long? sourceConstantValueSize)
         {
-            return CanBeCoercedInto(targetTypeReference.ClrType, sourceTypeReference.ClrType);
+            return CanBeCoercedInto(targetTypeReference.ClrType, sourceTypeReference.ClrType, sourceConstantValueSize);
         }
 
         /// <summary>
@@ -58,13 +60,17 @@ namespace Perlang.Interpreter.Typing
         /// </summary>
         /// <param name="targetType">The target type.</param>
         /// <param name="sourceType">The source type.</param>
+        /// <param name="sourceConstantValueSize">If the source is a constant value (e.g. integer literal), this
+        /// parameter will contain the size of the constant (in bits).</param>
         /// <returns>`true` if a source value can be coerced into the target type, `false` otherwise.</returns>
-        public static bool CanBeCoercedInto(Type targetType, Type sourceType)
+        public static bool CanBeCoercedInto(Type targetType, Type sourceType, long? sourceConstantValueSize)
         {
             if (targetType == sourceType)
             {
                 return true;
             }
+
+            // TODO: Ensure we have checks that validate that `var i: int = null` etc fails for all supported numeric types.
 
             if (sourceType == typeof(NullObject) &&
                 targetType != typeof(int) &&
@@ -79,7 +85,7 @@ namespace Perlang.Interpreter.Typing
 
             // TODO: Implement more of the coercions being advertised in the XML docs. :)
 
-            int? sourceSize = SignedIntegerLengthByType.TryGetObjectValue(sourceType);
+            long? sourceSize = sourceConstantValueSize ?? SignedIntegerLengthByType.TryGetObjectValue(sourceType);
             int? targetSize = SignedIntegerLengthByType.TryGetObjectValue(targetType) ?? FloatIntegerLengthByType.TryGetObjectValue(targetType);
 
             if (sourceSize == null || targetSize == null)

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -8,6 +8,7 @@ using Humanizer;
 using Perlang.Extensions;
 using Perlang.Interpreter.Extensions;
 using Perlang.Interpreter.NameResolution;
+using Perlang.Parser;
 
 namespace Perlang.Interpreter.Typing
 {
@@ -263,7 +264,14 @@ namespace Perlang.Interpreter.Typing
             }
             else
             {
-                expr.TypeReference.ClrType = expr.Value.GetType();
+                if (expr.Value is INumericLiteral parsedNumber)
+                {
+                    expr.TypeReference.ClrType = parsedNumber.Value.GetType();
+                }
+                else
+                {
+                    expr.TypeReference.ClrType = expr.Value.GetType();
+                }
             }
 
             return VoidObject.Void;

--- a/src/Perlang.Parser/FloatingPointLiteral.cs
+++ b/src/Perlang.Parser/FloatingPointLiteral.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+
+namespace Perlang.Parser;
+
+internal readonly struct FloatingPointLiteral<T> : INumericLiteral
+    where T : notnull
+{
+    internal T Value { get; }
+
+    /// <inheritdoc cref="INumericLiteral.BitsUsed"/>
+    public long BitsUsed { get; }
+
+    object INumericLiteral.Value => Value;
+
+    public FloatingPointLiteral(T value)
+    {
+        Value = value;
+
+        BitsUsed = value switch
+        {
+            double doubleValue => Math.ILogB(doubleValue),
+            _ => throw new ArgumentException($"Unsupported numeric type encountered: {value.GetType().Name}")
+        };
+    }
+
+    public override string? ToString()
+    {
+        return Value.ToString();
+    }
+}

--- a/src/Perlang.Parser/INumericLiteral.cs
+++ b/src/Perlang.Parser/INumericLiteral.cs
@@ -1,0 +1,13 @@
+#nullable enable
+namespace Perlang.Parser;
+
+public interface INumericLiteral
+{
+    public object Value { get; }
+
+    /// <summary>
+    /// Gets a number that indicates the actual size of the value in <see cref="Value"/>. This is used to be able to do
+    /// things like "implicit casting" from `int` to `uint`, which is perfectly safe for positive integers.
+    /// </summary>
+    public long BitsUsed { get; }
+}

--- a/src/Perlang.Parser/IntegerLiteral.cs
+++ b/src/Perlang.Parser/IntegerLiteral.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using System.Numerics;
+
+namespace Perlang.Parser;
+
+internal class IntegerLiteral<T> : INumericLiteral
+    where T : notnull
+{
+    internal T Value { get; }
+
+    /// <inheritdoc cref="INumericLiteral.BitsUsed"/>
+    public long BitsUsed { get; }
+
+    object INumericLiteral.Value => Value;
+
+    public IntegerLiteral(T value)
+    {
+        Value = value;
+
+        BitsUsed = value switch
+        {
+            int intValue => Math.ILogB(intValue),
+            uint uintValue => Math.ILogB(uintValue),
+            long longValue => Math.ILogB(longValue),
+            ulong ulongValue => Math.ILogB(ulongValue),
+            BigInteger bigintValue => bigintValue.GetBitLength(),
+            _ => throw new ArgumentException($"Unsupported numeric type encountered: {value.GetType().Name}")
+        };
+    }
+
+    public override string? ToString()
+    {
+        return Value.ToString();
+    }
+}

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -639,7 +639,8 @@ namespace Perlang.Parser
                 // Numbers are retained as strings in the scanning phase, to properly be able to parse negative numbers
                 // in the parsing stage (where we can more easily join the MINUS and NUMBER token together). See #302
                 // for details.
-                return new Expr.Literal(NumberParser.Parse((NumericToken)Previous()));
+                INumericLiteral numericLiteral = NumberParser.Parse((NumericToken)Previous());
+                return new Expr.Literal(numericLiteral);
             }
 
             if (Match(STRING))

--- a/src/Perlang.Tests.Integration/Typing/IntTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/IntTests.cs
@@ -1,26 +1,25 @@
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
-namespace Perlang.Tests.Integration.Typing
+namespace Perlang.Tests.Integration.Typing;
+
+/// <summary>
+/// Tests for the `int` data type.
+/// </summary>
+public class IntTests
 {
-    /// <summary>
-    /// Tests for the `int` data type.
-    /// </summary>
-    public class IntTests
+    [Fact]
+    public void int_variable_has_expected_type_when_initialized_to_8bit_value()
     {
-        [Fact]
-        public void int_variable_has_expected_type_when_initialized_to_8bit_value()
-        {
-            // An 8-bit integer (sbyte) should be expanded to 32-bit when the assignment target is of the 'int' type.
-            string source = @"
+        // An 8-bit integer (sbyte) should be expanded to 32-bit when the assignment target is of the 'int' type.
+        string source = @"
                 var i: int = 103;
 
                 print(i.get_type());
             ";
 
-            var output = EvalReturningOutputString(source);
+        var output = EvalReturningOutputString(source);
 
-            Assert.Equal("System.Int32", output);
-        }
+        Assert.Equal("System.Int32", output);
     }
 }

--- a/src/Perlang.Tests.Integration/Typing/LongTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/LongTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
@@ -117,8 +116,9 @@ namespace Perlang.Tests.Integration.Typing
         [Fact]
         public void long_variable_with_32bit_value_emits_expected_error_when_initializer_assigned_to_int_variable()
         {
-            // Expansions are fine (103 to long), but the other way around is not supported with implicit conversions.
-            // Attempting to initialize an int variable with this value is expected to fail.
+            // Expansions are fine (103 to `long`), but assignments to a smaller-sized integer, potentially losing data,
+            // is not supported with implicit conversions. Attempting to initialize an `int` variable from a `long` is
+            // expected to fail.
             string source = @"
                 var l: long = 103;
                 var i: int = l;


### PR DESCRIPTION
This extracts some of the functionality from #307 to a separate PR for better reviewability, by keeping refactorings and functional changes separate.