### PR TITLE
(interpreter) Improved type combination support w/ binary operators

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -8,9 +8,10 @@
 
 ### Fixed
 - Fix broken support for certain negative integer literals. [[#302][302]]
+- Improved type combination support with binary operators [[#327][327]]
 
 ### Tests
-- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1289 tests in version 0.2.0.
+- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1327 tests in version 0.2.0.
 - Improve coverage of binary operator type combinations [[#313][313]]
 - Add `BinaryoperatorData` test [[#316][316]]
 - Add full type coverage for `+` and `-` operators [[#317][317]]
@@ -39,3 +40,4 @@
 [324]: https://github.com/perlang-org/perlang/pull/324
 [325]: https://github.com/perlang-org/perlang/pull/325
 [326]: https://github.com/perlang-org/perlang/pull/326
+[327]: https://github.com/perlang-org/perlang/pull/327

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -890,6 +890,13 @@ namespace Perlang.Interpreter
             throw new RuntimeError(@operator, "Operand must be a number.");
         }
 
+        /// <summary>
+        /// Ensures that the given operands to a binary expression are numeric.
+        /// </summary>
+        /// <param name="operator">The operator for the given operand. Only used for error handling.</param>
+        /// <param name="left">The left-hand operand (evaluated value).</param>
+        /// <param name="right">The right-hand operand (evaluated value).</param>
+        /// <exception cref="RuntimeError">When one or both of the given operands are non-numeric.</exception>
         private static void CheckNumberOperands(Token @operator, object? left, object? right)
         {
             if (IsValidNumberType(left) && IsValidNumberType(right))
@@ -1138,6 +1145,10 @@ namespace Perlang.Interpreter
                 // IComparable would be useful to reduce code duplication here, but it has one major problem: it only
                 // supports same-type comparisons (int+int, long+long etc). We do not want to limit our code like that.
                 //
+
+                // Note: do **NOT** add new operators here without adding corresponding tests. (in the future, try to
+                // enforce this via e.g. ArchUnit.NET or a unit test)
+
                 case GREATER:
                     CheckNumberOperands(expr.Operator, left, right);
 
@@ -1146,6 +1157,13 @@ namespace Perlang.Interpreter
                     {
                         double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double rightNumber = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
+
+                        return leftNumber > rightNumber;
+                    }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
 
                         return leftNumber > rightNumber;
                     }
@@ -1200,6 +1218,13 @@ namespace Perlang.Interpreter
 
                         return leftNumber >= rightNumber;
                     }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
+
+                        return leftNumber >= rightNumber;
+                    }
                     else if (left is int or long && right is float or double)
                     {
                         long leftNumber = leftConvertible!.ToInt64(CultureInfo.InvariantCulture);
@@ -1251,6 +1276,13 @@ namespace Perlang.Interpreter
 
                         return leftNumber < rightNumber;
                     }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
+
+                        return leftNumber < rightNumber;
+                    }
                     else if (left is int or long && right is float or double)
                     {
                         long leftNumber = leftConvertible!.ToInt64(CultureInfo.InvariantCulture);
@@ -1299,6 +1331,13 @@ namespace Perlang.Interpreter
                     {
                         double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double rightNumber = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
+
+                        return leftNumber <= rightNumber;
+                    }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
 
                         return leftNumber <= rightNumber;
                     }
@@ -1361,6 +1400,13 @@ namespace Perlang.Interpreter
                     {
                         double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double rightNumber = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
+
+                        return leftNumber - rightNumber;
+                    }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
 
                         return leftNumber - rightNumber;
                     }
@@ -1468,6 +1514,13 @@ namespace Perlang.Interpreter
 
                         return leftNumber + rightNumber;
                     }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
+
+                        return leftNumber + rightNumber;
+                    }
                     else if (left is int && right is int)
                     {
                         int leftNumber = leftConvertible!.ToInt32(CultureInfo.InvariantCulture);
@@ -1527,6 +1580,13 @@ namespace Perlang.Interpreter
 
                         return leftNumber + rightNumber;
                     }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
+
+                        return leftNumber + rightNumber;
+                    }
                     else if (left is int && right is int)
                     {
                         int leftNumber = leftConvertible!.ToInt32(CultureInfo.InvariantCulture);
@@ -1575,6 +1635,13 @@ namespace Perlang.Interpreter
                     {
                         double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double rightNumber = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
+
+                        return leftNumber / rightNumber;
+                    }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
 
                         return leftNumber / rightNumber;
                     }
@@ -1636,6 +1703,13 @@ namespace Perlang.Interpreter
 
                         return leftNumber * rightNumber;
                     }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
+
+                        return leftNumber * rightNumber;
+                    }
                     else if (left is int or long && right is float or double)
                     {
                         long leftNumber = leftConvertible!.ToInt64(CultureInfo.InvariantCulture);
@@ -1687,7 +1761,9 @@ namespace Perlang.Interpreter
                 case STAR_STAR:
                     CheckNumberOperands(expr.Operator, left, right);
 
-                    if (left is float or double || right is float or double)
+                    if ((left is float or double && right is float or double) ||
+                        (left is float or double && right is int) ||
+                        (left is int && right is float or double))
                     {
                         double value = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double exponent = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
@@ -1710,6 +1786,10 @@ namespace Perlang.Interpreter
                         // surprises to the user.
                         int exponent = (int)right;
 
+                        // TODO: If we start doing compile-time evaluation of constant expressions, we should use
+                        // TODO: Expr.TypeReference here to check if the result should be narrowed down. For example,
+                        // TODO: `2 ** 10` can be stored without precision loss in both an `int` or a `uint`. We
+                        // TODO: shouldn't enforce the usage of BigInteger when we don't have to.
                         return BigInteger.Pow(value, exponent);
                     }
                     else if (left is BigInteger value && right is int)
@@ -1742,6 +1822,13 @@ namespace Perlang.Interpreter
                     {
                         long leftNumber = leftConvertible!.ToInt64(CultureInfo.InvariantCulture);
                         double rightNumber = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
+
+                        return leftNumber % rightNumber;
+                    }
+                    else if (left is float or double && right is int or long)
+                    {
+                        double leftNumber = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
+                        long rightNumber = rightConvertible!.ToInt64(CultureInfo.InvariantCulture);
 
                         return leftNumber % rightNumber;
                     }
@@ -1812,7 +1899,9 @@ namespace Perlang.Interpreter
                     }
                     else
                     {
-                        // TODO: "Operands must be numbers" isn't completely correct here.
+                        // TODO: "Operands must be numbers" isn't completely correct here. It should be fine once we
+                        // TODO: have gotten rid of these and made all such errors (compile-time) validation errors instead.
+                        // TODO: That way, this will just be a "fallback", an escape hatch if you will.
                         throw new RuntimeError(expr.Operator, $"Operands must be numbers, not {StringifyType(left)} and {StringifyType(right)}");
                     }
 

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -114,6 +114,11 @@ namespace Perlang.Interpreter.Typing
                         return VoidObject.Void;
                     }
 
+                    // TODO: This does not make sense for all binary operators. For example, LESS_LESS and
+                    // GREATER_GREATER only works with certain combinations of integer types. We should move them to a
+                    // separate `case` arm and try to handle them here => becomes a compile-time error instead of a
+                    // runtime error.
+
                     ITypeReference? typeReference = GreaterType(leftTypeReference, rightTypeReference);
 
                     if (typeReference == null)
@@ -153,8 +158,13 @@ namespace Perlang.Interpreter.Typing
                     {
                         expr.TypeReference.ClrType = typeof(double);
                     }
-                    else if ((leftTypeReference.ClrType == typeof(int) || leftTypeReference.ClrType == typeof(long)) &&
+                    else if (leftTypeReference.ClrType == typeof(int) &&
                              (rightTypeReference.ClrType == typeof(float) || rightTypeReference.ClrType == typeof(double)))
+                    {
+                        expr.TypeReference.ClrType = typeof(double);
+                    }
+                    else if ((leftTypeReference.ClrType == typeof(float) || leftTypeReference.ClrType == typeof(double)) &&
+                             (rightTypeReference.ClrType == typeof(int)))
                     {
                         expr.TypeReference.ClrType = typeof(double);
                     }

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
@@ -26,8 +26,10 @@ public static class BinaryOperatorData
             new object[] { "2147483646", "2147483647", "False" },
             new object[] { "2147483647", "2147483647", "False" },
             new object[] { "2147483647", "2147483646", "True" },
-            new object[] { "12", "34.0", "False" },
+            new object[] { "-12", "34.0", "False" },
             new object[] { "2147483647", "33.0", "True" },
+            new object[] { "12.0", "34", "False" },
+            new object[] { "12.0", "9223372036854775807", "False" },
             new object[] { "12.0", "34.0", "False" },
             new object[] { "34.0", "33.0", "True" },
 
@@ -42,8 +44,6 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "True" },
             new object[] { "18446744073709551616", "9223372036854775807", "True" },
             new object[] { "18446744073709551616", "18446744073709551616", "False" },
-            new object[] { "12.0", "34.0", "False" },
-            new object[] { "34.0", "33.0", "True" },
         };
 
     public static IEnumerable<object[]> Greater_unsupported_types =>
@@ -68,9 +68,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -81,8 +79,10 @@ public static class BinaryOperatorData
             new object[] { "2147483646", "2147483647", "False" },
             new object[] { "2147483647", "2147483647", "True" },
             new object[] { "2147483647", "2147483646", "True" },
-            new object[] { "12", "34.0", "False" },
+            new object[] { "-12", "34.0", "False" },
             new object[] { "2147483647", "33.0", "True" },
+            new object[] { "12.0", "34", "False" },
+            new object[] { "12.0", "9223372036854775807", "False" },
             new object[] { "12.0", "34.0", "False" },
             new object[] { "34.0", "33.0", "True" },
 
@@ -123,9 +123,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -137,6 +135,8 @@ public static class BinaryOperatorData
             new object[] { "12", "-34", "False" },
             new object[] { "12", "34.0", "True" },
             new object[] { "-12", "34", "True" },
+            new object[] { "-12.0", "-34", "False" },
+            new object[] { "-12.0", "9223372036854775807", "True" },
             new object[] { "-12", "-34", "False" },
             new object[] { "-12", "-34.0", "False" },
             new object[] { "2147483646", "2147483647", "True" },
@@ -155,6 +155,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "False" },
             new object[] { "18446744073709551616", "9223372036854775807", "False" },
             new object[] { "18446744073709551616", "18446744073709551617", "True" },
+            new object[] { "-12.0", "-34", "False" },
+            new object[] { "-12.0", "9223372036854775807", "True" },
             new object[] { "12.0", "34.0", "True" },
             new object[] { "34.0", "33.0", "False" },
         };
@@ -181,9 +183,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -196,7 +196,9 @@ public static class BinaryOperatorData
             new object[] { "2147483647", "2147483646", "False" },
             new object[] { "12", "34.0", "True" },
             new object[] { "2147483647", "33.0", "False" },
-            new object[] { "12.0", "34.0", "True" },
+            new object[] { "-12.0", "34.0", "True" },
+            new object[] { "-12.0", "-34", "False" },
+            new object[] { "-12.0", "9223372036854775807", "True" },
             new object[] { "34.0", "33.0", "False" },
 
             new object[] { "2", "18446744073709551616", "True" },
@@ -236,9 +238,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -354,6 +354,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "18446744069414584320", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551617", "-1", typeof(BigInteger) },
+            new object[] { "-12.0", "-34", "22", typeof(double) },
+            new object[] { "-12.0", "9223372036854775807", "-9.223372036854776E+18", typeof(double) }, // TODO: Support this or not?
             new object[] { "12.0", "34.0", "-22", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
         };
 
@@ -381,9 +383,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -407,7 +407,9 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "18446744069414584320", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "9223372036854775809", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551617", "-1", typeof(BigInteger) },
-            new object[] { "12.0", "34.0", "-22", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
+            new object[] { "-12.0", "-34", "22", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
+            new object[] { "-12.0", "9223372036854775807", "-9.223372036854776E+18", typeof(double) }, // TODO: Support this or not? Can cause precision loss
+            new object[] { "12.0", "34.0", "-22", typeof(double) },
         };
 
     public static IEnumerable<object[]> SubtractionAssignment_unsupported_types_runtime =>
@@ -423,9 +425,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551615", "18446744073709551615", "Operands must be numbers, not System.UInt64 and System.UInt64" },
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -473,6 +473,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "18446744078004518912", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233", typeof(BigInteger) },
+            new object[] { "12.0", "34", "46", typeof(double) },
+            new object[] { "12.0", "9223372036854775807", "9.223372036854776E+18", typeof(double) },
             new object[] { "12.0", "34.0", "46", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
             new object[] { "12.1", "34.2", "46.300000000000004", typeof(double) }, // IEEE-754... :-)
         };
@@ -483,9 +485,7 @@ public static class BinaryOperatorData
             new object[] { "2", "4294967295", "Operands must be numbers, not int and System.UInt32" },
             new object[] { "2", "4294967296", "Operands must be numbers, not int and long" },
             new object[] { "2", "18446744073709551615", "Operands must be numbers, not int and System.UInt64" },
-            new object[] { "12.0", "34", "Operands must be numbers, not double and int" },
             new object[] { "12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
             new object[] { "4294967295", "2", "Operands must be numbers, not System.UInt32 and int" },
@@ -527,6 +527,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967296", "18446744078004518912", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "27670116110564327423", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551617", "36893488147419103233", typeof(BigInteger) },
+            new object[] { "-12.0", "-34", "-46", typeof(double) },
+            new object[] { "-12.0", "9223372036854775807", "9.223372036854776E+18", typeof(double) },
             new object[] { "12.0", "34.0", "46", typeof(double) }, // Doubles with fraction part zero => fraction part excluded in string representation.
             new object[] { "12.1", "34.2", "46.300000000000004", typeof(double) }, // IEEE-754... :-)
         };
@@ -544,9 +546,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551615", "18446744073709551615", "Operands must be numbers, not System.UInt64 and System.UInt64" },
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
-            new object[] { "-12.0", "-34", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -589,6 +589,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "2", "9223372036854775808", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "2", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551616", "1", typeof(BigInteger) },
+            new object[] { "34.0", "5", "6.8", typeof(double) },
+            new object[] { "34.0", "9223372036854775807", "3.686287386450715E-18", typeof(double) },
             new object[] { "34.0", "5.0", "6.8", typeof(double) },
             new object[] { "34", "5.0", "6.8", typeof(double) }
         };
@@ -617,9 +619,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "12.0", "5", "Operands must be numbers, not double and int" },
             new object[] { "12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -643,6 +643,8 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "2", "36893488147419103232", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "170141183460469231713240559642174554112", typeof(BigInteger) },
             new object[] { "18446744073709551616", "18446744073709551616", "340282366920938463463374607431768211456", typeof(BigInteger) },
+            new object[] { "12.0", "5", "60", typeof(double) },
+            new object[] { "12.0", "9223372036854775807", "1.1068046444225731E+20", typeof(double) }, // TODO: Should we support this or not? Can cause precision loss.
             new object[] { "12.34", "0.3", "3.702", typeof(double) }
         };
 
@@ -670,9 +672,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "12.0", "5", "Operands must be numbers, not double and int" },
             new object[] { "12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };
@@ -687,17 +687,16 @@ public static class BinaryOperatorData
         new List<object[]>
         {
             new object[] { "2", "10", "1024", typeof(BigInteger) },
+            new object[] { "2.1", "10", "1667.9880978201006", typeof(double) },
             new object[] { "2.0", "10.0", "1024", typeof(double) },
             new object[] { "2", "9.9", "955.425783333691", typeof(double) },
             new object[] { "4294967296", "2", "18446744073709551616", typeof(BigInteger) },
-            new object[] { "4294967296", "10.0", "2.13598703592091E+96", typeof(double) },
             new object[] { "18446744073709551616", "2", "340282366920938463463374607431768211456", typeof(BigInteger) }
         };
 
     public static IEnumerable<object[]> Exponential_unsupported_types =>
         new List<object[]>
         {
-            new object[] { "2.1", "10", "Unsupported ** operands specified: double and int" },
             new object[] { "4294967296", "4294967296", "Unsupported ** operands specified: long and long" },
             new object[] { "10.0", "4294967296", "Unsupported ** operands specified: double and long" },
             new object[] { "18446744073709551616", "18446744073709551616", "Unsupported ** operands specified: bigint and bigint" },
@@ -715,6 +714,7 @@ public static class BinaryOperatorData
             new object[] { "9223372036854775807", "4294967295", "Unsupported ** operands specified: long and System.UInt32" },
             new object[] { "9223372036854775807", "18446744073709551615", "Unsupported ** operands specified: long and System.UInt64" },
             new object[] { "9223372036854775807", "18446744073709551616", "Unsupported ** operands specified: long and bigint" },
+            new object[] { "9223372036854775807", "10.0", "Unsupported ** operands specified: long and double" },
             new object[] { "18446744073709551615", "2", "Unsupported ** operands specified: System.UInt64 and int" },
             new object[] { "18446744073709551615", "4294967295", "Unsupported ** operands specified: System.UInt64 and System.UInt32" },
             new object[] { "18446744073709551615", "9223372036854775807", "Unsupported ** operands specified: System.UInt64 and long" },
@@ -743,7 +743,6 @@ public static class BinaryOperatorData
             new object[] { "5", "3", "2", typeof(int) },
             new object[] { "2", "18446744073709551616", "2", typeof(BigInteger) },
             new object[] { "9", "2.0", "1", typeof(double) },
-            new object[] { "9.0", "2.0", "1", typeof(double) },
             new object[] { "2147483647", "2", "1", typeof(int) },
             new object[] { "-2147483648", "2", "0", typeof(int) },
             new object[] { "9223372036854775807", "9223372036854775807", "0", typeof(long) },
@@ -751,7 +750,10 @@ public static class BinaryOperatorData
             new object[] { "9223372036854775807", "12.0", "8", typeof(double) }, // TODO: We should consider making this unsupported, since it may cause loss of precision.
             new object[] { "18446744073709551616", "3", "1", typeof(BigInteger) },
             new object[] { "18446744073709551616", "9223372036854775807", "2", typeof(BigInteger) },
-            new object[] { "18446744073709551616", "18446744073709551616", "0", typeof(BigInteger) }
+            new object[] { "18446744073709551616", "18446744073709551616", "0", typeof(BigInteger) },
+            new object[] { "9.0", "2.0", "1", typeof(double) },
+            new object[] { "-12.0", "2", "-0", typeof(double) },
+            new object[] { "-12.0", "9223372036854775807", "-12", typeof(double) },
         };
 
     public static IEnumerable<object[]> Modulo_unsupported_types =>
@@ -778,9 +780,7 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "4294967295", "Operands must be numbers, not bigint and System.UInt32" },
             new object[] { "18446744073709551616", "18446744073709551615", "Operands must be numbers, not bigint and System.UInt64" },
             new object[] { "18446744073709551616", "12.0", "Operands must be numbers, not bigint and double" },
-            new object[] { "9.0", "2", "Operands must be numbers, not double and int" },
             new object[] { "-12.0", "4294967295", "Operands must be numbers, not double and System.UInt32" },
-            new object[] { "-12.0", "9223372036854775807", "Operands must be numbers, not double and long" },
             new object[] { "-12.0", "18446744073709551615", "Operands must be numbers, not double and System.UInt64" },
             new object[] { "-12.0", "18446744073709551616", "Operands must be numbers, not double and bigint" },
         };


### PR DESCRIPTION
In particular, `float`/`double`+`int`/`long` operands were often broken
(missing in the implementation since the conversion from `dynamic` to
"static code").