### PR TITLE
(compiler) Use correct error message for unsupported operand types

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -9,6 +9,7 @@
 - Add first steps towards experimental compiler [[#409][409]]
 - Preserve exact floating point representation [[#412][412]]
 - Add `BigInt` support for compiled mode [[#418][418]]
+- Use correct error message for unsupported operand types [[#421][421]]
 
 ### Changed
 #### Data types
@@ -47,3 +48,4 @@
 [413]: https://github.com/perlang-org/perlang/pull/413
 [414]: https://github.com/perlang-org/perlang/pull/414
 [418]: https://github.com/perlang-org/perlang/pull/418
+[421]: https://github.com/perlang-org/perlang/pull/421

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -713,7 +713,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -726,7 +726,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -767,7 +767,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 {
                     // TODO: Strings/other types need different handling, and are more complex since they will
                     // TODO: inherently require memory allocation. We don't have a defined model for when that
-                    // TODO: memory would be deallocated.
+                    // TODO: memory would be deallocated, #378
                     string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
@@ -781,7 +781,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -794,7 +794,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -821,7 +821,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -857,7 +857,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -879,7 +879,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -910,7 +910,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                         }
                         else
                         {
-                            string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                            string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                             throw new RuntimeError(expr.Operator, message);
                         }
 
@@ -921,7 +921,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 }
                 else
                 {
-                    string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
+                    string message = CompilerMessages.UnsupportedOperandsInBinaryExpression(expr.Operator.Type, expr.Left.TypeReference, expr.Right.TypeReference);
                     throw new RuntimeError(expr.Operator, message);
                 }
 
@@ -929,6 +929,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 
             default:
             {
+                // Other operator types are not supported for binary expressions
                 string message = CompilerMessages.UnsupportedOperatorTypeInBinaryExpression(expr.Operator.Type);
                 throw new RuntimeError(expr.Operator, message);
             }


### PR DESCRIPTION
Noted while working on another PR:
https://github.com/perlang-org/perlang/pull/420#discussion_r1450926569. `UnsupportedOperatorTypeInBinaryExpression` should only be used for the fallback for unsupported operator tokens.