### PR TITLE
(test) Add `bigint < double` test

### DIFF
--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -37,6 +37,7 @@
 
 ### Tests
 - Minor test improvements [[#410][410]]
+- Add `bigint < double` test [[#433][433]]
 
 [366]: https://github.com/perlang-org/perlang/pull/366
 [369]: https://github.com/perlang-org/perlang/pull/369
@@ -59,3 +60,4 @@
 [425]: https://github.com/perlang-org/perlang/pull/425
 [427]: https://github.com/perlang-org/perlang/pull/427
 [432]: https://github.com/perlang-org/perlang/pull/432
+[433]: https://github.com/perlang-org/perlang/pull/433

--- a/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/Comparison.cs
@@ -54,6 +54,21 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("true");
         }
 
+        [Fact]
+        public void less_than_bigint_and_double_throws_expected_error()
+        {
+            string source = $@"
+                var b = (2 ** 64) < 18446744073709551616.1;
+                print b;
+            ";
+
+            var result = EvalWithValidationErrorCatch(source);
+
+            result.Errors.Should()
+                .ContainSingle().Which
+                .Message.Should().Be("Unsupported < operand types: 'bigint' and 'double'");
+        }
+
         [Theory]
         [MemberData(nameof(ComparisonTypes))]
         public void less_than_same_is_false(string left, string right)


### PR DESCRIPTION
I had this present in an old stash but it couldnt be merged at the time, because of #229. Now that this issue has been solved, let's finish this and add a test which tests the expected error in this case.