### PR TITLE
(parser) Preserve exact floating point representation

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -6,6 +6,7 @@
 ### Added
 #### Experimental compilation
 - Add C++-based stdlib project [[#407][407]]
+- Preserve exact floating point representation [[#412][412]]
 
 ### Changed
 #### Data types
@@ -37,3 +38,4 @@
 [389]: https://github.com/perlang-org/perlang/pull/389
 [407]: https://github.com/perlang-org/perlang/pull/407
 [410]: https://github.com/perlang-org/perlang/pull/410
+[412]: https://github.com/perlang-org/perlang/pull/412

--- a/src/Perlang.Parser/FloatingPointLiteral.cs
+++ b/src/Perlang.Parser/FloatingPointLiteral.cs
@@ -3,21 +3,21 @@ using System;
 
 namespace Perlang.Parser;
 
-internal readonly struct FloatingPointLiteral<T> : INumericLiteral
+internal readonly struct FloatingPointLiteral<T> : IFloatingPointLiteral, INumericLiteral
     where T : notnull
 {
-    internal T Value { get; }
+    public object Value { get; }
+    public string NumberCharacters { get; }
 
     /// <inheritdoc cref="INumericLiteral.BitsUsed"/>
     public long BitsUsed { get; }
 
     public bool IsPositive { get; }
 
-    object INumericLiteral.Value => Value;
-
-    public FloatingPointLiteral(T value)
+    public FloatingPointLiteral(T value, string numberCharacters)
     {
         Value = value;
+        NumberCharacters = numberCharacters;
 
         BitsUsed = value switch
         {

--- a/src/Perlang.Parser/IFloatingPointLiteral.cs
+++ b/src/Perlang.Parser/IFloatingPointLiteral.cs
@@ -1,0 +1,12 @@
+#nullable  enable
+namespace Perlang.Parser;
+
+public interface IFloatingPointLiteral
+{
+    /// <summary>
+    /// Gets a string representation of this floating point literal. This is to ensure we avoid precision loss while
+    /// carrying the value over to the compiler, since `float`/`double` `ToString()` and back are not necessarily
+    /// round-trip safe.
+    /// </summary>
+    public string NumberCharacters { get; }
+}

--- a/src/Perlang.Parser/PerlangParser.cs
+++ b/src/Perlang.Parser/PerlangParser.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Perlang.Internal.Extensions;
 using static Perlang.Internal.Utils;
 using static Perlang.TokenType;
 
@@ -570,7 +571,20 @@ namespace Perlang.Parser
                 // changed.
                 if (@operator.Type == MINUS && right is Expr.Literal rightLiteral)
                 {
-                    return new Expr.Literal(NumberParser.MakeNegative(rightLiteral.Value!));
+                    if (rightLiteral.Value is INumericLiteral numericLiteral)
+                    {
+                        return new Expr.Literal(NumberParser.MakeNegative(numericLiteral));
+                    }
+                    else if (rightLiteral.Value is null)
+                    {
+                        Error(Peek(), "Unary minus operator does not support null operand");
+                        return new Expr.Literal(null);
+                    }
+                    else
+                    {
+                        // TODO: Call Error() here to produce a context-aware error instead of just throwing a raw exception
+                        throw new ArgumentException($"Type {rightLiteral.Value.GetType().ToTypeKeyword()} not supported");
+                    }
                 }
                 else
                 {

--- a/src/Perlang.Stdlib/Internal/Utils.cs
+++ b/src/Perlang.Stdlib/Internal/Utils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Numerics;
 using Perlang.Internal.Extensions;
 using Perlang.Lang;
 using String = Perlang.Lang.String;
@@ -12,15 +11,15 @@ namespace Perlang.Internal
     /// </summary>
     public static class Utils
     {
-        private static readonly Lang.String NullString = AsciiString.from("null");
+        private static readonly String NullString = AsciiString.from("null");
 
-        public static Lang.String Stringify(object @object)
+        public static String Stringify(object @object)
         {
             if (@object == null)
             {
                 return NullString;
             }
-            else if (@object is Lang.String nativeString)
+            else if (@object is String nativeString)
             {
                 return nativeString;
             }

--- a/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
The idea is to avoid losing the exact floating point representation as given by the user when constructing the parsed syntax tree. This will be useful in the compilation part (#409), where we want to avoid losing precision because of round-tripping to `double` and back to `string`.