### PR TITLE
(many) Implement `AsciiString` for ASCII-only strings

### DIFF
--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -16,6 +16,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=incoercible/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=indexee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libc/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=memcmp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=numerability/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pascalize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pascalized/@EntryIndexedValue">True</s:Boolean>
@@ -23,6 +24,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Titleized/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=toupper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ucrtbase/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werror/@EntryIndexedValue">True</s:Boolean>

--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -4,6 +4,9 @@
 ### Added
 
 ### Changed
+#### Data types
+- Implement `AsciiString` for ASCII-only strings [[#377][377]]
+
 #### Maintenance
 - Bump TngTech.ArchUnitNET.xUnit from 0.5.0 to 0.10.5 [[#366][366]]
 - Bump xunit from 2.4.1 to 2.4.2 [[#369][369]]
@@ -15,4 +18,5 @@
 [366]: https://github.com/perlang-org/perlang/pull/366
 [369]: https://github.com/perlang-org/perlang/pull/369
 [374]: https://github.com/perlang-org/perlang/pull/374
+[377]: https://github.com/perlang-org/perlang/pull/377
 [380]: https://github.com/perlang-org/perlang/pull/380

--- a/src/Perlang.Common/Expr.cs
+++ b/src/Perlang.Common/Expr.cs
@@ -220,6 +220,9 @@ namespace Perlang
             public Token? Token => (Expression as ITokenAware)?.Token;
         }
 
+        /// <summary>
+        /// A literal string or number.
+        /// </summary>
         public class Literal : Expr
         {
             public object? Value { get; }

--- a/src/Perlang.Common/Perlang.Common.csproj
+++ b/src/Perlang.Common/Perlang.Common.csproj
@@ -9,6 +9,7 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Common.xml</DocumentationFile>
       <NoWarn>1591;1701;1702</NoWarn>
+      <WarningsAsErrors>CS8618;NU1605;SYSLIB0011</WarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Perlang.Interpreter/InterpreterMessages.cs
+++ b/src/Perlang.Interpreter/InterpreterMessages.cs
@@ -1,5 +1,5 @@
 using Perlang.Interpreter.Extensions;
-using static Perlang.Utils;
+using static Perlang.Internal.Utils;
 
 namespace Perlang.Interpreter;
 

--- a/src/Perlang.Interpreter/Typing/BooleanOperandsValidator.cs
+++ b/src/Perlang.Interpreter/Typing/BooleanOperandsValidator.cs
@@ -1,5 +1,5 @@
 using System;
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 using Perlang.Interpreter.NameResolution;
 
 namespace Perlang.Interpreter.Typing

--- a/src/Perlang.Interpreter/Typing/Messages.cs
+++ b/src/Perlang.Interpreter/Typing/Messages.cs
@@ -1,5 +1,5 @@
 #nullable enable
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 using Perlang.Interpreter.Extensions;
 
 namespace Perlang.Interpreter.Typing;

--- a/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypeAssignmentValidator.cs
@@ -1,5 +1,5 @@
 using System;
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 using Perlang.Interpreter.NameResolution;
 using Perlang.Parser;
 

--- a/src/Perlang.Interpreter/Typing/TypeCoercer.cs
+++ b/src/Perlang.Interpreter/Typing/TypeCoercer.cs
@@ -109,8 +109,17 @@ namespace Perlang.Interpreter.Typing
 
             if (sourceSize == null || targetSize == null)
             {
-                // One or both of the values involved are non-numeric. The coercion is unsupported in this case.
-                return false;
+                // One or both of the values involved are non-numeric. The coercion is normally unsupported in this
+                // case, but let's check for assignability first: The target type can be a supertype of sourceType
+                // (inheritance or interfaces), in which case the coercion is fine.
+                if (sourceType?.IsAssignableTo(targetType) ?? false)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             // Expansions are fine; in other words, as long as the target type is wider (number of bits) or than or

--- a/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
+++ b/src/Perlang.Interpreter/Typing/TypesResolvedValidator.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 using Perlang.Interpreter.NameResolution;
 using Perlang.Parser;
 

--- a/src/Perlang.Parser/NumberParser.cs
+++ b/src/Perlang.Parser/NumberParser.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.Numerics;
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 
 #nullable enable
 namespace Perlang.Parser;

--- a/src/Perlang.Parser/Perlang.Parser.csproj
+++ b/src/Perlang.Parser/Perlang.Parser.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Perlang.Common\Perlang.Common.csproj" />
+      <ProjectReference Include="..\Perlang.Stdlib\Perlang.Stdlib.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Perlang.Stdlib/Internal/Extensions/TypeExtensions.cs
+++ b/src/Perlang.Stdlib/Internal/Extensions/TypeExtensions.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Numerics;
+using Perlang.Lang;
 
-namespace Perlang.Extensions
+namespace Perlang.Internal.Extensions
 {
     /// <summary>
     /// Extension methods for <see cref="Type"/>.
@@ -20,7 +21,8 @@ namespace Perlang.Extensions
                 { } when type == typeof(Single) => "float",
                 { } when type == typeof(Double) => "double",
                 { } when type == typeof(NullObject) => "null",
-                { } when type == typeof(String) => "string",
+                { } when type == typeof(Lang.String) => "string",
+                { } when type == typeof(AsciiString) => "AsciiString",
 
                 // TODO: add bool here
                 { } when type.IsAssignableTo(typeof(IPerlangFunction)) => "function",

--- a/src/Perlang.Stdlib/Internal/MemoryAllocator.cs
+++ b/src/Perlang.Stdlib/Internal/MemoryAllocator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+
+namespace Perlang.Internal;
+
+/// <summary>
+/// Very simple memory allocator.
+/// </summary>
+internal static class MemoryAllocator
+{
+    private static readonly ConcurrentBag<IntPtr> AllocatedChunks = new();
+
+    static MemoryAllocator()
+    {
+        AppDomain.CurrentDomain.ProcessExit += FreeAllocatedMemory;
+    }
+
+    public static unsafe void* Allocate(nuint count)
+    {
+        // TODO: Use jemalloc instead. Requires creating a NuGet package of it for easiest consumption from this project.
+        // TODO: See https://github.com/dotnet/runtime/issues/11404 and https://github.com/allisterb/jemalloc.NET for
+        // TODO: some prior art.
+
+        // We keep a local track of all memory allocated using this allocator, for a poor-man's "garbage collection"
+        // when the process exits. In the future we may attempt to do better: #
+        void* result = NativeMemory.Alloc(count);
+        AllocatedChunks.Add((IntPtr)result);
+        return result;
+    }
+
+    private static unsafe void FreeAllocatedMemory(object sender, EventArgs e)
+    {
+        foreach (IntPtr allocatedChunk in AllocatedChunks)
+        {
+            var allocatedChunkPtr = (void*)allocatedChunk;
+            NativeMemory.Free(allocatedChunkPtr);
+        }
+    }
+}

--- a/src/Perlang.Stdlib/Internal/Utils.cs
+++ b/src/Perlang.Stdlib/Internal/Utils.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Globalization;
-using Perlang.Extensions;
+using Perlang.Internal.Extensions;
 
-namespace Perlang
+namespace Perlang.Internal
 {
     /// <summary>
     /// Various utility methods.

--- a/src/Perlang.Stdlib/Lang/AsciiString.cs
+++ b/src/Perlang.Stdlib/Lang/AsciiString.cs
@@ -1,0 +1,271 @@
+#nullable enable
+#pragma warning disable S112
+#pragma warning disable SA1300
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Perlang.Internal;
+using Perlang.Stdlib;
+
+namespace Perlang.Lang;
+
+/// <summary>
+/// Representation of a string with ASCII-only content.
+///
+/// <see cref="AsciiString"/> have the following characteristics:
+///
+/// - They consist of valid ASCII characters (0-127) only.
+///
+/// - They are _immutable_. Once constructed, an <see cref="AsciiString"/> cannot be modified. Methods which seem to
+///   perform "modifications" of the string like <see cref="ToUpper"/> etc. will always allocate a new instance and
+///   operate on that.
+///
+/// - They are _backed by native memory_. This means that they can be used with zero/very low cost together with
+///   standard POSIX/libc functions like `puts`, `memcmp`, etc.
+/// </summary>
+public class AsciiString : Lang.String
+{
+    private readonly unsafe byte* bytes;
+    private readonly nuint length;
+
+    public override nuint Length => length;
+
+    /// <summary>
+    /// Memoized uppercase form of this string. Will be initialized on the first call to <see cref="ToUpper"/>.
+    /// </summary>
+    private AsciiString? upperString;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsciiString"/> class from an existing <see cref="char"/> array. A
+    /// new `byte[]` will be allocated to contain the string content.
+    /// </summary>
+    /// <param name="chars">A char array, validated by the caller to be ASCII safe.</param>
+    /// <returns>A newly allocated <see cref="AsciiString"/>.</returns>
+    public static AsciiString from(IReadOnlyList<char> chars)
+    {
+        // TODO: Consider validating the data here after all, or try to enforce that the caller has validated it
+        // TODO: somehow. Enforcing correctness might be a more noble goal than speed in this use case.
+        return new AsciiString(chars);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="AsciiString"/> from the given .NET string. Note that this method will allocate a new
+    /// backing buffer for holding the string contents; it will not reuse the existing bytes.
+    /// </summary>
+    /// <param name="s">The input string.</param>
+    /// <returns>A newly allocated <see cref="AsciiString"/>.</returns>
+    /// <exception cref="ArgumentException">The given string contains non-ASCII characters.</exception>
+    public static AsciiString from(string s)
+    {
+        char[] chars = s.ToCharArray();
+
+        foreach (char c in chars)
+        {
+            if (c > 127)
+            {
+                throw new ArgumentException($"Attempted to construct an AsciiString from a string which contains non-ASCII characters: {s}");
+            }
+        }
+
+        return new AsciiString(chars);
+    }
+
+    /// <summary>
+    /// Concatenates the given strings. This method will allocate a new <see cref="AsciiString"/> and the existing
+    /// string data will be copied to it.
+    /// </summary>
+    /// <param name="a">The first string to concatenate.</param>
+    /// <param name="b">The second string to concatenate.</param>
+    /// <returns>A concatenated string (`a` + `b`).</returns>
+    public static unsafe AsciiString operator +(AsciiString a, AsciiString b)
+    {
+        nuint resultLength = a.Length + b.Length;
+        byte* c = (byte*)MemoryAllocator.Allocate(resultLength + 1);
+
+        // TODO: Consider converting to call memcpy(), to be less .NET dependent.
+        Buffer.MemoryCopy(a.bytes, c, resultLength + 1, a.Length);
+        Buffer.MemoryCopy(b.bytes, c + a.Length, resultLength + 1 - a.Length, b.Length);
+
+        // Add a trailing NUL character
+        c[resultLength] = 0;
+
+        return from(c, resultLength);
+    }
+
+    /// <summary>
+    /// Determines whether the given strings are identical.
+    /// </summary>
+    /// <param name="a">The first string to compare, or `null`.</param>
+    /// <param name="b">The second string to compare, or `null`.</param>
+    /// <returns>`true` if `a` is identical to `b`; otherwise, `false`.</returns>
+    public static bool operator ==(AsciiString? a, AsciiString? b)
+    {
+        return a?.GetHashCode() == b?.GetHashCode();
+    }
+
+    /// <summary>
+    /// Determined whether the given strings are non-identical.
+    /// </summary>
+    /// <param name="a">The first string to compare, or `null`.</param>
+    /// <param name="b">The second string to compare, or `null`.</param>
+    /// <returns>`true` if `a` is not identical to `b`; otherwise, `false`.</returns>
+    public static bool operator !=(AsciiString? a, AsciiString? b)
+    {
+        return a?.GetHashCode() != b?.GetHashCode();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsciiString"/> class from an existing <see cref="byte"/> array. The
+    /// array will be reused; no copying will take place.
+    /// </summary>
+    /// <param name="bytes">A pointer to a byte array, validated by the caller to be ASCII safe.</param>
+    /// <param name="length">The length of the string, excluding NUL terminator.</param>
+    /// <returns>A newly allocated <see cref="AsciiString"/>.</returns>
+    private static unsafe AsciiString from(byte* bytes, nuint length)
+    {
+        return new AsciiString(bytes, length);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsciiString"/> class.
+    /// </summary>
+    /// <param name="bytes">A pointer to a byte array, validated by the caller to be ASCII safe.</param>
+    /// <param name="length">The length of the string, excluding NUL terminator.</param>
+    private unsafe AsciiString(byte* bytes, nuint length)
+    {
+        this.bytes = bytes;
+        this.length = length;
+
+        // We presume the caller to provide us a valid string, but since the absence of this can cause so nefarious
+        // bugs, we validate it when running in debug mode.
+        Debug.Assert(bytes[length] == 0, $"String is not properly NUL-terminated");
+    }
+
+    // TODO: Try to get rid of this constructor, once we have rewritten the scanner to use Perlang strings instead
+    // TODO: of .NET strings.
+
+    private unsafe AsciiString(IReadOnlyList<char> chars)
+    {
+        bytes = (byte*)MemoryAllocator.Allocate((nuint)chars.Count + 1);
+        length = (nuint)chars.Count;
+
+        for (int i = 0; i < chars.Count; i++)
+        {
+            // This cast is safe, presuming the caller has asserted that the
+            // string contains only ASCII safe content. We don't want to do it
+            // at this point to avoid the cost of doing it multiple times.
+            bytes[i] = (byte)chars[i];
+        }
+
+        // Add a trailing NUL character, to make it possible to use this byte array with methods expecting
+        // NUL-terminated strings.
+        bytes[length] = 0;
+    }
+
+    /// <summary>
+    /// Determines whether the specified object is equal to the current object.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current object.</param>
+    /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj is not AsciiString str)
+        {
+            return false;
+        }
+
+        if (str.Length != Length)
+        {
+            return false;
+        }
+
+        unsafe
+        {
+            // TODO: casting from nuint to uint here means we will not properly support strings larger than 4G on 64-bit
+            // TODO: architectures.
+            return Libc.Internal.memcmp(str.bytes, bytes, (uint)Length) == 0;
+        }
+    }
+
+    /// <summary>Gets a numerical hash for this <see cref="AsciiString"/>.</summary>
+    /// <returns>A hash code for the current <see cref="AsciiString"/>.</returns>
+    public override unsafe int GetHashCode()
+    {
+        int hashCode = 0;
+
+        for (nuint i = 0; i < length; i++)
+        {
+            // Inspired by https://stackoverflow.com/a/9009817/227779. This approach should be fine for us, since
+            // `bytes` is guaranteed to be immutable.
+            hashCode *= 17;
+            hashCode += bytes[i];
+        }
+
+        return hashCode;
+    }
+
+    // TODO: Replace the need for this by making our "print" keyword not use
+    // TODO: ToString() for this class. Ideally, we could just call "puts" with
+    // TODO: a pointer to the `bytes` array straight away; for ASCII strings
+    // TODO: this would work on both Windows and POSIX systems. For UTF-8
+    // TODO: strings, it would *not* work on Windows though so we would need to
+    // TODO: special-case that platform... :|
+    public override unsafe string ToString()
+    {
+        return Marshal.PtrToStringUTF8((nint)bytes)!;
+    }
+
+    public override unsafe Lang.String ToUpper()
+    {
+        // TODO: This implementation will allocate memory multiple times when racing. However, the MemoryAllocator will
+        // TODO: ensure that all "extra" buffers is freed at program exit. This is considered "good enough" for now, but
+        // TODO: we should clearly make this side-effect free when racing at some future point. Perhaps even removing
+        // TODO: the memoized upperString would be one way to "fix" this.
+        if (upperString != null)
+        {
+            return upperString;
+        }
+
+        byte* upperBytes = (byte*)MemoryAllocator.Allocate(Length + 1);
+
+        for (nuint i = 0; i < Length; i++)
+        {
+            upperBytes[i] = (byte)Libc.Internal.toupper(bytes[i]);
+        }
+
+        // Add a trailing NUL character
+        upperBytes[Length] = 0;
+
+        upperString = from(upperBytes, Length);
+        return upperString;
+    }
+
+    // TODO: This could return `byte`, but the problem by doing so is that we will make it impossible to distinguish
+    // TODO: between `byte` and `char` values. `print(byte)` would return 102 but `print(char)` would print the literal
+    // TODO: `f` character. We should add a `Lang.Char` type to mitigate this. (Or AsciiChar + Utf16Char? A potential
+    // TODO: Utf8Char would be 32-bit)
+    public unsafe char this[nuint i]
+    {
+        get
+        {
+            // Manual implementation of "safe" byte arrays: perform the range checking ourselves. Doing it like this is
+            // manual and more risky than letting the well-tested .NET CLR do it for us, *but* it has the significant
+            // advantage of letting us keep the `bytes` array as an unmanaged `byte*` pointer. This means zero-cost
+            // P/Invoke, which is for now considered more important than letting the .NET runtime handle safety for us.
+            if (i < length)
+            {
+                return (char)bytes[i];
+            }
+            else
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
+    }
+}

--- a/src/Perlang.Stdlib/Lang/String.cs
+++ b/src/Perlang.Stdlib/Lang/String.cs
@@ -1,0 +1,22 @@
+#nullable enable
+#pragma warning disable S101
+#pragma warning disable SA1302
+
+namespace Perlang.Lang;
+
+/// <summary>
+/// Base class for Perlang strings
+///
+/// Concrete implementations of this string are currently the following:
+///
+/// - <see cref="AsciiString"/> - a string known to consist of valid ASCII characters only. The uppermost bit in each
+///                               byte is zero for all characters.
+/// </summary>
+public abstract class String
+{
+    public abstract nuint Length { get; }
+
+    public abstract Lang.String ToUpper();
+
+    public abstract override string ToString();
+}

--- a/src/Perlang.Stdlib/Perlang.Stdlib.csproj
+++ b/src/Perlang.Stdlib/Perlang.Stdlib.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>Perlang</RootNamespace>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Perlang.Stdlib/Stdlib/Base64.cs
+++ b/src/Perlang.Stdlib/Stdlib/Base64.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Text;
 using Perlang.Attributes;
@@ -19,9 +20,9 @@ namespace Perlang.Stdlib
         /// </summary>
         /// <param name="plainText">A plain-text string.</param>
         /// <returns>The string representation in base64 of `plainText`.</returns>
-        public static string Encode(string plainText)
+        public static string Encode(Lang.String plainText)
         {
-            var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
+            var plainTextBytes = Encoding.UTF8.GetBytes(plainText.ToString());
 
             return Convert.ToBase64String(plainTextBytes, Base64FormattingOptions.InsertLineBreaks);
         }
@@ -33,19 +34,23 @@ namespace Perlang.Stdlib
         /// </summary>
         /// <param name="base64Data">A base 64-encoded string.</param>
         /// <returns>The decoded representation of `base64Data`.</returns>
-        public static string Decode(string base64Data)
+        public static string Decode(Lang.String base64Data)
         {
             // Convert.FromBase64String requires data to be padded. We relax this a bit, like many other programming
             // languages (Ruby, PHP, Javascript) and do not require the padding to be present. It would be even more
             // efficient to be able to tell Convert.FromBase64String() to ignore it, but this will do for now.
-            int numPaddingCharacters = base64Data.Length % 4;
+            nuint numPaddingCharacters = base64Data.Length % 4;
+
+            // Using a .NET string here is simple, but we should use Perlang strings consistently here in the long run
+            // (when we rewrite Base64 to not rely on the .NET BCL)
+            string base64String = base64Data.ToString();
 
             if (numPaddingCharacters != 0)
             {
-                base64Data += new string('=', 4 - numPaddingCharacters);
+                base64String += new string('=', (int)(4 - numPaddingCharacters));
             }
 
-            var data = Convert.FromBase64String(base64Data);
+            var data = Convert.FromBase64String(base64String);
 
             // For now, blindly assume that the base64-encoded data is a valid UTF-8/ASCII string and parse it as such.
             // Future improvements here could be to make it possible to return a byte array instead, but for now,

--- a/src/Perlang.Tests.Architecture/TokenAwareTest.cs
+++ b/src/Perlang.Tests.Architecture/TokenAwareTest.cs
@@ -1,5 +1,4 @@
 ﻿using ArchUnitNET.Domain;
-using ArchUnitNET.Fluent;
 using ArchUnitNET.Loader;
 using ArchUnitNET.xUnit;
 using Xunit;

--- a/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
+++ b/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
@@ -7,7 +7,7 @@ namespace Perlang.Tests.Integration.IndexOperator;
 public class StringIndexing
 {
     [Fact]
-    public void string_can_be_indexed_by_integer()
+    public void AsciiString_can_be_indexed_by_integer()
     {
         string source = @"
             print ""foobar""[0];
@@ -19,7 +19,7 @@ public class StringIndexing
     }
 
     [Fact]
-    public void string_indexed_by_integer_returns_char_object()
+    public void AsciiString_indexed_by_integer_returns_char_object()
     {
         string source = @"
             print ""foobar""[0].get_type();
@@ -27,13 +27,15 @@ public class StringIndexing
 
         var output = EvalReturningOutputString(source);
 
+        // TODO: Ideally this would be a Perlang `char` type, which is printable as a character but is 8-bit wide. It
+        // TODO: would only be applicable to `AsciiString` instances though, so its usefulness would be limited...
         output.Should().Be("System.Char");
     }
 
     [Fact]
-    public void string_indexed_by_integer_assigned_to_other_type_variable_throws_expected_error()
+    public void AsciiString_indexed_by_integer_assigned_to_other_type_variable_throws_expected_error()
     {
-        // This is expected to fail, since an individual element of a string is `char`
+        // This is expected to fail, since an individual element of an AsciiString is `byte`
         string source = @"
             var s: string = ""foobar""[0];
         ";
@@ -57,6 +59,6 @@ public class StringIndexing
         result.Errors.Should()
             .ContainSingle()
             .Which
-            .Message.Should().Contain("cannot be indexed by 'string'");
+            .Message.Should().Contain("cannot be indexed by 'AsciiString'");
     }
 }

--- a/src/Perlang.Tests.Integration/LogicalOperator/And.cs
+++ b/src/Perlang.Tests.Integration/LogicalOperator/And.cs
@@ -103,7 +103,7 @@ namespace Perlang.Tests.Integration.LogicalOperator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("'string' is not a valid && operand", exception.Message);
+            Assert.Matches("'AsciiString' is not a valid && operand", exception.Message);
         }
 
         [Fact]

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionAssignmentTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionAssignmentTests.cs
@@ -123,7 +123,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
 
             result.Errors.Should()
                 .ContainSingle().Which
-                .Message.Should().Match("Inferred: Perlang.NullObject is not comparable and can therefore not be used with the $PLUS_EQUAL += operator");
+                .Message.Should().Match("Inferred: Perlang.NullObject cannot be used with the $PLUS_EQUAL += operator");
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
 
             result.Errors.Should()
                 .ContainSingle().Which
-                .Message.Should().Match("Cannot assign 'int' to 'string' variable");
+                .Message.Should().Match("Cannot assign 'int' to 'AsciiString' variable");
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
@@ -115,6 +115,22 @@ namespace Perlang.Tests.Integration.Operator.Binary
         }
 
         [Fact]
+        void addition_of_bigint_and_string_coerces_number_to_string()
+        {
+            string source = @"
+                var i = 18446744073709551616;
+                var s = ""xyz"";
+
+                print i + s;
+            ";
+
+            string result = EvalReturningOutputString(source);
+
+            result.Should()
+                .Be("18446744073709551616xyz");
+        }
+
+        [Fact]
         void addition_of_string_and_integer_coerces_number_to_string()
         {
             string source = @"
@@ -128,6 +144,22 @@ namespace Perlang.Tests.Integration.Operator.Binary
 
             result.Should()
                 .Be("abc123");
+        }
+
+        [Fact]
+        void addition_of_string_and_bigint_coerces_number_to_string()
+        {
+            string source = @"
+                var s = ""abc"";
+                var i = 18446744073709551616;
+
+                print s + i;
+            ";
+
+            string result = EvalReturningOutputString(source);
+
+            result.Should()
+                .Be("abc18446744073709551616");
         }
 
         [Theory]

--- a/src/Perlang.Tests.Integration/Operator/Binary/DivisionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/DivisionTests.cs
@@ -85,7 +85,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Unsupported / operand types: 'string' and 'int'", exception.Message);
+            Assert.Matches("Unsupported / operand types: 'AsciiString' and 'int'", exception.Message);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Unsupported / operand types: 'int' and 'string'", exception.Message);
+            Assert.Matches("Unsupported / operand types: 'int' and 'AsciiString'", exception.Message);
         }
 
         // TODO: This should definitely be a compile-time error (constant division by zero). We should aim for

--- a/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
@@ -303,7 +303,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported ** operand types: 'string' and 'int'", exception.Message);
+            Assert.Equal("Unsupported ** operand types: 'AsciiString' and 'int'", exception.Message);
         }
 
         [Fact]
@@ -317,7 +317,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported ** operand types: 'int' and 'string'", exception.Message);
+            Assert.Equal("Unsupported ** operand types: 'int' and 'AsciiString'", exception.Message);
         }
 
         [Fact]

--- a/src/Perlang.Tests.Integration/Operator/Binary/ModuloTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ModuloTests.cs
@@ -127,7 +127,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported % operand types: 'string' and 'int'", exception.Message);
+            Assert.Equal("Unsupported % operand types: 'AsciiString' and 'int'", exception.Message);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported % operand types: 'int' and 'string'", exception.Message);
+            Assert.Equal("Unsupported % operand types: 'int' and 'AsciiString'", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/MultiplicationTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/MultiplicationTests.cs
@@ -85,7 +85,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported * operand types: 'string' and 'int'", exception.Message);
+            Assert.Equal("Unsupported * operand types: 'AsciiString' and 'int'", exception.Message);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Equal("Unsupported * operand types: 'int' and 'string'", exception.Message);
+            Assert.Equal("Unsupported * operand types: 'int' and 'AsciiString'", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/ShiftLeftTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ShiftLeftTests.cs
@@ -129,6 +129,6 @@ public class ShiftLeftTests
         var exception = result.Errors.FirstOrDefault();
 
         Assert.Single(result.Errors);
-        Assert.Matches("Unsupported << operand types: 'int' and 'string'", exception.Message);
+        Assert.Matches("Unsupported << operand types: 'int' and 'AsciiString'", exception.Message);
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/ShiftRightTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ShiftRightTests.cs
@@ -129,6 +129,6 @@ public class ShiftRightTests
         var exception = result.Errors.FirstOrDefault();
 
         Assert.Single(result.Errors);
-        Assert.Matches("Unsupported >> operand types: 'int' and 'string'", exception.Message);
+        Assert.Matches("Unsupported >> operand types: 'int' and 'AsciiString'", exception.Message);
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/SubtractionAssignmentTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/SubtractionAssignmentTests.cs
@@ -125,7 +125,7 @@ public class SubtractionAssignmentTests
         var exception = result.Errors.First();
 
         Assert.Single(result.Errors);
-        Assert.Equal("Inferred: Perlang.NullObject is not comparable and can therefore not be used with the $MINUS_EQUAL -= operator", exception.Message);
+        Assert.Equal("Inferred: Perlang.NullObject cannot be used with the $MINUS_EQUAL -= operator", exception.Message);
     }
 
     [Fact]
@@ -140,6 +140,6 @@ public class SubtractionAssignmentTests
         var exception = result.Errors.First();
 
         Assert.Single(result.Errors);
-        Assert.Equal("Cannot assign 'int' to 'string' variable", exception.Message);
+        Assert.Equal("Cannot assign 'int' to 'AsciiString' variable", exception.Message);
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/Binary/SubtractionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/SubtractionTests.cs
@@ -69,6 +69,6 @@ public class SubtractionTests
 
         result.Errors.Should()
             .ContainSingle().Which
-            .Message.Should().Match("Unsupported - operand types: 'string' and 'string'");
+            .Message.Should().Match("Unsupported - operand types: 'AsciiString' and 'AsciiString'");
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -133,7 +133,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("can only be used to decrement numbers, not string", exception.Message);
+            Assert.Matches("can only be used to decrement numbers, not AsciiString", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -140,7 +140,7 @@ namespace Perlang.Tests.Integration.Operator
             var exception = result.Errors.First();
 
             Assert.Single(result.Errors);
-            Assert.Matches("can only be used to increment numbers, not string", exception.Message);
+            Assert.Matches("can only be used to increment numbers, not AsciiString", exception.Message);
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Stdlib/LibcTests.cs
+++ b/src/Perlang.Tests.Integration/Stdlib/LibcTests.cs
@@ -16,7 +16,7 @@ namespace Perlang.Tests.Integration.Stdlib
             var result = Eval("Libc.environ()");
 
             result.Should()
-                .BeOfType<ImmutableDictionary<string, string>>().Which.Should()
+                .BeOfType<ImmutableDictionary<Lang.String, string>>().Which.Should()
                 .NotBeEmpty();
         }
 
@@ -26,10 +26,10 @@ namespace Perlang.Tests.Integration.Stdlib
             var result = Eval("Libc.environ()");
 
             result.Should()
-                .BeOfType<ImmutableDictionary<string, string>>().Which.Should()
+                .BeOfType<ImmutableDictionary<Lang.String, string>>().Which.Should()
 
                 // PATH is typically Path on Windows, hence the need for uppercasing it to make tests pass on Windows.
-                .Contain(d => d.Key.ToUpper() == "PATH");
+                .Contain(d => d.Key.ToUpper().ToString() == "PATH");
         }
 
 #if _WINDOWS

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Perlang.Tests.Integration.Typing;
+
+using static Perlang.Tests.Integration.EvalHelper;
+
+public class StringTests
+{
+    [Fact]
+    public void string_variable_can_be_printed()
+    {
+        string source = @"
+                var s: string = ""this is a string"";
+
+                print(s);
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is a string");
+    }
+
+    [Fact]
+    public void string_variable_can_be_reassigned()
+    {
+        string source = @"
+                var s: string = ""this is a string"";
+                s = ""this is another string"";
+
+                print(s);
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is another string");
+    }
+
+    [Fact]
+    public void ascii_string_variable_has_expected_type()
+    {
+        string source = @"
+                var s: string = ""this is an ASCII string"";
+
+                print(s.get_type());
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("Perlang.Lang.AsciiString");
+    }
+}

--- a/src/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -49,8 +49,10 @@ namespace Perlang.Tests.Integration.Typing
             var result = EvalWithValidationErrorCatch(source);
             var exception = result.Errors.FirstOrDefault();
 
+            // TODO: Fix this error. Should be something like "Cannot initialize int variable with AsciiString";
+            // TODO: initialization isn't assignment.
             Assert.Single(result.Errors);
-            Assert.Equal("Cannot assign string to int variable", exception.Message);
+            Assert.Equal("Cannot assign AsciiString to int variable", exception.Message);
         }
 
         [Fact]
@@ -233,7 +235,7 @@ namespace Perlang.Tests.Integration.Typing
             var exception = result.Errors.FirstOrDefault();
 
             Assert.Single(result.Errors);
-            Assert.Matches("Cannot assign 'string' to 'int' variable", exception!.Message);
+            Assert.Matches("Cannot assign 'AsciiString' to 'int' variable", exception!.Message);
         }
 
         [Fact]

--- a/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/src/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -411,7 +411,7 @@ namespace Perlang.Tests.ConsoleApp
                 StdoutLines.Should().Contain(
                         "[line 6] Warning at 'greet': Null parameter detected for 'name'")
                     .And.Contain(
-                        "[line 2] Operands must be numbers, not string and null"
+                        "[line 2] Operands must be numbers, not AsciiString and null"
                     );
 
                 exitCode.Should().Be((int)Program.ExitCodes.RUNTIME_ERROR);

--- a/src/Perlang.Tests/Lang/AsciiStringTests.cs
+++ b/src/Perlang.Tests/Lang/AsciiStringTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Perlang.Lang;
+using Xunit;
+
+namespace Perlang.Tests.Lang;
+
+public class AsciiStringTests
+{
+    [Fact]
+    void AsciiString_can_be_concatenated()
+    {
+        var foo = AsciiString.from("foo");
+        var bar = AsciiString.from("bar");
+
+        var foobar = foo + bar;
+
+        foobar.Should()
+            .Be(AsciiString.from("foobar"));
+    }
+
+    [Fact]
+    void AsciiString_can_be_converted_to_NET_string()
+    {
+        var foo = AsciiString.from("foo");
+
+        string result = foo.ToString();
+
+        result.Should()
+            .Be("foo");
+    }
+
+    [Fact]
+    void AsciiString_ToUpper_converts_to_uppercase()
+    {
+        var s = AsciiString.from("Path");
+
+        Perlang.Lang.String result = s.ToUpper();
+
+        result.Should()
+            .Be(AsciiString.from("PATH"));
+    }
+
+    [Fact]
+    void AsciiString_ToUpper_on_already_uppercased_string_is_noop()
+    {
+        var s = AsciiString.from("PATH");
+
+        Perlang.Lang.String result = s.ToUpper();
+
+        result.Should()
+            .Be(AsciiString.from("PATH"));
+    }
+
+    [Fact]
+    void AsciiString_ToUpper_ToString_returns_expected_value()
+    {
+        var s = AsciiString.from("PATH");
+
+        string result = s.ToUpper().ToString();
+
+        result.Should()
+            .Be("PATH");
+    }
+}


### PR DESCRIPTION
Related to #370, this fixes the first parts of this issue.