### PR TITLE
(tests) Remove Moq dependency

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -4,5 +4,9 @@
 ### Added
 
 ### Changed
+#### Maintenance
+- Remove Moq dependency [[#380][380]]
 
 ### Fixed
+
+[380]: https://github.com/perlang-org/perlang/pull/380

--- a/src/Perlang.Tests/Perlang.Tests.csproj
+++ b/src/Perlang.Tests/Perlang.Tests.csproj
@@ -23,8 +23,6 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="coverlet.collector" Version="1.3.0" />
-        <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="Moq.Analyzers" Version="0.0.8" />
 
         <!-- Dependency needed by Moq/Moq.Analyzers; our reflection code fails without this being listed explicitly -->
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />


### PR DESCRIPTION
This was added in #210, but it seems to never really have been needed/used in the code that actually got merged. Unnecessary dependencies should be removed, so let's get rid of it now.

Supersedes #367 and #375.