### PR TITLE
(many) Implement `Utf8String` for strings with non-ASCII content

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -6,6 +6,7 @@
 ### Changed
 #### Data types
 - Implement `AsciiString` for ASCII-only strings [[#377][377]]
+- Implement `Utf8String` for strings with non-ASCII content [[#385][385]]
 
 #### Maintenance
 - Bump TngTech.ArchUnitNET.xUnit from 0.5.0 to 0.10.5 [[#366][366]]
@@ -20,3 +21,4 @@
 [374]: https://github.com/perlang-org/perlang/pull/374
 [377]: https://github.com/perlang-org/perlang/pull/377
 [380]: https://github.com/perlang-org/perlang/pull/380
+[385]: https://github.com/perlang-org/perlang/pull/385

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -614,8 +614,7 @@ namespace Perlang.Interpreter
                 }
                 catch (SystemException ex)
                 {
-                    // TODO: Include the original stack trace in the exception being thrown here, to simplify debugging.
-                    throw new RuntimeError(null, ex.Message);
+                    throw new RuntimeError(null, ex.Message, ex);
                 }
             }
         }

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -664,16 +664,18 @@ namespace Perlang.Parser
             if (Match(STRING))
             {
                 // Determine what type of string this is and act accordingly.
-                var s = (string)Previous().Literal!;
+                string s = (string)Previous().Literal!;
                 char[] chars = s.ToCharArray();
 
                 foreach (char c in chars)
                 {
                     if (c > 127)
                     {
-                        // Non-ASCII character encountered. Fall back to .NET String in this case.
-                        // TODO: parse as Utf8String or Utf16String instead, https://github.com/perlang-org/perlang/issues/370
-                        return new Expr.Literal(s);
+                        // Non-ASCII character encountered => use Utf8String instead
+                        // TODO: think about whether Utf16String would be a better default here. Could be Utf16 by
+                        // TODO: default and opt-in to Utf8 (or the other way around). See
+                        // TODO: https://github.com/perlang-org/perlang/issues/370
+                        return new Expr.Literal(Utf8String.from(s));
                     }
                 }
 

--- a/src/Perlang.Stdlib/Lang/AsciiString.cs
+++ b/src/Perlang.Stdlib/Lang/AsciiString.cs
@@ -38,7 +38,7 @@ public class AsciiString : Lang.String
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsciiString"/> class from an existing <see cref="char"/> array. A
-    /// new `byte[]` will be allocated to contain the string content.
+    /// new <see cref="byte"/> buffer will be allocated to contain the string content.
     /// </summary>
     /// <param name="chars">A char array, validated by the caller to be ASCII safe.</param>
     /// <returns>A newly allocated <see cref="AsciiString"/>.</returns>

--- a/src/Perlang.Stdlib/Lang/Utf8String.cs
+++ b/src/Perlang.Stdlib/Lang/Utf8String.cs
@@ -1,0 +1,63 @@
+#nullable enable
+#pragma warning disable SA1300
+using System;
+using System.Runtime.InteropServices.Marshalling;
+using System.Text;
+using Perlang.Internal;
+
+namespace Perlang.Lang;
+
+/// <summary>
+/// Representation of a string encoded with the UTF-8 encoding.
+///
+/// UTF-8 strings can represent the full Unicode span of characters. Their main disadvantage is that the variable-length
+/// encoding of non-ASCII characters makes looping over characters be a much more complex process than with <see
+/// cref="AsciiString"/> or the future Utf16String.
+/// </summary>
+public class Utf8String : String
+{
+    private readonly unsafe byte* bytes;
+    private readonly nuint length;
+
+    public override nuint Length => length;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Utf8String"/> class from an existing <see cref="char"/> array. A
+    /// new <see cref="byte"/> buffer will be allocated to contain the string content.
+    /// </summary>
+    /// <param name="s">A .NET string.</param>
+    /// <returns>A newly allocated <see cref="Utf8String"/>.</returns>
+    public static Utf8String from(string s)
+    {
+        return new Utf8String(s);
+    }
+
+    // TODO: Try to get rid of this constructor, once we have rewritten the scanner to use Perlang strings instead
+    // TODO: of .NET strings.
+
+    private unsafe Utf8String(string s)
+    {
+        // Inspired by System.Runtime.InteropServices.Marshalling.Utf8StringMarshaller in the .NET 7 framework.
+        length = (nuint)checked(Encoding.UTF8.GetByteCount(s) + 1);
+        bytes = (byte*)MemoryAllocator.Allocate(length);
+
+        // We use a Span<> here as a convenient way to make GetBytes() be able to write into our unmanaged memory
+        // buffer.
+        Span<byte> managedBuffer = new Span<byte>(bytes, (int)length);
+        int bytesWritten = Encoding.UTF8.GetBytes(s, managedBuffer);
+
+        // Add a trailing NUL character, to make it possible to use this byte array with methods expecting
+        // NUL-terminated strings.
+        bytes[bytesWritten] = 0;
+    }
+
+    public override String ToUpper()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override unsafe string ToString()
+    {
+        return Utf8StringMarshaller.ConvertToManaged(bytes)!;
+    }
+}

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Perlang.Tests.Integration.Typing;
 
-using static Perlang.Tests.Integration.EvalHelper;
+using static EvalHelper;
 
 public class StringTests
 {
@@ -36,6 +36,22 @@ public class StringTests
 
         output.Should()
             .Be("this is another string");
+    }
+
+    [Fact]
+    public void ascii_string_inferred_variable_can_be_reassigned_with_non_ascii_value()
+    {
+        string source = @"
+                var s: string = ""this is a string"";
+                s = ""this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ"";
+
+                print(s);
+            ";
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ");
     }
 
     [Fact]


### PR DESCRIPTION
Similar to #377, but this seemed much simple to accomplish. Likely because the ground work was already done because of #377.