### PR TITLE
(many) Upgrade to .NET 7 RTM

### DIFF
--- a/.github/workflows/publish-release-packages.yml
+++ b/.github/workflows/publish-release-packages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100-rc.1.22431.12
+          dotnet-version: 7.0.x
 
       - name: Re-generate auto-generated files
         run: make auto-generated

--- a/.github/workflows/publish-snapshot-packages.yml
+++ b/.github/workflows/publish-snapshot-packages.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100-rc.1.22431.12
+          dotnet-version: 7.0.x
 
       - name: Re-generate auto-generated files
         run: make auto-generated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100-rc.1.22431.12
+          dotnet-version: 7.0.x
 
       - name: Re-generate auto-generated files
         run: make auto-generated

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100-rc.1.22431.12
+          dotnet-version: 7.0.x
 
         #
         # Technically, this part is very different from the later part which

--- a/release-notes/v0.3.0.md
+++ b/release-notes/v0.3.0.md
@@ -4,8 +4,9 @@
 
 ### Added
 #### General
-- Upgrade to .NET 7 RC1 [[#347][347]]
+- ~~Upgrade to .NET 7 RC1 [[#347][347]]~~, superseded by [[#351][351]]
 - Upgrade `System.CommandLine` to 2.0.0-beta4.22272.1 [[#350][350]]
+- Upgrade to .NET 7 RTM [[#351][351]]
 
 ### Changed
 * Quote types names in error message emitted when attempting to reassign a variable to an incoercible type. [[#343][343]]
@@ -18,3 +19,4 @@
 [344]: https://github.com/perlang-org/perlang/pull/344
 [347]: https://github.com/perlang-org/perlang/pull/347
 [350]: https://github.com/perlang-org/perlang/pull/350
+[351]: https://github.com/perlang-org/perlang/pull/351


### PR DESCRIPTION
.NET 7 was [released last week](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/). This PR upgrades our CI tooling to use the RTM version for building the releases.