### PR TITLE
(ci) Include `stdlib` in Linux-based `.tar.gz` snapshots

### DIFF
--- a/.github/workflows/publish-release-packages.yml
+++ b/.github/workflows/publish-release-packages.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Re-generate auto-generated files
         run: make auto-generated
 
-      - name: Rebuild stdlib
-        run: make stdlib
-
       #
       # Build releases
       #
@@ -48,6 +45,10 @@ jobs:
 
       - name: Build ${{ matrix.arch }} release
         run: dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r ${{ matrix.arch }} --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
+
+      - name: Rebuild stdlib
+        run: make stdlib && cp -rv lib src/Perlang.ConsoleApp/bin/Release/net7.0/${{ matrix.arch }}/publish
+        if: runner.os == 'Linux'
 
       #
       # Create .tar.gz archives

--- a/.github/workflows/publish-snapshot-packages.yml
+++ b/.github/workflows/publish-snapshot-packages.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Build ${{ matrix.arch }} release
         run: dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r ${{ matrix.arch }} --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
 
+      - name: Rebuild stdlib
+        run: make stdlib && cp -rv lib src/Perlang.ConsoleApp/bin/Release/net7.0/${{ matrix.arch }}/publish
+        if: runner.os == 'Linux'
+
       #
       # Create .tar.gz archives
       #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Re-generate auto-generated files
         run: make auto-generated
 
-      # Needed to run tests, when they are running in experimental compilation mode
-      # (PERLANG_EXPERIMENTAL_COMPILATION=true)
+      # Needed to run tests, when they are running in experimental compilation
+      # mode (PERLANG_EXPERIMENTAL_COMPILATION=true). This also makes sure that
+      # the stdlib builds without errors on all supported platforms.
       - name: Rebuild stdlib
         run: make stdlib
 

--- a/release-notes/v0.4.0.md
+++ b/release-notes/v0.4.0.md
@@ -17,6 +17,7 @@
 - Implement modulo operator for `BigInt` [[#432][432]]
 - Support `<<` and `>>` for bigint in compiled mode [[#440][440]]
 - Detect stdlib bundled with Perlang binaries [[#444][444]]
+- Include `stdlib` in Linux-based `.tar.gz` snapshots [[#445][445]]
 
 ### Changed
 #### Data types


### PR DESCRIPTION
With this in place, we should theoretically be able to use experimental compiled mode (#406) from snapshot and release builds too.