### PR TITLE
(interpreter) Allow coercions from `long` to `double`

### DIFF
--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -3,6 +3,7 @@
 ### Added
 - Allow assignment from `int` to `double` [[#300][300]]
 - Add support for `uint` data type [[#307][307]]
+- Allow coercions from `long` to `double [[#336][336]]
 
 ### Changed
 - Refactor number parsing to use *Literal types [[#308][308]]
@@ -15,7 +16,7 @@
 - Fix binary operator support for `int` + `long` [[#328][328]]
 
 ### Tests
-- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1530 tests in version 0.2.0.
+- Greatly increased the test coverage in general. The number of tests increased from 537 tests in the previous release to 1532 tests in version 0.2.0.
 - Improve coverage of binary operator type combinations [[#313][313]]
 - Add test to ensure `BinaryoperatorData` covers all numeric type combinations [[#316][316]]
 - Add full type coverage for `+` and `-` operators [[#317][317]]
@@ -55,3 +56,4 @@
 [331]: https://github.com/perlang-org/perlang/pull/331
 [332]: https://github.com/perlang-org/perlang/pull/332
 [333]: https://github.com/perlang-org/perlang/pull/333
+[336]: https://github.com/perlang-org/perlang/pull/336

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -1825,11 +1825,9 @@ namespace Perlang.Interpreter
                     CheckNumberOperands(expr.Operator, left, right);
 
                     if ((left is float or double && right is float or double) ||
-                        (left is float or double && right is int or uint) ||
-                        (left is int or uint && right is float or double))
+                        (left is float or double && right is int or long or uint) ||
+                        (left is int or long or uint && right is float or double))
                     {
-                        // TODO: `long` can be safely cast to `double` in .NET. We could consider supporting it here
-                        // TODO: also; it loses no precision for all integers between 2^53 and -2^53 and people working with numbers larger than th
                         double value = leftConvertible!.ToDouble(CultureInfo.InvariantCulture);
                         double exponent = rightConvertible!.ToDouble(CultureInfo.InvariantCulture);
 

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -36,9 +36,10 @@ namespace Perlang.Interpreter.Typing
 
         internal static ImmutableDictionary<Type, int?> FloatIntegerLengthByType => new Dictionary<Type, int?>
         {
-            // Double-precision values are 64-bit but can only save 53-bit integers with exact precision. Since there
-            // are no "53-bit" types, we just make this the "next smaller available" bit length.
-            { typeof(Double), 32 }
+            // Double-precision values are 64-bit but can store numbers up to 1.7E +/- 308 (with data loss, i.e. numbers
+            // larger than +/- 2^53 can not be exactly represented. We presume people working with numbers this large to
+            // be (or make themselves aware of) this limitation.
+            { typeof(Double), 64 }
         }.ToImmutableDictionary();
 
         /// <summary>

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -228,18 +228,13 @@ namespace Perlang.Interpreter.Typing
                         // TODO: `PerlangInterpreter.VisitBinaryExpr()` for details.
                         expr.TypeReference.ClrType = typeof(BigInteger);
                     }
-                    else if ((leftTypeReference.ClrType == typeof(float) || leftTypeReference.ClrType == typeof(double)) &&
-                             (rightTypeReference.ClrType == typeof(float) || rightTypeReference.ClrType == typeof(double)))
+                    else if (new[] { typeof(int), typeof(long), typeof(uint), typeof(float), typeof(double) }.Contains(leftTypeReference.ClrType) &&
+                             new[] { typeof(float), typeof(double) }.Contains(rightTypeReference.ClrType))
                     {
                         expr.TypeReference.ClrType = typeof(double);
                     }
-                    else if ((leftTypeReference.ClrType == typeof(int) || leftTypeReference.ClrType == typeof(uint)) &&
-                             (rightTypeReference.ClrType == typeof(float) || rightTypeReference.ClrType == typeof(double)))
-                    {
-                        expr.TypeReference.ClrType = typeof(double);
-                    }
-                    else if ((leftTypeReference.ClrType == typeof(float) || leftTypeReference.ClrType == typeof(double)) &&
-                             (rightTypeReference.ClrType == typeof(int) || rightTypeReference.ClrType == typeof(uint)))
+                    else if (new[] { typeof(float), typeof(double) }.Contains(leftTypeReference.ClrType) &&
+                             new[] { typeof(int), typeof(long), typeof(uint), typeof(float), typeof(double) }.Contains(rightTypeReference.ClrType))
                     {
                         expr.TypeReference.ClrType = typeof(double);
                     }

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
@@ -662,8 +662,10 @@ public static class BinaryOperatorData
             new object[] { "4294967295", "2", "18446744065119617025", typeof(BigInteger) },
             new object[] { "4294967295", "12.0", "3.9402006086306546E+115", typeof(double) },
             new object[] { "9223372036854775807", "2", "85070591730234615847396907784232501249", typeof(BigInteger) },
+            new object[] { "9223372036854775807", "2.0", "8.507059173023462E+37", typeof(double) },
             new object[] { "18446744073709551616", "2", "340282366920938463463374607431768211456", typeof(BigInteger) },
-            new object[] { "12.0", "4294967295", "Infinity", typeof(double) },
+            new object[] { "2.0", "4294967295", "Infinity", typeof(double) },
+            new object[] { "2.0", "9223372036854775807", "Infinity", typeof(double) },
         };
 
     public static IEnumerable<object[]> Exponential_unsupported_types =>
@@ -681,7 +683,6 @@ public static class BinaryOperatorData
             new object[] { "9223372036854775807", "9223372036854775807", "Unsupported ** operand types: 'long' and 'long'" },
             new object[] { "9223372036854775807", "18446744073709551615", "Unsupported ** operand types: 'long' and 'System.UInt64'" },
             new object[] { "9223372036854775807", "18446744073709551616", "Unsupported ** operand types: 'long' and 'bigint'" },
-            new object[] { "9223372036854775807", "10.0", "Unsupported ** operand types: 'long' and 'double'" },
             new object[] { "18446744073709551615", "2", "Unsupported ** operand types: 'System.UInt64' and 'int'" },
             new object[] { "18446744073709551615", "4294967295", "Unsupported ** operand types: 'System.UInt64' and 'uint'" },
             new object[] { "18446744073709551615", "9223372036854775807", "Unsupported ** operand types: 'System.UInt64' and 'long'" },
@@ -693,7 +694,6 @@ public static class BinaryOperatorData
             new object[] { "18446744073709551616", "18446744073709551615", "Unsupported ** operand types: 'bigint' and 'System.UInt64'" },
             new object[] { "18446744073709551616", "18446744073709551616", "Unsupported ** operand types: 'bigint' and 'bigint'" },
             new object[] { "18446744073709551616", "12.0", "Unsupported ** operand types: 'bigint' and 'double'" },
-            new object[] { "-12.0", "9223372036854775807", "Unsupported ** operand types: 'double' and 'long'" },
             new object[] { "-12.0", "18446744073709551615", "Unsupported ** operand types: 'double' and 'System.UInt64'" },
             new object[] { "-12.0", "18446744073709551616", "Unsupported ** operand types: 'double' and 'bigint'" },
         };

--- a/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/DoubleTests.cs
@@ -36,22 +36,25 @@ public class DoubleTests
     }
 
     [Fact]
-    public void double_variable_throws_expected_exception_when_initialized_from_long_constant()
+    public void double_variable_can_be_initialized_from_long_constant()
     {
         // 64-bit integers cannot be reliably stored in a double, since IEEE 754 double-precision floating point can
         // only represent without data loss integers in the range -2^53 to 2^53. More details:
         // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values
+        //
+        // _However_, since other well-respected languages like Java and C# allow this implicit conversion, we decided
+        // to allow it in Perlang alike, to reduce end-user confusion.
 
-        // TODO: Consider changing these semantics. .NET (and Java) both supports this kind of implicit conversion.
         string source = @"
                 var d: double = 9223372036854775807;
+
+                print(d);
             ";
 
-        var result = EvalWithValidationErrorCatch(source);
-        var exception = result.Errors.First();
+        var result = EvalReturningOutputString(source);
 
-        Assert.Single(result.Errors);
-        Assert.Matches("Cannot assign long to double variable", exception.Message);
+        // Note how this is less exact than the source value
+        Assert.Equal("9.223372036854776E+18", result);
     }
 
     [Fact]


### PR DESCRIPTION
We already supported some of this, so allowing it all the way made more sense. It also nicely aligns our semantics more with Java and C#, which are languages we greatly respect.