### PR TITLE
(stdlib) `BigInt::pow`: Detect negative exponents and throw an exception

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -4,6 +4,7 @@
 
 ### Added
 #### Experimental compilation
+- `BigInt::pow`: Detect negative exponents and throw an exception [[#450][450]]
 
 ### Changed
 #### Data types
@@ -22,3 +23,4 @@
 [446]: https://github.com/perlang-org/perlang/pull/446
 [447]: https://github.com/perlang-org/perlang/pull/447
 [449]: https://github.com/perlang-org/perlang/pull/449
+[450]: https://github.com/perlang-org/perlang/pull/450

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -573,6 +573,11 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 
                     // Probably enabled by -Wconversion, but this causes issues with valid code like `2147483647 /
                     // 4294967295U`.
+                    //
+                    // NOTE: disabling this also enables extremely dangerous constructs like being able to call
+                    // BigInt::pow(-3), causing the negative integer to be reinterpreted as a very large uint32 instead.
+                    // We should re-think this and really try to re-enable this, to prevent such horrible code from
+                    // compiling.
                     "-Wno-sign-conversion",
 
                     // We currently overflow without warnings, but we could consider implementing something like this

--- a/src/stdlib/src/bigint.cpp
+++ b/src/stdlib/src/bigint.cpp
@@ -1508,8 +1508,12 @@ BigInt BigInt::operator--(int)
 
 #endif  // BIG_INT_INCREMENT_DECREMENT_OPERATORS_HPP
 
-BigInt BigInt::pow(uint32_t exponent) const
+BigInt BigInt::pow(int32_t exponent) const
 {
+    if (exponent < 0) {
+        throw std::invalid_argument("The exponent must be greater than or equal to zero");
+    }
+
     BigInt result;
     check_tommath_result(mp_expt_u32(&get_data(), exponent, &result.data));
 

--- a/src/stdlib/src/bigint.hpp
+++ b/src/stdlib/src/bigint.hpp
@@ -152,9 +152,11 @@ class BigInt {
         bool operator!=(const unsigned long long&) const;
         bool operator!=(const double&) const;
 
-        BigInt pow(uint32_t exponent) const;
+        [[nodiscard]]
+        BigInt pow(int32_t exponent) const;
 
         // Conversion functions:
+        [[nodiscard]]
         std::string to_string() const;
 
     ::mp_int& get_data()
@@ -163,6 +165,7 @@ class BigInt {
             return data;
         }
 
+        [[nodiscard]]
         const ::mp_int& get_data() const
         {
             assert(data.dp != nullptr);


### PR DESCRIPTION
This was detected while working on the `EvalHelper` methods to try and make more of them work in compiled mode too. This would be a noble goal, but for now feels kind of non-trivial. Because of this, the change likely does unfortunately not have excessive test coverage at the moment; we'll just have to take the compiler's word (Clang) for it that it works. :-)