### PR TITLE
(tests) Verify expected types in binary operator tests

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -22,6 +22,7 @@
 - Add full type coverage for `**` operator [[#323][323]]
 - Add full type coverage for `%` operator [[#324][324]]
 - Add full type coverage for `<<` and `>>` operator [[#325][325]]
+- Verify expected types in binary operator tests [[#326][326]]
 
 [300]: https://github.com/perlang-org/perlang/pull/300
 [302]: https://github.com/perlang-org/perlang/issues/302
@@ -37,3 +38,4 @@
 [323]: https://github.com/perlang-org/perlang/pull/323
 [324]: https://github.com/perlang-org/perlang/pull/324
 [325]: https://github.com/perlang-org/perlang/pull/325
+[326]: https://github.com/perlang-org/perlang/pull/326

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
@@ -1,5 +1,7 @@
 #pragma warning disable SA1515
 using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -330,41 +332,29 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Subtraction_result =>
-        new List<object[]>
-        {
-            new object[] { "12", "34", "-22" },
-            new object[] { "12", "-34", "46" },
-            new object[] { "-12", "34", "-46" },
-            new object[] { "-12", "-34", "22" },
-            new object[] { "2", "18446744073709551616", "-18446744073709551614" },
-            new object[] { "-12", "-34.0", "22" },
-            new object[] { "4294967296", "9223372036854775807", "-9223372032559808511" },
-            new object[] { "9223372036854775807", "9223372036854775807", "0" },
-            new object[] { "9223372036854775807", "18446744073709551616", "-9223372036854775809" },
-            new object[] { "9223372036854775807", "12.0", "9.223372036854776E+18" }, // TODO: We should make this unsupported. As can be seen in the exponential expression, the operation loses precision.
-            new object[] { "18446744073709551616", "2", "18446744073709551614" },
-            new object[] { "18446744073709551616", "4294967296", "18446744069414584320" },
-            new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809" },
-            new object[] { "18446744073709551616", "18446744073709551617", "-1" },
-            new object[] { "12.0", "34.0", "-22" }, // Doubles with fraction part zero => fraction part excluded in string representation.
-        };
+        Subtraction_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Subtraction_type =>
+        Subtraction_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Subtraction_result_and_type =>
         new List<object[]>
         {
-            new object[] { "12", "34", "System.Int32" },
-            new object[] { "12", "-34", "System.Int32" },
-            new object[] { "-12", "34", "System.Int32" },
-            new object[] { "-12", "-34", "System.Int32" },
-            new object[] { "-12", "-34.0", "System.Double" },
-            new object[] { "4294967296", "9223372036854775807", "System.Int64" },
-            new object[] { "12.0", "34.0", "System.Double" },
-            new object[] { "9223372036854775807", "9223372036854775807", "System.Int64" },
-            new object[] { "9223372036854775807", "12.0", "System.Double" },
-            new object[] { "18446744073709551616", "2", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "4294967296", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "9223372036854775807", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" }
+            new object[] { "12", "34", "-22", typeof(int) },
+            new object[] { "12", "-34", "46", typeof(int) },
+            new object[] { "-12", "34", "-46", typeof(int) },
+            new object[] { "-12", "-34", "22", typeof(int) },
+            new object[] { "2", "18446744073709551616", "-18446744073709551614", typeof(BigInteger) },
+            new object[] { "-12", "-34.0", "22", typeof(double) }, // TODO: Should we really support this? What does other languages do?
+            new object[] { "4294967296", "9223372036854775807", "-9223372032559808511", typeof(long) },
+            new object[] { "9223372036854775807", "9223372036854775807", "0", typeof(long) },
+            new object[] { "9223372036854775807", "18446744073709551616", "-9223372036854775809", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "12.0", "9.223372036854776E+18", typeof(double) }, // TODO: We should make this unsupported. As can be seen in the exponential expression, the operation loses precision.
+            new object[] { "18446744073709551616", "2", "18446744073709551614", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "4294967296", "18446744069414584320", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551617", "-1", typeof(BigInteger) },
+            new object[] { "12.0", "34.0", "-22", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
         };
 
     public static IEnumerable<object[]> Subtraction_unsupported_types =>
@@ -399,35 +389,25 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> SubtractionAssignment_result =>
-        new List<object[]>
-        {
-            new object[] { "12", "34", "-22" },
-            new object[] { "12", "-34", "46" },
-            new object[] { "-12", "34", "-46" },
-            new object[] { "-12", "-34", "22" },
-            new object[] { "4294967296", "9223372036854775807", "-9223372032559808511" },
-            new object[] { "9223372036854775807", "9223372036854775807", "0" },
-            new object[] { "18446744073709551616", "2", "18446744073709551614" },
-            new object[] { "18446744073709551616", "4294967296", "18446744069414584320" },
-            new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809" },
-            new object[] { "18446744073709551616", "18446744073709551617", "-1" },
-            new object[] { "12.0", "34.0", "-22" }, // Doubles with fraction part zero => fraction part excluded in string representation.
-        };
+        SubtractionAssignment_result_and_type.GetResult();
 
     public static IEnumerable<object[]> SubtractionAssignment_type =>
+        SubtractionAssignment_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> SubtractionAssignment_result_and_type =>
         new List<object[]>
         {
-            new object[] { "12", "34", "System.Int32" },
-            new object[] { "12", "-34", "System.Int32" },
-            new object[] { "-12", "34", "System.Int32" },
-            new object[] { "-12", "-34", "System.Int32" },
-            new object[] { "4294967296", "9223372036854775807", "System.Int64" },
-            new object[] { "12.0", "34.0", "System.Double" },
-            new object[] { "9223372036854775807", "9223372036854775807", "System.Int64" },
-            new object[] { "18446744073709551616", "2", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "4294967296", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "9223372036854775807", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" }
+            new object[] { "12", "34", "-22", typeof(int) },
+            new object[] { "12", "-34", "46", typeof(int) },
+            new object[] { "-12", "34", "-46", typeof(int) },
+            new object[] { "-12", "-34", "22", typeof(int) },
+            new object[] { "4294967296", "9223372036854775807", "-9223372032559808511", typeof(long) },
+            new object[] { "9223372036854775807", "9223372036854775807", "0", typeof(long) },
+            new object[] { "18446744073709551616", "2", "18446744073709551614", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "4294967296", "18446744069414584320", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551617", "-1", typeof(BigInteger) },
+            new object[] { "12.0", "34.0", "-22", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
         };
 
     public static IEnumerable<object[]> SubtractionAssignment_unsupported_types_runtime =>
@@ -471,43 +451,30 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Addition_result =>
-        new List<object[]>
-        {
-            new object[] { "12", "34", "46" },
-            new object[] { "12", "-34", "-22" },
-            new object[] { "-12", "34", "22" },
-            new object[] { "-12", "-34", "-46" },
-            new object[] { "-12", "-34.0", "-46" },
-            new object[] { "2", "18446744073709551616", "18446744073709551618" },
-            new object[] { "4294967296", "9223372036854775807", "-9223372032559808513" }, // Probably becomes negative because of integer overflow.
-            new object[] { "4294967296", "18446744073709551616", "18446744078004518912" },
-            new object[] { "9223372036854775807", "9223372036854775807", "-2" },
-            new object[] { "9223372036854775807", "12.0", "9.223372036854776E+18" }, // TODO: We should make this unsupported. As can be seen in the exponential expression, the operation loses precision.
-            new object[] { "18446744073709551616", "2", "18446744073709551618" },
-            new object[] { "18446744073709551616", "4294967296", "18446744078004518912" },
-            new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423" },
-            new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233" },
-            new object[] { "12.0", "34.0", "46" }, // Doubles with fraction part zero => fraction part excluded in string representation.
-            new object[] { "12.1", "34.2", "46.300000000000004" }, // IEEE-754... :-)
-        };
+        Addition_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Addition_type =>
+        Addition_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Addition_result_and_type =>
         new List<object[]>
         {
-            new object[] { "12", "34", "System.Int32" },
-            new object[] { "12", "-34", "System.Int32" },
-            new object[] { "-12", "34", "System.Int32" },
-            new object[] { "-12", "-34", "System.Int32" },
-            new object[] { "-12", "-34.0", "System.Double" },
-            new object[] { "4294967296", "9223372036854775807", "System.Int64" }, // Probably becomes negative because of integer overflow.
-            new object[] { "9223372036854775807", "9223372036854775807", "System.Int64" },
-            new object[] { "9223372036854775807", "12.0", "System.Double" },
-            new object[] { "18446744073709551616", "2", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "4294967296", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "9223372036854775807", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" },
-            new object[] { "12.0", "34.0", "System.Double" },
-            new object[] { "12.1", "34.2", "System.Double" },
+            new object[] { "12", "34", "46", typeof(int) },
+            new object[] { "12", "-34", "-22", typeof(int) },
+            new object[] { "-12", "34", "22", typeof(int) },
+            new object[] { "-12", "-34", "-46", typeof(int) },
+            new object[] { "-12", "-34.0", "-46", typeof(double) },
+            new object[] { "2", "18446744073709551616", "18446744073709551618", typeof(BigInteger) },
+            new object[] { "4294967296", "9223372036854775807", "-9223372032559808513", typeof(long) }, // Probably becomes negative because of integer overflow.
+            new object[] { "4294967296", "18446744073709551616", "18446744078004518912", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "9223372036854775807", "-2", typeof(long) },
+            new object[] { "9223372036854775807", "12.0", "9.223372036854776E+18", typeof(double) }, // TODO: We should make this unsupported. As can be seen in the exponential expression, the operation loses precision.
+            new object[] { "18446744073709551616", "2", "18446744073709551618", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "4294967296", "18446744078004518912", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233", typeof(BigInteger) },
+            new object[] { "12.0", "34.0", "46", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
+            new object[] { "12.1", "34.2", "46.300000000000004", typeof(double) }, // IEEE-754... :-)
         };
 
     public static IEnumerable<object[]> Addition_unsupported_types =>
@@ -542,37 +509,26 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> AdditionAssignment_result =>
-        new List<object[]>
-        {
-            new object[] { "12", "34", "46" },
-            new object[] { "12", "-34", "-22" },
-            new object[] { "-12", "34", "22" },
-            new object[] { "-12", "-34", "-46" },
-            new object[] { "4294967296", "9223372036854775807", "-9223372032559808513" }, // Probably becomes negative because of integer overflow.
-            new object[] { "9223372036854775807", "9223372036854775807", "-2" },
-            new object[] { "18446744073709551616", "2", "18446744073709551618" },
-            new object[] { "18446744073709551616", "4294967296", "18446744078004518912" },
-            new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423" },
-            new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233" },
-            new object[] { "12.0", "34.0", "46" }, // Doubles with fraction part zero => fraction part excluded in string representation.
-            new object[] { "12.1", "34.2", "46.300000000000004" }, // IEEE-754... :-)
-        };
+        AdditionAssignment_result_and_type.GetResult();
 
     public static IEnumerable<object[]> AdditionAssignment_type =>
+        AdditionAssignment_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> AdditionAssignment_result_and_type =>
         new List<object[]>
         {
-            new object[] { "12", "34", "System.Int32" },
-            new object[] { "12", "-34", "System.Int32" },
-            new object[] { "-12", "34", "System.Int32" },
-            new object[] { "-12", "-34", "System.Int32" },
-            new object[] { "4294967296", "9223372036854775807", "System.Int64" }, // Probably becomes negative because of integer overflow.
-            new object[] { "9223372036854775807", "9223372036854775807", "System.Int64" },
-            new object[] { "18446744073709551616", "2", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "4294967296", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "9223372036854775807", "System.Numerics.BigInteger" },
-            new object[] { "18446744073709551616", "18446744073709551617", "System.Numerics.BigInteger" },
-            new object[] { "12.0", "34.0", "System.Double" },
-            new object[] { "12.1", "34.2", "System.Double" },
+            new object[] { "12", "34", "46", typeof(int) },
+            new object[] { "12", "-34", "-22", typeof(int) },
+            new object[] { "-12", "34", "22", typeof(int) },
+            new object[] { "-12", "-34", "-46", typeof(int) },
+            new object[] { "4294967296", "9223372036854775807", "-9223372032559808513", typeof(long) }, // Probably becomes negative because of integer overflow.
+            new object[] { "9223372036854775807", "9223372036854775807", "-2", typeof(long) },
+            new object[] { "18446744073709551616", "2", "18446744073709551618", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "4294967296", "18446744078004518912", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233", typeof(BigInteger) },
+            new object[] { "12.0", "34.0", "46", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
+            new object[] { "12.1", "34.2", "46.300000000000004", typeof(double) }, // IEEE-754... :-)
         };
 
     public static IEnumerable<object[]> AdditionAssignment_unsupported_types_runtime =>
@@ -616,28 +572,25 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Division_result =>
-        new List<object[]>
-        {
-            new object[] { "35", "5", "7" },
-            new object[] { "34", "5", "6" }, // `int` division => expecting to be truncated.
-            new object[] { "2", "18446744073709551616", "0" },
-            new object[] { "9223372036854775807", "9223372036854775807", "1" },
-            new object[] { "9223372036854775807", "18446744073709551616", "0" },
-            new object[] { "9223372036854775807", "12.0", "7.686143364045646E+17" }, // TODO: We should make this unsupported
-            new object[] { "18446744073709551616", "2", "9223372036854775808" },
-            new object[] { "18446744073709551616", "9223372036854775807", "2" },
-            new object[] { "18446744073709551616", "18446744073709551616", "1" },
-            new object[] { "34.0", "5.0", "6.8" },
-            new object[] { "34", "5.0", "6.8" }
-        };
+        Division_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Division_type =>
+        Division_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Division_result_and_type =>
         new List<object[]>
         {
-            new object[] { "35", "5", "System.Int32" },
-            new object[] { "34", "5", "System.Int32" },
-            new object[] { "34.0", "5.0", "System.Double" },
-            new object[] { "34", "5.0", "System.Double" }
+            new object[] { "35", "5", "7", typeof(int) },
+            new object[] { "34", "5", "6", typeof(int) }, // `int` division => expecting to be truncated.
+            new object[] { "2", "18446744073709551616", "0", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "9223372036854775807", "1", typeof(long) },
+            new object[] { "9223372036854775807", "18446744073709551616", "0", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "12.0", "7.686143364045646E+17", typeof(double) }, // TODO: We should make this unsupported
+            new object[] { "18446744073709551616", "2", "9223372036854775808", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "2", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551616", "1", typeof(BigInteger) },
+            new object[] { "34.0", "5.0", "6.8", typeof(double) },
+            new object[] { "34", "5.0", "6.8", typeof(double) }
         };
 
     public static IEnumerable<object[]> Division_unsupported_types =>
@@ -672,28 +625,25 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Multiplication_result =>
-        new List<object[]>
-        {
-            new object[] { "5", "3", "15" },
-            new object[] { "2", "18446744073709551616", "36893488147419103232" },
-            new object[] { "12", "34.0", "408" },
-            new object[] { "1073741824", "2", "-2147483648" }, // Becomes negative because of signed `int` overflow.
-            new object[] { "9223372036854775807", "9223372036854775807", "1" },
-            new object[] { "9223372036854775807", "18446744073709551616", "170141183460469231713240559642174554112" },
-            new object[] { "9223372036854775807", "12.0", "1.1068046444225731E+20" }, // TODO: We should make this unsupported, since it's likely to lose precision
-            new object[] { "18446744073709551616", "2", "36893488147419103232" },
-            new object[] { "18446744073709551616", "9223372036854775807", "170141183460469231713240559642174554112" },
-            new object[] { "18446744073709551616", "18446744073709551616", "340282366920938463463374607431768211456" },
-            new object[] { "12.34", "0.3", "3.702" }
-        };
+        Multiplication_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Multiplication_type =>
+        Multiplication_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Multiplication_result_and_type =>
         new List<object[]>
         {
-            new object[] { "5", "3", "System.Int32" },
-            new object[] { "12", "34.0", "System.Double" },
-            new object[] { "12.34", "0.3", "System.Double" },
-            new object[] { "1073741824", "2", "System.Int32" }
+            new object[] { "5", "3", "15", typeof(int) },
+            new object[] { "2", "18446744073709551616", "36893488147419103232", typeof(BigInteger) },
+            new object[] { "12", "34.0", "408", typeof(double) },
+            new object[] { "1073741824", "2", "-2147483648", typeof(int) }, // Becomes negative because of signed `int` overflow.
+            new object[] { "9223372036854775807", "9223372036854775807", "1", typeof(long) },
+            new object[] { "9223372036854775807", "18446744073709551616", "170141183460469231713240559642174554112", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "12.0", "1.1068046444225731E+20", typeof(double) }, // TODO: We should make this unsupported, since it's likely to lose precision
+            new object[] { "18446744073709551616", "2", "36893488147419103232", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "170141183460469231713240559642174554112", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551616", "340282366920938463463374607431768211456", typeof(BigInteger) },
+            new object[] { "12.34", "0.3", "3.702", typeof(double) }
         };
 
     public static IEnumerable<object[]> Multiplication_unsupported_types =>
@@ -728,25 +678,20 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Exponential_result =>
-        new List<object[]>
-        {
-            new object[] { "2", "10", "1024" },
-            new object[] { "2.0", "10.0", "1024" },
-            new object[] { "2", "9.9", "955.425783333691" },
-            new object[] { "4294967296", "2", "18446744073709551616" },
-            new object[] { "4294967296", "10.0", "2.13598703592091E+96" },
-            new object[] { "18446744073709551616", "2", "340282366920938463463374607431768211456" }
-        };
+        Exponential_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Exponential_type =>
+        Exponential_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Exponential_result_and_type =>
         new List<object[]>
         {
-            new object[] { "2", "10", "System.Numerics.BigInteger" },
-            new object[] { "2.0", "10.0", "System.Double" },
-            new object[] { "2", "9.9", "System.Double" },
-            new object[] { "4294967296", "2", "System.Numerics.BigInteger" },
-            new object[] { "4294967296", "10.0", "System.Double" },
-            new object[] { "18446744073709551616", "2", "System.Numerics.BigInteger" }
+            new object[] { "2", "10", "1024", typeof(BigInteger) },
+            new object[] { "2.0", "10.0", "1024", typeof(double) },
+            new object[] { "2", "9.9", "955.425783333691", typeof(double) },
+            new object[] { "4294967296", "2", "18446744073709551616", typeof(BigInteger) },
+            new object[] { "4294967296", "10.0", "2.13598703592091E+96", typeof(double) },
+            new object[] { "18446744073709551616", "2", "340282366920938463463374607431768211456", typeof(BigInteger) }
         };
 
     public static IEnumerable<object[]> Exponential_unsupported_types =>
@@ -787,31 +732,26 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> Modulo_result =>
-        new List<object[]>
-        {
-            new object[] { "5", "3", "2" },
-            new object[] { "2", "18446744073709551616", "2" },
-            new object[] { "9", "2.0", "1" },
-            new object[] { "9.0", "2.0", "1" },
-            new object[] { "2147483647", "2", "1" },
-            new object[] { "-2147483648", "2", "0" },
-            new object[] { "9223372036854775807", "9223372036854775807", "0" },
-            new object[] { "9223372036854775807", "18446744073709551616", "9223372036854775807" },
-            new object[] { "9223372036854775807", "12.0", "8" }, // TODO: We should consider making this unsupported, since it may cause loss of precision.
-            new object[] { "18446744073709551616", "3", "1" },
-            new object[] { "18446744073709551616", "9223372036854775807", "2" },
-            new object[] { "18446744073709551616", "18446744073709551616", "0" }
-        };
+        Modulo_result_and_type.GetResult();
 
     public static IEnumerable<object[]> Modulo_type =>
+        Modulo_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> Modulo_result_and_type =>
         new List<object[]>
         {
-            new object[] { "5", "3", "System.Int32" },
-            new object[] { "9", "2.0", "System.Double" },
-            new object[] { "9.0", "2.0", "System.Double" },
-            new object[] { "2147483647", "2", "System.Int32" },
-            new object[] { "-2147483648", "2", "System.Int32" },
-            new object[] { "18446744073709551616", "3", "System.Numerics.BigInteger" }
+            new object[] { "5", "3", "2", typeof(int) },
+            new object[] { "2", "18446744073709551616", "2", typeof(BigInteger) },
+            new object[] { "9", "2.0", "1", typeof(double) },
+            new object[] { "9.0", "2.0", "1", typeof(double) },
+            new object[] { "2147483647", "2", "1", typeof(int) },
+            new object[] { "-2147483648", "2", "0", typeof(int) },
+            new object[] { "9223372036854775807", "9223372036854775807", "0", typeof(long) },
+            new object[] { "9223372036854775807", "18446744073709551616", "9223372036854775807", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "12.0", "8", typeof(double) }, // TODO: We should consider making this unsupported, since it may cause loss of precision.
+            new object[] { "18446744073709551616", "3", "1", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "9223372036854775807", "2", typeof(BigInteger) },
+            new object[] { "18446744073709551616", "18446744073709551616", "0", typeof(BigInteger) }
         };
 
     public static IEnumerable<object[]> Modulo_unsupported_types =>
@@ -846,21 +786,18 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> ShiftLeft_result =>
-        new List<object[]>
-        {
-            new object[] { "1", "10", "1024" },
-            new object[] { "1073741824", "1", "-2147483648" }, // Wraps around => becomes negative
-            new object[] { "9223372036854775807", "2", "-4" }, // Wraps around => becomes negative
-            new object[] { "18446744073709551616", "2", "73786976294838206464" },
-        };
+        ShiftLeft_result_and_type.GetResult();
 
     public static IEnumerable<object[]> ShiftLeft_type =>
+        ShiftLeft_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> ShiftLeft_result_and_type =>
         new List<object[]>
         {
-            new object[] { "1", "10", "System.Int32" },
-            new object[] { "1073741824", "1", "System.Int32" },
-            new object[] { "4294967296", "1", "System.Int64" },
-            new object[] { "18446744073709551616", "1", "System.Numerics.BigInteger" }
+            new object[] { "1", "10", "1024", typeof(int) },
+            new object[] { "1073741824", "1", "-2147483648", typeof(int) }, // Wraps around => becomes negative
+            new object[] { "9223372036854775807", "2", "-4", typeof(long) }, // Wraps around => becomes negative
+            new object[] { "18446744073709551616", "2", "73786976294838206464", typeof(BigInteger) },
         };
 
     public static IEnumerable<object[]> ShiftLeft_unsupported_types =>
@@ -902,19 +839,17 @@ public static class BinaryOperatorData
         };
 
     public static IEnumerable<object[]> ShiftRight_result =>
-        new List<object[]>
-        {
-            new object[] { "2147483647", "32", "2147483647" },
-            new object[] { "9223372036854775807", "2", "2305843009213693951" }, // Integer overflow => becomes negative
-            new object[] { "18446744073709551616", "2", "4611686018427387904" },
-        };
+        ShiftRight_result_and_type.GetResult();
 
     public static IEnumerable<object[]> ShiftRight_type =>
+        ShiftRight_result_and_type.GetTypes();
+
+    private static IEnumerable<object[]> ShiftRight_result_and_type =>
         new List<object[]>
         {
-            new object[] { "65536", "6", "System.Int32" },
-            new object[] { "1073741824", "1", "System.Int32" },
-            new object[] { "4611686018427387904", "1", "System.Int64" },
+            new object[] { "2147483647", "32", "2147483647", typeof(int) },
+            new object[] { "9223372036854775807", "2", "2305843009213693951", typeof(long) }, // Integer overflow => becomes negative
+            new object[] { "18446744073709551616", "2", "4611686018427387904", typeof(BigInteger) },
         };
 
     public static IEnumerable<object[]> ShiftRight_unsupported_types =>
@@ -954,4 +889,13 @@ public static class BinaryOperatorData
             new object[] { "12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
             new object[] { "12.0", "12.0", "Operands must be numbers, not double and double" },
         };
+}
+
+internal static class IEnumerableObjectExtensionMethods
+{
+    internal static IEnumerable<object[]> GetResult(this IEnumerable<object[]> resultAndTypes) =>
+        resultAndTypes.Select(obj => obj[..3]);
+
+    internal static IEnumerable<object[]> GetTypes(this IEnumerable<object[]> resultAndTypes) =>
+        resultAndTypes.Select(obj => new[] { obj[0], obj[1], obj[3].ToString() });
 }


### PR DESCRIPTION
We previously had some of these types checked, but they were kept in a separate list from the values, making it more painful to maintain and much harder to ensure that all values are present in both lists. This commit refactors this to use _one_ unified list for both the expected values and the expectd types, with some syntactic sugar to present it to the tests with "only the expected parameters". This should be a much more maintainable solution in the long run.