### PR TITLE
(compiler) Initial support for `**` operator in compiled mode

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -9,6 +9,7 @@
 - Add first steps towards experimental compiler [[#409][409]]
 - Preserve exact floating point representation [[#412][412]]
 - Add `BigInt` support for compiled mode [[#418][418]]
+- Initial support for `**` operator in compiled mode [[#420][420]]
 - Use correct error message for unsupported operand types [[#421][421]]
 
 ### Changed
@@ -48,4 +49,5 @@
 [413]: https://github.com/perlang-org/perlang/pull/413
 [414]: https://github.com/perlang-org/perlang/pull/414
 [418]: https://github.com/perlang-org/perlang/pull/418
+[420]: https://github.com/perlang-org/perlang/pull/420
 [421]: https://github.com/perlang-org/perlang/pull/421

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
@@ -12,7 +12,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
 {
     public class AdditionTests
     {
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(BinaryOperatorData.Addition_result), MemberType = typeof(BinaryOperatorData))]
         void performs_addition(string i, string j, string expectedResult)
         {

--- a/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
@@ -35,7 +35,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         // Tests for the < (less than) operator
         //
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_greater_is_true(string left, string right)
         {
@@ -54,7 +54,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("true");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_same_is_false(string left, string right)
         {
@@ -73,7 +73,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("false");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_smaller_is_false(string left, string right)
         {
@@ -96,7 +96,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         // Tests for the <= (less than or equals) operator
         //
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_or_equals_greater_is_true(string left, string right)
         {
@@ -115,7 +115,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("true");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_or_equals_same_is_true(string left, string right)
         {
@@ -134,7 +134,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("true");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_or_equals_smaller_is_false(string left, string right)
         {
@@ -157,7 +157,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         // Tests for the > (greater than) operator
         //
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_smaller_is_false(string left, string right)
         {
@@ -176,7 +176,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("false");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_same_is_false(string left, string right)
         {
@@ -195,7 +195,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("false");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_smaller_is_true(string left, string right)
         {
@@ -217,7 +217,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         //
         // Tests for the >= (greater than or equals) operator
         //
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_or_equals_larger_is_false(string left, string right)
         {
@@ -236,7 +236,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("false");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_or_equals_same_is_true(string left, string right)
         {
@@ -255,7 +255,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("true");
         }
 
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void greater_than_or_equals_smaller_is_true(string left, string right)
         {

--- a/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/ExponentialTests.cs
@@ -33,6 +33,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [MemberData(nameof(BinaryOperatorData.Exponential_type), MemberType = typeof(BinaryOperatorData))]
         public void with_supported_types_returns_expected_type(string i, string j, string expectedResult)
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = $@"
                     print ({i} ** {j}).get_type();
                 ";
@@ -278,7 +280,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
             Assert.Equal("256", result);
         }
 
-        [SkippableFact]
+        [Fact]
         public void exponential_bigint_and_negative_int_throws_expected_runtime_error()
         {
             string source = @"

--- a/src/stdlib/src/bigint.cpp
+++ b/src/stdlib/src/bigint.cpp
@@ -247,6 +247,16 @@ BigInt::BigInt(const unsigned long long& num) {
     sign = '+';
 }
 
+BigInt::BigInt(const double& num) {
+    if (ceil(num) != num) {
+        // num has a fractional part and can inherently never be equal to a BigInt.
+        throw std::invalid_argument("Expected a value without any fractional part, got \'" + std::to_string(num) + "\'");
+    }
+
+    // Without this cast, values like "4096" will be converted to "4096.000000"
+    value = std::to_string((long)num);
+    sign = '+';
+}
 
 /*
     String to BigInt

--- a/src/stdlib/src/bigint.hpp
+++ b/src/stdlib/src/bigint.hpp
@@ -36,6 +36,7 @@ class BigInt {
         BigInt(const unsigned long&);
         BigInt(const long long&);
         BigInt(const unsigned long long& num);
+        BigInt(const double& num);
         BigInt(const std::string&);
 
         // Assignment operators:

--- a/src/stdlib/test/print.cc
+++ b/src/stdlib/test/print.cc
@@ -91,11 +91,6 @@ TEST(PrintDouble_9223372036854775807)
     fwrite_mocked = false;
 
     CHECK_EQ("9.22337203685478E+18\n", captured_output);
-
-    // TODO: temp code
-    double i1 = -12.0;
-    BigInt i2 = BigInt("18446744073709551616");
-    perlang::print(i1 != i2);
 }
 
 // TODO: Make this test work. We need to (linker-)wrap puts to make it happen.


### PR DESCRIPTION
Note that `BigInteger`-based values are not yet supported. This also means that simple things like `int ** int` won't work, because the type of such expressions is `BigInteger`.