### PR TITLE
(tests) Make `BinaryOperatorDataTests` faster

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -28,6 +28,7 @@
 - Add full type coverage for `<<` and `>>` operator [[#325][325]]
 - Verify expected types in binary operator tests [[#326][326]]
 - De-duplicate `ReservedKeywordsTests`; improve coverage to cover all reserved words [[#331][331]]
+- Make BinaryOperatorDataTests faster [[#332][332]]
 
 [300]: https://github.com/perlang-org/perlang/pull/300
 [302]: https://github.com/perlang-org/perlang/issues/302
@@ -49,3 +50,4 @@
 [328]: https://github.com/perlang-org/perlang/pull/328
 [329]: https://github.com/perlang-org/perlang/pull/329
 [331]: https://github.com/perlang-org/perlang/pull/331
+[332]: https://github.com/perlang-org/perlang/pull/332

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorDataTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorDataTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -117,6 +118,8 @@ public class BinaryOperatorDataTests
         EnsureAllTypesAreHandled(ShiftRight_result, ShiftRight_unsupported_types, "ShiftRight");
     }
 
+    private static readonly ConcurrentDictionary<string, Type> TypesForEvaluatedValues = new();
+
     private static void EnsureAllTypesAreHandled(IEnumerable<object[]> supportedResults, IEnumerable<object[]> unsupportedTypes, string operatorName)
     {
         var data = supportedResults.Concat(unsupportedTypes);
@@ -129,8 +132,21 @@ public class BinaryOperatorDataTests
 
         foreach (object[] objects in data)
         {
-            Type leftType = EvalHelper.Eval((string)objects[0]).GetType();
-            Type rightType = EvalHelper.Eval((string)objects[1]).GetType();
+            string o1 = (string)objects[0];
+            string o2 = (string)objects[1];
+
+            if (!TypesForEvaluatedValues.ContainsKey(o1))
+            {
+                TypesForEvaluatedValues[o1] = EvalHelper.Eval(o1).GetType();
+            }
+
+            if (!TypesForEvaluatedValues.ContainsKey(o2))
+            {
+                TypesForEvaluatedValues[o2] = EvalHelper.Eval(o2).GetType();
+            }
+
+            Type leftType = TypesForEvaluatedValues[o1];
+            Type rightType = TypesForEvaluatedValues[o2];
 
             seenTypeCombinations.Add((leftType, rightType));
         }


### PR DESCRIPTION
I've noted lately that some of the tests now take a noticeable time to execute. The fact that commonly used test values like `4294967295` was being evaluated over and over again was perhaps good for stress-testing the concurrency handling in the Perlang interpreter :wink: but pretty stupid from any other point of view.

Caching these evaluated values brings the execution for these tests down from about ~25s to about 2-3s on my machine, which is a nice small step to retain very fast execution of our test suite.