### PR TITLE
(interpreter) Prevent assignment from double to integer types

### DIFF
--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -16,12 +16,16 @@ namespace Perlang.Interpreter.Typing
             { typeof(Int32), 32 },
             { typeof(Int64), 64 },
 
-            // Double-precision values are 64-bit but can only save 53-bit integers with exact precision
-            { typeof(Double), 32 },
-
             // In practice, even larger numbers should be possible. For the time being, I think it's quite fine if
             // bigints in Perlang are limited to 2 billion digits. :)
             { typeof(BigInteger), Int32.MaxValue }
+        }.ToImmutableDictionary();
+
+        private static ImmutableDictionary<Type, int?> FloatIntegerLengthByType => new Dictionary<Type, int?>
+        {
+            // Double-precision values are 64-bit but can only save 53-bit integers with exact precision. Since there
+            // are no "53-bit" types, we just make this the "next smaller available" bit length.
+            { typeof(Double), 32 }
         }.ToImmutableDictionary();
 
         /// <summary>
@@ -76,7 +80,7 @@ namespace Perlang.Interpreter.Typing
             // TODO: Implement more of the coercions being advertised in the XML docs. :)
 
             int? sourceSize = SignedIntegerLengthByType.TryGetObjectValue(sourceType);
-            int? targetSize = SignedIntegerLengthByType.TryGetObjectValue(targetType);
+            int? targetSize = SignedIntegerLengthByType.TryGetObjectValue(targetType) ?? FloatIntegerLengthByType.TryGetObjectValue(targetType);
 
             if (sourceSize == null || targetSize == null)
             {

--- a/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
@@ -53,6 +53,21 @@ public class DoubleTests
     }
 
     [Fact]
+    public void double_variable_throws_expected_exception_when_assigned_to_long_variable()
+    {
+        string source = @"
+                var d: double = 8589934592.1;
+                var l: long = d;
+            ";
+
+        var result = EvalWithValidationErrorCatch(source);
+        var exception = result.Errors.First();
+
+        Assert.Single(result.Errors);
+        Assert.Matches("Cannot assign double to long variable", exception.Message);
+    }
+
+    [Fact]
     public void double_variable_has_expected_type_when_initialized_to_8bit_value()
     {
         // An 8-bit integer (sbyte) should be expanded to 64-bit when the assignment target is of the 'long' type.


### PR DESCRIPTION
Fixes #309.

No changelog entry is needed on this one, since it fixes a regression introduced in #300; no release has been made where the bug was present.