### PR TITLE
(consoleapp) Upgrade `System.CommandLine` to 2.0.0-beta4.22272.1

### DIFF
--- a/release-notes/v0.3.0.md
+++ b/release-notes/v0.3.0.md
@@ -5,6 +5,7 @@
 ### Added
 #### General
 - Upgrade to .NET 7 RC1 [[#347][347]]
+- Upgrade `System.CommandLine` to 2.0.0-beta4.22272.1 [[#350][350]]
 
 ### Changed
 * Quote types names in error message emitted when attempting to reassign a variable to an incoercible type. [[#343][343]]
@@ -16,3 +17,4 @@
 [343]: https://github.com/perlang-org/perlang/pull/343
 [344]: https://github.com/perlang-org/perlang/pull/344
 [347]: https://github.com/perlang-org/perlang/pull/347
+[350]: https://github.com/perlang-org/perlang/pull/350

--- a/src/Perlang.ConsoleApp/CommandResultExtensions.cs
+++ b/src/Perlang.ConsoleApp/CommandResultExtensions.cs
@@ -4,12 +4,11 @@ using System.CommandLine.Parsing;
 
 namespace Perlang.ConsoleApp
 {
-    // TODO: Remove this class if/when https://github.com/dotnet/command-line-api/pull/1272 gets merged.
     public static class CommandResultExtensions
     {
         public static bool HasOption(
             this CommandResult commandResult,
-            IOption option)
+            Option option)
         {
             if (commandResult is null)
             {
@@ -21,7 +20,7 @@ namespace Perlang.ConsoleApp
 
         public static bool HasArgument(
             this CommandResult commandResult,
-            IArgument argument)
+            Argument argument)
         {
             if (commandResult is null)
             {

--- a/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -39,7 +39,8 @@
 
     <ItemGroup>
         <PackageReference Include="ReadLine" Version="2.0.1" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a step towards resolving #348. The old version of this dependency of ours is not properly annotated for trimming. This has been fixed in https://github.com/dotnet/command-line-api/pull/1572, which is included in the updated version.