### PR TITLE
(compiler) Detect stdlib bundled with Perlang binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ docfx/docfx.exe:
 darkerfx-push:
 	rsync -av docs/templates/darkerfx/ ../darkerfx/darkerfx/
 
-install: auto-generated
+install: auto-generated stdlib
 	./scripts/local_install_linux.sh
 
 # Downloads and installs the latest snapshot from https://builds.perlang.org

--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -16,6 +16,7 @@
 - Run more tests in compiled mode [[#427][427]]
 - Implement modulo operator for `BigInt` [[#432][432]]
 - Support `<<` and `>>` for bigint in compiled mode [[#440][440]]
+- Detect stdlib bundled with Perlang binaries [[#444][444]]
 
 ### Changed
 #### Data types
@@ -79,3 +80,4 @@
 [440]: https://github.com/perlang-org/perlang/pull/440
 [442]: https://github.com/perlang-org/perlang/pull/442
 [443]: https://github.com/perlang-org/perlang/pull/443
+[444]: https://github.com/perlang-org/perlang/pull/444

--- a/scripts/local_install_linux.sh
+++ b/scripts/local_install_linux.sh
@@ -11,3 +11,6 @@ mkdir -p $HOME/.perlang/nightly/bin
 
 dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
 cp -r src/Perlang.ConsoleApp/bin/Release/net7.0/linux-x64/publish/* $HOME/.perlang/nightly/bin
+
+# Copy the precompiled stdlib binaries as well, so that experimental compiled mode can find them
+cp -r lib/ $HOME/.perlang/nightly/bin


### PR DESCRIPTION
This provides some of the groundwork for this, mentioned in https://github.com/perlang-org/ perlang/issues/406:

> Distribute the (compiled) stdlib along with snapshot builds

The changes to the `Makefile` means that running `make install` will now install the `stdlib` into the expected location. The next step is to get the `stdlib` bundled with releases and release snapshots as well.