### PR TITLE
(tests) Rename test classes

### DIFF
--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionAssignmentTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionAssignmentTests.cs
@@ -4,10 +4,10 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary
 {
-    public class AdditionAssignment
+    public class AdditionAssignmentTests
     {
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.PlusEqual_result), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.AdditionAssignment_result), MemberType = typeof(BinaryOperatorData))]
         public void performs_addition_assignment(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -38,7 +38,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.PlusEqual_unsupported_types_runtime), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.AdditionAssignment_unsupported_types_runtime), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_runtime_error(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -56,7 +56,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.PlusEqual_unsupported_types_validation), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.AdditionAssignment_unsupported_types_validation), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_validation_error(string i, string j, string expectedResult)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
@@ -10,10 +10,10 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary
 {
-    public class Addition
+    public class AdditionTests
     {
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Plus_result), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Addition_result), MemberType = typeof(BinaryOperatorData))]
         void performs_addition(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -47,7 +47,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Plus_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Addition_unsupported_types), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
@@ -18,7 +18,7 @@ namespace Perlang.Tests.Integration.Operator.Binary;
 /// </summary>
 public static class BinaryOperatorData
 {
-    public static IEnumerable<object[]> Greater() =>
+    public static IEnumerable<object[]> Greater =>
         new List<object[]>
         {
             new object[] { "2147483646", "2147483647", "False" },
@@ -39,7 +39,7 @@ public static class BinaryOperatorData
             new object[] { "33", "4294967295", "Operands must be numbers, not int and System.UInt32" },
         };
 
-    public static IEnumerable<object[]> GreaterEqual() =>
+    public static IEnumerable<object[]> GreaterEqual =>
         new List<object[]>
         {
             new object[] { "2147483646", "2147483647", "False" },
@@ -60,7 +60,7 @@ public static class BinaryOperatorData
             new object[] { "33", "4294967295", "Operands must be numbers, not int and System.UInt32" }
         };
 
-    public static IEnumerable<object[]> Less() =>
+    public static IEnumerable<object[]> Less =>
         new List<object[]>
         {
             new object[] { "2147483646", "2147483647", "True" },
@@ -72,7 +72,7 @@ public static class BinaryOperatorData
             new object[] { "34.0", "33.0", "False" },
         };
 
-    public static IEnumerable<object[]> Less_unsupported_types() =>
+    public static IEnumerable<object[]> Less_unsupported_types =>
         new List<object[]>
         {
             new object[] { "12.0", "34", "Operands must be numbers, not double and int" },
@@ -102,7 +102,7 @@ public static class BinaryOperatorData
             new object[] { "33", "4294967295", "Operands must be numbers, not int and System.UInt32" }
         };
 
-    public static IEnumerable<object[]> BangEqual =>
+    public static IEnumerable<object[]> NotEqual =>
         new List<object[]>
         {
             new object[] { "12", "34", "True" },
@@ -113,7 +113,7 @@ public static class BinaryOperatorData
             new object[] { "12.345", "67.890", "True" }
         };
 
-    public static IEnumerable<object[]> EqualEqual =>
+    public static IEnumerable<object[]> Equal =>
         new List<object[]>
         {
             new object[] { "12", "34", "False" },
@@ -124,7 +124,7 @@ public static class BinaryOperatorData
             new object[] { "12.345", "67.890", "False" }
         };
 
-    public static IEnumerable<object[]> Minus_result =>
+    public static IEnumerable<object[]> Subtraction_result =>
         new List<object[]>
         {
             new object[] { "12", "34", "-22" },
@@ -160,7 +160,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" }
         };
 
-    public static IEnumerable<object[]> Minus_unsupported_types =>
+    public static IEnumerable<object[]> Subtraction_unsupported_types =>
         new List<object[]>
         {
             new object[] { "2", "4294967295", "Operands must be numbers, not int and System.UInt32" },
@@ -192,7 +192,7 @@ public static class BinaryOperatorData
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
 
-    public static IEnumerable<object[]> MinusEqual_result =>
+    public static IEnumerable<object[]> SubtractionAssignment_result =>
         new List<object[]>
         {
             new object[] { "12", "34", "-22" },
@@ -224,7 +224,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" }
         };
 
-    public static IEnumerable<object[]> MinusEqual_unsupported_types_runtime =>
+    public static IEnumerable<object[]> SubtractionAssignment_unsupported_types_runtime =>
         new List<object[]>
         {
             new object[] { "4294967295", "33", "Operands must be numbers, not System.UInt32 and int" },
@@ -244,7 +244,7 @@ public static class BinaryOperatorData
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
 
-    public static IEnumerable<object[]> MinusEqual_unsupported_types_validation =>
+    public static IEnumerable<object[]> SubtractionAssignment_unsupported_types_validation =>
         new List<object[]>
         {
             new object[] { "2", "4294967295", "Cannot assign System.UInt32 to int variable" },
@@ -258,7 +258,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "12.0", "Cannot assign double to bigint variable" },
         };
 
-    public static IEnumerable<object[]> Plus_result =>
+    public static IEnumerable<object[]> Addition_result =>
         new List<object[]>
         {
             new object[] { "12", "34", "46" },
@@ -295,7 +295,7 @@ public static class BinaryOperatorData
         new object[] { "12.1", "34.2", "System.Double" },
     };
 
-    public static IEnumerable<object[]> Plus_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> Addition_unsupported_types => new List<object[]>
     {
         new object[] { "12.0", "34", "Operands must be numbers, not double and int" },
         new object[] { "9.0", "2", "Operands must be numbers, not double and int" },
@@ -306,7 +306,7 @@ public static class BinaryOperatorData
         // TODO: add unsupported errors from subtraction
     };
 
-    public static IEnumerable<object[]> PlusEqual_result =>
+    public static IEnumerable<object[]> AdditionAssignment_result =>
         new List<object[]>
         {
             new object[] { "12", "34", "46" },
@@ -339,7 +339,7 @@ public static class BinaryOperatorData
         new object[] { "12.1", "34.2", "System.Double" },
     };
 
-    public static IEnumerable<object[]> PlusEqual_unsupported_types_runtime => new List<object[]>
+    public static IEnumerable<object[]> AdditionAssignment_unsupported_types_runtime => new List<object[]>
     {
         new object[] { "12.0", "34", "Operands must be numbers, not double and int" },
         new object[] { "9.0", "2", "Operands must be numbers, not double and int" },
@@ -350,13 +350,13 @@ public static class BinaryOperatorData
         // TODO: add unsupported errors from subtraction
     };
 
-    public static IEnumerable<object[]> PlusEqual_unsupported_types_validation => new List<object[]>
+    public static IEnumerable<object[]> AdditionAssignment_unsupported_types_validation => new List<object[]>
     {
         new object[] { "-12", "-34.0", "Cannot assign double to int variable" },
         new object[] { "9223372036854775807", "12.0", "Cannot assign double to long variable" },
     };
 
-    public static IEnumerable<object[]> Slash_result => new List<object[]>
+    public static IEnumerable<object[]> Division_result => new List<object[]>
     {
         new object[] { "35", "5", "7" },
         new object[] { "34", "5", "6" }, // `int` division => expecting to be truncated.
@@ -372,12 +372,12 @@ public static class BinaryOperatorData
         new object[] { "34", "5.0", "System.Double" }
     };
 
-    public static IEnumerable<object[]> Slash_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> Division_unsupported_types => new List<object[]>
     {
         new object[] { "34.0", "5", "Operands must be numbers, not double and int" },
     };
 
-    public static IEnumerable<object[]> Star_result => new List<object[]>
+    public static IEnumerable<object[]> Multiplication_result => new List<object[]>
     {
         new object[] { "5", "3", "15" },
         new object[] { "12", "34.0", "408" },
@@ -393,7 +393,7 @@ public static class BinaryOperatorData
         new object[] { "1073741824", "2", "System.Int32" }
     };
 
-    public static IEnumerable<object[]> Star_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> Multiplication_unsupported_types => new List<object[]>
     {
         new object[] { "13.0", "35", "Operands must be numbers, not double and int" },
     };
@@ -426,7 +426,7 @@ public static class BinaryOperatorData
         new object[] { "18446744073709551616", "18446744073709551616", "Unsupported ** operands specified: bigint and bigint" }
     };
 
-    public static IEnumerable<object[]> Percent_result => new List<object[]>
+    public static IEnumerable<object[]> Modulo_result => new List<object[]>
     {
         new object[] { "5", "3", "2" },
         new object[] { "9", "2.0", "1" },
@@ -446,7 +446,7 @@ public static class BinaryOperatorData
         new object[] { "18446744073709551616", "3", "System.Numerics.BigInteger" }
     };
 
-    public static IEnumerable<object[]> Percent_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> Modulo_unsupported_types => new List<object[]>
     {
         new object[] { "9.0", "2", "Operands must be numbers, not double and int" },
         new object[] { "4294967295", "2", "Operands must be numbers, not System.UInt32 and int" },
@@ -454,7 +454,7 @@ public static class BinaryOperatorData
         new object[] { "18446744073709551615", "2", "Operands must be numbers, not System.UInt64 and int" },
     };
 
-    public static IEnumerable<object[]> LessLess_result => new List<object[]>
+    public static IEnumerable<object[]> ShiftLeft_result => new List<object[]>
     {
         new object[] { "1", "10", "1024" },
         new object[] { "1073741824", "1", "-2147483648" }, // Integer overflow => becomes negative
@@ -469,13 +469,13 @@ public static class BinaryOperatorData
         new object[] { "18446744073709551616", "1", "System.Numerics.BigInteger" }
     };
 
-    public static IEnumerable<object[]> LessLess_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> ShiftLeft_unsupported_types => new List<object[]>
     {
         new object[] { "2147483648", "1", "Operands must be numbers, not System.UInt32 and int" },
         new object[] { "9223372036854775808", "1", "Operands must be numbers, not System.UInt64 and int" }
     };
 
-    public static IEnumerable<object[]> GreaterGreater_result => new List<object[]>
+    public static IEnumerable<object[]> ShiftRight_result => new List<object[]>
     {
         new object[] { "65536", "6", "1024" },
         new object[] { "1073741824", "1", "536870912" },
@@ -489,7 +489,7 @@ public static class BinaryOperatorData
         new object[] { "4611686018427387904", "1", "System.Int64" },
     };
 
-    public static IEnumerable<object[]> GreaterGreater_unsupported_types => new List<object[]>
+    public static IEnumerable<object[]> ShiftRight_unsupported_types => new List<object[]>
     {
         new object[] { "2147483648", "1", "Operands must be numbers, not System.UInt32 and int" },
         new object[] { "9223372036854775808", "1", "Operands must be numbers, not System.UInt64 and int" }

--- a/src/Perlang.Tests.Integration/Operator/Binary/DivisionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/DivisionTests.cs
@@ -11,10 +11,10 @@ namespace Perlang.Tests.Integration.Operator.Binary
     // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide.lox
     // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide_nonnum_num.lox
     // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide_num_nonnum.lox
-    public class Division
+    public class DivisionTests
     {
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Slash_result), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Division_result), MemberType = typeof(BinaryOperatorData))]
         void performs_division(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -45,7 +45,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Slash_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Division_unsupported_types), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/EqualTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/EqualTests.cs
@@ -4,17 +4,17 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class NotEqual
+public class EqualTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.BangEqual), MemberType = typeof(BinaryOperatorData))]
-    void performs_non_equality_comparison(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.Equal), MemberType = typeof(BinaryOperatorData))]
+    void performs_equality_comparison(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 != i2;
+                print i1 == i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -24,16 +24,16 @@ public class NotEqual
     }
 
     [Theory]
-    [InlineData("Foo", "Bar", "True")]
-    [InlineData("Foo", "foo", "True")] // Comparison is case sensitive
-    [InlineData("foo", "foo", "False")]
+    [InlineData("Foo", "Bar", "False")]
+    [InlineData("Foo", "foo", "False")] // Comparison is case sensitive
+    [InlineData("foo", "foo", "True")]
     void strings_can_be_compared_for_equality(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = ""{i}"";
                 var i2 = ""{j}"";
 
-                print i1 != i2;
+                print i1 == i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -41,6 +41,4 @@ public class NotEqual
         result.Should()
             .Be(expectedResult);
     }
-
-    // TODO: unsupported_types_emits_expected_errors
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
@@ -13,7 +13,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
     ///
     /// The type of the returned value is varies depending on the input types.
     /// </summary>
-    public class Exponential
+    public class ExponentialTests
     {
         [Theory]
         [MemberData(nameof(BinaryOperatorData.Exponential_result), MemberType = typeof(BinaryOperatorData))]

--- a/src/Perlang.Tests.Integration/Operator/Binary/GreaterEqualTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/GreaterEqualTests.cs
@@ -4,7 +4,7 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class GreaterEqual
+public class GreaterEqualTests
 {
     [Theory]
     [MemberData(nameof(BinaryOperatorData.GreaterEqual), MemberType = typeof(BinaryOperatorData))]

--- a/src/Perlang.Tests.Integration/Operator/Binary/GreaterTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/GreaterTests.cs
@@ -4,17 +4,17 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class LessEqual
+public class GreaterTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.LessEqual), MemberType = typeof(BinaryOperatorData))]
-    void performs_less_equal_comparison(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.Greater), MemberType = typeof(BinaryOperatorData))]
+    void performs_greater_than_comparison(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 <= i2;
+                print i1 > i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -24,14 +24,14 @@ public class LessEqual
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.LessEqual_unsupported_types), MemberType = typeof(BinaryOperatorData))]
-    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
+    [MemberData(nameof(BinaryOperatorData.Greater_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 <= i2;
+                print i1 > i2;
             ";
 
         // TODO: Should definitely not be a runtime-error, but rather caught in the validation phase.

--- a/src/Perlang.Tests.Integration/Operator/Binary/LessEqualTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/LessEqualTests.cs
@@ -4,17 +4,17 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class Less
+public class LessEqualTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Less), MemberType = typeof(BinaryOperatorData))]
-    void performs_less_than_comparison(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.LessEqual), MemberType = typeof(BinaryOperatorData))]
+    void performs_less_equal_comparison(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 < i2;
+                print i1 <= i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -24,14 +24,14 @@ public class Less
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Less_unsupported_types), MemberType = typeof(BinaryOperatorData))]
-    void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
+    [MemberData(nameof(BinaryOperatorData.LessEqual_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 < i2;
+                print i1 <= i2;
             ";
 
         // TODO: Should definitely not be a runtime-error, but rather caught in the validation phase.

--- a/src/Perlang.Tests.Integration/Operator/Binary/LessTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/LessTests.cs
@@ -4,17 +4,17 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class Greater
+public class LessTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Greater), MemberType = typeof(BinaryOperatorData))]
-    void performs_greater_than_comparison(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.Less), MemberType = typeof(BinaryOperatorData))]
+    void performs_less_than_comparison(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 > i2;
+                print i1 < i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -24,14 +24,14 @@ public class Greater
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Greater_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.Less_unsupported_types), MemberType = typeof(BinaryOperatorData))]
     void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 > i2;
+                print i1 < i2;
             ";
 
         // TODO: Should definitely not be a runtime-error, but rather caught in the validation phase.

--- a/src/Perlang.Tests.Integration/Operator/Binary/ModuloTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ModuloTests.cs
@@ -10,10 +10,10 @@ namespace Perlang.Tests.Integration.Operator.Binary
     /// <summary>
     /// Tests for the % (modulo) operator.
     /// </summary>
-    public class Modulo
+    public class ModuloTests
     {
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Percent_result), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Modulo_result), MemberType = typeof(BinaryOperatorData))]
         public void returns_remainder_of_division(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -41,7 +41,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Percent_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Modulo_unsupported_types), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/MultiplicationTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/MultiplicationTests.cs
@@ -11,13 +11,13 @@ namespace Perlang.Tests.Integration.Operator.Binary
     // https://github.com/munificent/craftinginterpreters/blob/adfb64d00d04e389ddc086d16cc29ac49fc6c21e/test/operator/multiply.lox
     // https://github.com/munificent/craftinginterpreters/blob/adfb64d00d04e389ddc086d16cc29ac49fc6c21e/test/operator/multiply_nonnum_num.lox
     // https://github.com/munificent/craftinginterpreters/blob/adfb64d00d04e389ddc086d16cc29ac49fc6c21e/test/operator/multiply_num_nonnum.lox
-    public class Multiplication
+    public class MultiplicationTests
     {
         //
         // Tests for the * (multiplication) operator
         //
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Star_result), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Multiplication_result), MemberType = typeof(BinaryOperatorData))]
         public void performs_multiplication(string i, string j, string expectedResult)
         {
             string source = $@"
@@ -45,7 +45,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Theory]
-        [MemberData(nameof(BinaryOperatorData.Star_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+        [MemberData(nameof(BinaryOperatorData.Multiplication_unsupported_types), MemberType = typeof(BinaryOperatorData))]
         public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
         {
             string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/NotEqualTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/NotEqualTests.cs
@@ -4,17 +4,17 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class Equal
+public class NotEqualTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.EqualEqual), MemberType = typeof(BinaryOperatorData))]
-    void performs_equality_comparison(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.NotEqual), MemberType = typeof(BinaryOperatorData))]
+    void performs_non_equality_comparison(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = {i};
                 var i2 = {j};
 
-                print i1 == i2;
+                print i1 != i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -24,16 +24,16 @@ public class Equal
     }
 
     [Theory]
-    [InlineData("Foo", "Bar", "False")]
-    [InlineData("Foo", "foo", "False")] // Comparison is case sensitive
-    [InlineData("foo", "foo", "True")]
+    [InlineData("Foo", "Bar", "True")]
+    [InlineData("Foo", "foo", "True")] // Comparison is case sensitive
+    [InlineData("foo", "foo", "False")]
     void strings_can_be_compared_for_equality(string i, string j, string expectedResult)
     {
         string source = $@"
                 var i1 = ""{i}"";
                 var i2 = ""{j}"";
 
-                print i1 == i2;
+                print i1 != i2;
             ";
 
         string result = EvalReturningOutputString(source);
@@ -41,4 +41,6 @@ public class Equal
         result.Should()
             .Be(expectedResult);
     }
+
+    // TODO: unsupported_types_emits_expected_errors
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/ShiftLeftTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ShiftLeftTests.cs
@@ -5,14 +5,14 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class ShiftRightOperator
+public class ShiftLeftTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.GreaterGreater_result), MemberType = typeof(BinaryOperatorData))]
-    public void performs_right_shifting(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.ShiftLeft_result), MemberType = typeof(BinaryOperatorData))]
+    public void performs_left_shifting(string i, string j, string expectedResult)
     {
         string source = $@"
-                    print {i} >> {j};
+                    print {i} << {j};
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -22,11 +22,11 @@ public class ShiftRightOperator
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.GreaterGreater_type), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.LessLess_type), MemberType = typeof(BinaryOperatorData))]
     public void with_supported_types_returns_expected_type(string i, string j, string expectedResult)
     {
         string source = $@"
-                    print ({i} >> {j}).get_type();
+                    print ({i} << {j}).get_type();
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -36,11 +36,11 @@ public class ShiftRightOperator
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.GreaterGreater_unsupported_types), MemberType = typeof(BinaryOperatorData))]
-    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.ShiftLeft_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
     {
         string source = $@"
-                    print {i} >> {j};
+                    print {i} << {j};
                 ";
 
         // TODO: Should definitely not be a runtime-error, but rather caught in the validation phase.
@@ -48,14 +48,14 @@ public class ShiftRightOperator
 
         result.Errors.Should()
             .ContainSingle().Which
-            .Message.Should().Match(expectedResult);
+            .Message.Should().Match(expectedError);
     }
 
     [Fact]
     public void takes_precedence_over_multiplication()
     {
         string source = @"
-                    print 65536 >> 6 * 3;
+                    print 1 << 10 * 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -66,7 +66,7 @@ public class ShiftRightOperator
     public void takes_precedence_over_division()
     {
         string source = @"
-                    print 65536 >> 6 / 3;
+                    print 1 << 10 / 3;
                 ";
 
         // Since the operands are integers, the division is expected to be truncated to its integer portion.
@@ -79,7 +79,7 @@ public class ShiftRightOperator
     public void takes_precedence_over_addition()
     {
         string source = @"
-                    print 65536 >> 6 + 3;
+                    print 1 << 10 + 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -90,7 +90,7 @@ public class ShiftRightOperator
     public void takes_precedence_over_subtraction()
     {
         string source = @"
-                    print 65536 >> 6 - 3;
+                    print 1 << 10 - 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -101,7 +101,7 @@ public class ShiftRightOperator
     public void takes_precedence_over_modulo_operator()
     {
         string source = @"
-                    print 65536 >> 6 % 1000;
+                    print 1 << 10 % 1000;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -112,7 +112,7 @@ public class ShiftRightOperator
     public void takes_precedence_over_power_operator()
     {
         string source = @"
-                    print 1024 >> 8 ** 10;
+                    print 1 << 2 ** 10;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -123,13 +123,13 @@ public class ShiftRightOperator
     public void with_integer_and_string_throws_expected_error()
     {
         string source = @"
-                    print 1 >> ""foo"";
+                    print 1 << ""foo"";
                 ";
 
         var result = EvalWithValidationErrorCatch(source);
         var exception = result.Errors.FirstOrDefault();
 
         Assert.Single(result.Errors);
-        Assert.Matches("Unsupported >> operands specified: int and string", exception.Message);
+        Assert.Matches("Unsupported << operands specified: int and string", exception.Message);
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/ShiftRightTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ShiftRightTests.cs
@@ -5,14 +5,14 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class ShiftLeftOperator
+public class ShiftRightTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.LessLess_result), MemberType = typeof(BinaryOperatorData))]
-    public void performs_left_shifting(string i, string j, string expectedResult)
+    [MemberData(nameof(BinaryOperatorData.ShiftRight_result), MemberType = typeof(BinaryOperatorData))]
+    public void performs_right_shifting(string i, string j, string expectedResult)
     {
         string source = $@"
-                    print {i} << {j};
+                    print {i} >> {j};
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -22,11 +22,11 @@ public class ShiftLeftOperator
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.LessLess_type), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.GreaterGreater_type), MemberType = typeof(BinaryOperatorData))]
     public void with_supported_types_returns_expected_type(string i, string j, string expectedResult)
     {
         string source = $@"
-                    print ({i} << {j}).get_type();
+                    print ({i} >> {j}).get_type();
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -36,11 +36,11 @@ public class ShiftLeftOperator
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.LessLess_unsupported_types), MemberType = typeof(BinaryOperatorData))]
-    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
+    [MemberData(nameof(BinaryOperatorData.ShiftRight_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    public void with_unsupported_types_emits_expected_error(string i, string j, string expectedResult)
     {
         string source = $@"
-                    print {i} << {j};
+                    print {i} >> {j};
                 ";
 
         // TODO: Should definitely not be a runtime-error, but rather caught in the validation phase.
@@ -48,14 +48,14 @@ public class ShiftLeftOperator
 
         result.Errors.Should()
             .ContainSingle().Which
-            .Message.Should().Match(expectedError);
+            .Message.Should().Match(expectedResult);
     }
 
     [Fact]
     public void takes_precedence_over_multiplication()
     {
         string source = @"
-                    print 1 << 10 * 3;
+                    print 65536 >> 6 * 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -66,7 +66,7 @@ public class ShiftLeftOperator
     public void takes_precedence_over_division()
     {
         string source = @"
-                    print 1 << 10 / 3;
+                    print 65536 >> 6 / 3;
                 ";
 
         // Since the operands are integers, the division is expected to be truncated to its integer portion.
@@ -79,7 +79,7 @@ public class ShiftLeftOperator
     public void takes_precedence_over_addition()
     {
         string source = @"
-                    print 1 << 10 + 3;
+                    print 65536 >> 6 + 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -90,7 +90,7 @@ public class ShiftLeftOperator
     public void takes_precedence_over_subtraction()
     {
         string source = @"
-                    print 1 << 10 - 3;
+                    print 65536 >> 6 - 3;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -101,7 +101,7 @@ public class ShiftLeftOperator
     public void takes_precedence_over_modulo_operator()
     {
         string source = @"
-                    print 1 << 10 % 1000;
+                    print 65536 >> 6 % 1000;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -112,7 +112,7 @@ public class ShiftLeftOperator
     public void takes_precedence_over_power_operator()
     {
         string source = @"
-                    print 1 << 2 ** 10;
+                    print 1024 >> 8 ** 10;
                 ";
 
         string result = EvalReturningOutputString(source);
@@ -123,13 +123,13 @@ public class ShiftLeftOperator
     public void with_integer_and_string_throws_expected_error()
     {
         string source = @"
-                    print 1 << ""foo"";
+                    print 1 >> ""foo"";
                 ";
 
         var result = EvalWithValidationErrorCatch(source);
         var exception = result.Errors.FirstOrDefault();
 
         Assert.Single(result.Errors);
-        Assert.Matches("Unsupported << operands specified: int and string", exception.Message);
+        Assert.Matches("Unsupported >> operands specified: int and string", exception.Message);
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/SubtractionAssignmentTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/SubtractionAssignmentTests.cs
@@ -5,10 +5,10 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class SubtractionAssignment
+public class SubtractionAssignmentTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.MinusEqual_result), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.SubtractionAssignment_result), MemberType = typeof(BinaryOperatorData))]
     public void performs_subtraction_assignment(string i, string j, string expectedResult)
     {
         string source = $@"
@@ -40,7 +40,7 @@ public class SubtractionAssignment
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.MinusEqual_unsupported_types_runtime), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.SubtractionAssignment_unsupported_types_runtime), MemberType = typeof(BinaryOperatorData))]
     public void with_unsupported_types_emits_expected_runtime_error(string i, string j, string expectedError)
     {
         string source = $@"
@@ -57,7 +57,7 @@ public class SubtractionAssignment
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.MinusEqual_unsupported_types_validation), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.SubtractionAssignment_unsupported_types_validation), MemberType = typeof(BinaryOperatorData))]
     public void with_unsupported_types_emits_expected_validation_error(string i, string j, string expectedError)
     {
         string source = $@"

--- a/src/Perlang.Tests.Integration/Operator/Binary/SubtractionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/SubtractionTests.cs
@@ -4,10 +4,10 @@ using static Perlang.Tests.Integration.EvalHelper;
 
 namespace Perlang.Tests.Integration.Operator.Binary;
 
-public class Subtraction
+public class SubtractionTests
 {
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Minus_result), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.Subtraction_result), MemberType = typeof(BinaryOperatorData))]
     void performs_subtraction(string i, string j, string expectedResult)
     {
         string source = $@"
@@ -41,7 +41,7 @@ public class Subtraction
     }
 
     [Theory]
-    [MemberData(nameof(BinaryOperatorData.Minus_unsupported_types), MemberType = typeof(BinaryOperatorData))]
+    [MemberData(nameof(BinaryOperatorData.Subtraction_unsupported_types), MemberType = typeof(BinaryOperatorData))]
     public void with_unsupported_types_emits_expected_error(string i, string j, string expectedError)
     {
         string source = $@"


### PR DESCRIPTION
This is mostly a cleanup of #313, and preparing for an upcoming PR where the ambiguity between the property names in `BinaryOperatorData` and the test class names become a bit of a problem. Extracting to a separate PR to maintain cleanliness of git history. :slightly_smiling_face: 