### PR TITLE
(interpreter) Make `int == double` use value-type semantics

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -24,6 +24,7 @@
 - Remove Moq dependency [[#380][380]]
 
 ### Fixed
+- Make `int == double` use value-type semantics [[#413][413]]
 
 ### Tests
 - Minor test improvements [[#410][410]]
@@ -39,3 +40,4 @@
 [407]: https://github.com/perlang-org/perlang/pull/407
 [410]: https://github.com/perlang-org/perlang/pull/410
 [412]: https://github.com/perlang-org/perlang/pull/412
+[413]: https://github.com/perlang-org/perlang/pull/413

--- a/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/BinaryOperatorData.cs
@@ -284,8 +284,8 @@ public static class BinaryOperatorData
         {
             new object[] { "12", "34", "True" },
             new object[] { "12", "12", "False" },
-            new object[] { "12", "12.0", "True" }, // Same value but different types. Note: this is truthy in C# AND Java.
-            new object[] { "12.0", "12", "True" }, // Same value but different types. Note: this is truthy in C# AND Java.
+            new object[] { "12", "12.0", "False" }, // Same value but different types. We follow the precedent of C#, Java and C++ and consider these to be equal.
+            new object[] { "12.0", "12", "False" }, // Likewise
 
             new object[] { "2147483647", "4294967295", "True" },
             new object[] { "2147483647", "9223372036854775807", "True" },
@@ -341,8 +341,8 @@ public static class BinaryOperatorData
         {
             new object[] { "12", "34", "False" },
             new object[] { "12", "12", "True" },
-            new object[] { "12", "12.0", "False" }, // Same value but different types. Note: this is truthy in C# AND Java.
-            new object[] { "12.0", "12", "False" }, // Same value but different types. Note: this is truthy in C# AND Java.
+            new object[] { "12", "12.0", "True" }, // Same value but different types. We follow the precedent of C#, Java and C++ and consider these to be equal.
+            new object[] { "12.0", "12", "True" }, // Likewise
             new object[] { "12.345", "12.345", "True" },
             new object[] { "12.345", "67.890", "False" },
 


### PR DESCRIPTION
This is an important preparation for https://github.com/perlang-org/perlang/pull/409, where we will use the same semantics. Doing the change already not for interpreted mode makes things easier, since we can then use the same tests for both interpreted and compiled mode.