### PR TITLE
(tests) Add `AsciiString_indexed_outside_string` test

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -17,6 +17,8 @@
 ### Fixed
 
 ### Tests
+- Add `AsciiString_indexed_outside_string` test [[#449][449]]
 
 [446]: https://github.com/perlang-org/perlang/pull/446
 [447]: https://github.com/perlang-org/perlang/pull/447
+[449]: https://github.com/perlang-org/perlang/pull/449

--- a/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
+++ b/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
@@ -19,6 +19,26 @@ public class StringIndexing
     }
 
     [SkippableFact]
+    public void AsciiString_indexed_outside_string_returns_expected_error()
+    {
+        // The reason why we can't easily support this yet is that -Warray-bounds returns a compile-time error for this in
+        // Clang (tested with Clang 14). We would need to be able to have an EvalHelper helper methods for checking ICE
+        // errors to be able to deal with it there.
+        Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
+        string source = @"
+            print ""foobar""[10];
+        ";
+
+        var result = EvalWithRuntimeErrorCatch(source);
+
+        result.Errors.Should()
+            .ContainSingle()
+            .Which
+            .Message.Should().Contain("Index was outside the bounds of the array");
+    }
+
+    [SkippableFact]
     public void AsciiString_indexed_by_integer_returns_char_object()
     {
         Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");


### PR DESCRIPTION
...to ensure that we throw the expected error in this case. This was an idea I got while working on the native `AsciiString` implementation.