### PR TITLE
(tests) De-duplicate `ReservedKeywordsTests`; improve coverage to cover all reserved words

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -14,7 +14,7 @@
 - Fix binary operator support for `int` + `long` [[#328][328]]
 
 ### Tests
-- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1334 tests in version 0.2.0.
+- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1431 tests in version 0.2.0.
 - Improve coverage of binary operator type combinations [[#313][313]]
 - Add test to ensure `BinaryoperatorData` covers all numeric type combinations [[#316][316]]
 - Add full type coverage for `+` and `-` operators [[#317][317]]
@@ -27,6 +27,7 @@
 - Add full type coverage for `%` operator [[#324][324]]
 - Add full type coverage for `<<` and `>>` operator [[#325][325]]
 - Verify expected types in binary operator tests [[#326][326]]
+- De-duplicate `ReservedKeywordsTests`; improve coverage to cover all reserved words [[#331][331]]
 
 [300]: https://github.com/perlang-org/perlang/pull/300
 [302]: https://github.com/perlang-org/perlang/issues/302
@@ -47,3 +48,4 @@
 [327]: https://github.com/perlang-org/perlang/pull/327
 [328]: https://github.com/perlang-org/perlang/pull/328
 [329]: https://github.com/perlang-org/perlang/pull/329
+[331]: https://github.com/perlang-org/perlang/pull/331

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -821,19 +821,6 @@ namespace Perlang.Parser
             {
                 throw Error(token, "Reserved keyword encountered", ParseErrorType.RESERVED_WORD_ENCOUNTERED);
             }
-
-            // Some type-related keywords are actually not marked as reserved words in the Scanner class, since they
-            // are defined in Perlang.Interpreter.Typing.TypeResolver.ResolveExplicitTypes. We special-case them here to
-            // make it easier to make these be proper reserved words sometime in the future.
-            switch (token.Lexeme)
-            {
-                case "int":
-                case "long":
-                case "bigint":
-                case "double":
-                case "string":
-                    throw Error(token, "Reserved keyword encountered", ParseErrorType.RESERVED_WORD_ENCOUNTERED);
-            }
         }
     }
 }

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -110,20 +110,40 @@ namespace Perlang.Parser
                 { "asm", RESERVED_WORD }
             }.ToImmutableDictionary();
 
-        private static ISet<string> reservedKeywordStrings;
+        public static IEnumerable<string> ReservedTypeKeywordStrings =>
+            new List<string>
+            {
+                // Some type-related keywords are actually not marked as reserved words in ReservedKeywords,
+                // since they are defined in Perlang.Interpreter.Typing.TypeResolver.ResolveExplicitTypes. We
+                // special-case them here to make it easier to make these be proper reserved words sometime in
+                // the future.
+                "int",
+                "long",
+                "bigint",
+                "double",
+                "string"
+            }.ToImmutableHashSet();
 
-        public static ISet<string> ReservedKeywordStrings
+        private static ISet<string> reservedKeywordOnlyStrings;
+
+        // Returns only the "proper" reserved keywords, not include the "reserved type keywords" listed above.
+        public static ISet<string> ReservedKeywordOnlyStrings
         {
             get
             {
-                reservedKeywordStrings ??= ReservedKeywords
+                reservedKeywordOnlyStrings ??= ReservedKeywords
                     .Where(kvp => kvp.Value == RESERVED_WORD)
                     .Select(kvp => kvp.Key)
-                    .ToHashSet();
+                    .ToImmutableHashSet();
 
-                return reservedKeywordStrings;
+                return reservedKeywordOnlyStrings;
             }
         }
+
+        public static IEnumerable<string> ReservedKeywordStrings =>
+            ReservedKeywordOnlyStrings
+                .Concat(ReservedTypeKeywordStrings)
+                .ToImmutableHashSet();
 
         private readonly string source;
         private readonly ScanErrorHandler scanErrorHandler;

--- a/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
+++ b/src/Perlang.Tests.Integration/ReservedKeywords/ReservedKeywordsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using Perlang.Parser;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
@@ -17,489 +18,118 @@ namespace Perlang.Tests.Integration.ReservedKeywords
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
 
-            Assert.Single(result.Errors);
-            Assert.Matches($"Error at 'class': Expect expression", exception.ToString());
-        }
-
-        [Theory]
-        [MemberData(nameof(GetReservedWords))]
-        public void reserved_keyword_throws_expected_error(string reservedWord)
-        {
-            string source = @$"
-                var {reservedWord} = 1;
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches($"Error at '{reservedWord}': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_public_throws_expected_error()
-        {
-            string source = @"
-                var public = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'public': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_private_throws_expected_error()
-        {
-            string source = @"
-                var private = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'private': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_protected_throws_expected_error()
-        {
-            string source = @"
-                var protected = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'protected': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_internal_throws_expected_error()
-        {
-            string source = @"
-                var internal = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'internal': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_static_throws_expected_error()
-        {
-            string source = @"
-                var static = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'static': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_volatile_throws_expected_error()
-        {
-            string source = @"
-                var volatile = 1
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'volatile': Reserved keyword encountered", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain("Error at 'class': Expect expression");
         }
 
         //
         // Variable declarations: ensure that reserved keywords cannot be used as variable names
         //
 
-        [Fact]
-        public void reserved_keyword_int_cannot_be_used_as_variable_name()
+        [Theory]
+        [MemberData(nameof(GetReservedWords))]
+        public void reserved_keyword_cannot_be_used_as_variable_name(string reservedWord)
         {
-            string source = @"
-                var int = 123;
+            string source = $@"
+                var {reservedWord} = 123;
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
 
-            Assert.Single(result.Errors);
-
-            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_float_cannot_be_used_as_variable_name()
-        {
-            string source = @"
-                var float = 123;
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-
-            Assert.Matches("Error at 'float': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_double_cannot_be_used_as_variable_name()
-        {
-            string source = @"
-                var double = 123;
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-
-            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_string_cannot_be_used_as_variable_name()
-        {
-            string source = @"
-                var string = ""foo"";
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.First();
-
-            Assert.Single(result.Errors);
-
-            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain($"Error at '{reservedWord}': Reserved keyword encountered");
         }
 
         //
         // Functions: ensure that reserved keywords cannot be used as function names
         //
 
-        [Fact]
-        public void reserved_keyword_int_cannot_be_used_as_function_name()
+        [Theory]
+        [MemberData(nameof(GetReservedWordsOnly))]
+        public void reserved_keyword_cannot_be_used_as_function_name(string reservedWord)
         {
-            string source = @"
-                fun int(): void {
-                }
+            string source = $@"
+                fun {reservedWord}(): void {{
+                }}
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain($"Error at '{reservedWord}': Expect function name");
         }
 
-        [Fact]
-        public void reserved_keyword_long_cannot_be_used_as_function_name()
+        [Theory]
+        [MemberData(nameof(GetTypeReservedWords))]
+        public void reserved_type_keyword_cannot_be_used_as_function_name(string reservedWord)
         {
-            string source = @"
-                fun long(): void {
-                }
+            string source = $@"
+                fun {reservedWord}(): void {{
+                }}
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'long': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_float_cannot_be_used_as_function_name()
-        {
-            string source = @"
-                fun float(): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'float': Expect function name", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_double_cannot_be_used_as_function_name()
-        {
-            string source = @"
-                fun double(): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_string_cannot_be_used_as_function_name()
-        {
-            string source = @"
-                fun string(): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain($"Error at '{reservedWord}': Reserved keyword encountered");
         }
 
         //
         // Functions: ensure that reserved words cannot be used as function parameter names
         //
 
-        [Fact]
-        public void reserved_keyword_int_cannot_be_used_as_function_parameter_name()
+        [Theory]
+        [MemberData(nameof(GetReservedWords))]
+        public void reserved_keyword_cannot_be_used_as_function_parameter_name(string reservedWord)
         {
-            string source = @"
-                fun foo(int: int): void {
-                }
+            string source = $@"
+                fun foo({reservedWord}: int): void {{
+                }}
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'int': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_long_cannot_be_used_as_function_parameter_name()
-        {
-            string source = @"
-                fun foo(long: long): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'long': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_float_cannot_be_used_as_function_parameter_name()
-        {
-            string source = @"
-                fun foo(float: float): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'float': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_double_cannot_be_used_as_function_parameter_name()
-        {
-            string source = @"
-                fun foo(double: double): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'double': Reserved keyword encountered", exception.ToString());
-        }
-
-        [Fact]
-        public void reserved_keyword_string_cannot_be_used_as_function_parameter_name()
-        {
-            string source = @"
-                fun foo(string: string): void {
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'string': Reserved keyword encountered", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain($"Error at '{reservedWord}': Reserved keyword encountered");
         }
 
         //
         // Return types: ensure that reserved keywords cannot be used as return types
         //
-        // Note that as 'byte', 'sbyte', 'float' etc are not valid types name yet, this test expects a particular error
-        // to be thrown. For more details on reserved words, see #178. (Technically, these test does not exercise the
-        // "reserved words" code paths at all; since the type names aren't defined, they fail as they would with any
-        // other non-defined type name.)
 
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_byte()
+        [Theory]
+        [MemberData(nameof(GetReservedWordsOnly))]
+        public void function_return_type_detects_reserved_keyword(string reservedWord)
         {
-            string source = @"
-                fun foo(): byte {
+            string source = $@"
+                fun foo(): {reservedWord} {{
                     return 123;
-                }
+                }}
             ";
 
             var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'byte': Expecting type name", exception.ToString());
+            result.Errors.Should()
+                .ContainSingle().Which
+                .ToString().Should().Contain($"Error at '{reservedWord}': Expecting type name");
         }
 
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_sbyte()
-        {
-            string source = @"
-                fun foo(): sbyte {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'sbyte': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_short()
-        {
-            string source = @"
-                fun foo(): short {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'short': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_ushort()
-        {
-            string source = @"
-                fun foo(): ushort {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'ushort': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_uint()
-        {
-            string source = @"
-                fun foo(): uint {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'uint': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_ulong()
-        {
-            string source = @"
-                fun foo(): ulong {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'ulong': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_float()
-        {
-            string source = @"
-                fun foo(): float {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'float': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_decimal()
-        {
-            string source = @"
-                fun foo(): decimal {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'decimal': Expecting type name", exception.ToString());
-        }
-
-        [Fact]
-        public void function_return_type_detects_reserved_keyword_char()
-        {
-            string source = @"
-                fun foo(): char {
-                    return 123;
-                }
-            ";
-
-            var result = EvalWithParseErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
-
-            Assert.Single(result.Errors);
-            Assert.Matches("Error at 'char': Expecting type name", exception.ToString());
-        }
-
-        public static IEnumerable<object[]> GetReservedWords()
-        {
-            return Scanner.ReservedKeywordStrings
+        public static IEnumerable<object[]> GetReservedWords() =>
+            Scanner.ReservedKeywordStrings
                 .Select(s => new object[] { s });
-        }
+
+        public static IEnumerable<object[]> GetTypeReservedWords() =>
+            Scanner.ReservedTypeKeywordStrings
+                .Select(s => new object[] { s });
+
+        public static IEnumerable<object[]> GetReservedWordsOnly() =>
+            Scanner.ReservedKeywordOnlyStrings
+                .Select(s => new object[] { s });
     }
 }


### PR DESCRIPTION
...and use `[Theory]`-based testing for more of the tests. This makes _all_ reserved keywords (even the ones which were previously special-cased in `PerlangParser.BlockReservedIdentifiers`) be tested by these tests.