### PR TITLE
(stdlib) Implement initial native `AsciiString` class

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -5,6 +5,7 @@
 ### Added
 #### Experimental compilation
 - `BigInt::pow`: Detect negative exponents and throw an exception [[#450][450]]
+- Implement initial native `AsciiString` class [[#451][451]]
 
 ### Changed
 #### Data types
@@ -24,3 +25,4 @@
 [447]: https://github.com/perlang-org/perlang/pull/447
 [449]: https://github.com/perlang-org/perlang/pull/449
 [450]: https://github.com/perlang-org/perlang/pull/450
+[451]: https://github.com/perlang-org/perlang/pull/451

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -61,9 +61,8 @@ namespace Perlang
                 var t when t == typeof(BigInteger) => "BigInt",
                 null => throw new InvalidOperationException("Internal error: ClrType was unexpectedly null"),
 
-                // TODO: Differentiate from these on the C++ level as well
-                var t when t.FullName == "Perlang.Lang.AsciiString" => "const char *",
-                var t when t.FullName == "Perlang.Lang.String" => "const char *",
+                var t when t.FullName == "Perlang.Lang.AsciiString" => "ASCIIString",
+                var t when t.FullName == "Perlang.Lang.String" => "String",
 
                 _ => throw new NotImplementedInCompiledModeException($"Internal error: C++ type for {clrType} not defined")
             };

--- a/src/Perlang.Tests.Integration/For/Syntax.cs
+++ b/src/Perlang.Tests.Integration/For/Syntax.cs
@@ -44,9 +44,11 @@ namespace Perlang.Tests.Integration.For
             }, output);
         }
 
-        [Fact]
+        [SkippableFact]
         public void no_clauses()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(): string {
                     for (;;) return ""done"";

--- a/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
+++ b/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
@@ -23,7 +23,8 @@ public class StringIndexing
     {
         // The reason why we can't easily support this yet is that -Warray-bounds returns a compile-time error for this in
         // Clang (tested with Clang 14). We would need to be able to have an EvalHelper helper methods for checking ICE
-        // errors to be able to deal with it there.
+        // errors to be able to deal with it there; EvalWithRuntimeErrorCatch wouldn't help (and is not supported in
+        // compiled mode yet)
         Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
 
         string source = @"

--- a/src/Perlang.Tests.Integration/Return.cs
+++ b/src/Perlang.Tests.Integration/Return.cs
@@ -8,9 +8,15 @@ namespace Perlang.Tests.Integration
     {
         // Tests based on Lox test suite: https://github.com/munificent/craftinginterpreters/tree/master/test/return
 
-        [Fact]
+        [SkippableFact]
         public void after_else()
         {
+            // The code below is incredibly hard to support in compiled mode, because: an AsciiString cannot be assigned
+            // to a String variable in C++ (because the latter is an abstract class; I believe the C++ compiler will try
+            // to make a copy of it, which is why it would be failing since the abstract String class cannot be
+            // instantiated)
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
             string source = @"
                 fun f(): string {
                   if (false) ""no""; else return ""ok"";
@@ -24,9 +30,11 @@ namespace Perlang.Tests.Integration
             Assert.Equal("ok", output);
         }
 
-        [Fact]
+        [SkippableFact]
         public void after_if()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
             string source = @"
                 fun f(): string {
                   if (true) return ""ok"";
@@ -40,9 +48,11 @@ namespace Perlang.Tests.Integration
             Assert.Equal("ok", output);
         }
 
-        [Fact]
+        [SkippableFact]
         public void after_while()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
             string source = @"
                 fun f(): string {
                   while (true) return ""ok"";
@@ -70,9 +80,11 @@ namespace Perlang.Tests.Integration
             Assert.Matches("Cannot return from top-level code.", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void in_function()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
             string source = @"
                 fun f(): string {
                   return ""ok"";

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -7,9 +7,11 @@ using static EvalHelper;
 
 public class StringTests
 {
-    [Fact]
+    [SkippableFact]
     public void string_variable_can_be_printed()
     {
+        Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
         string source = @"
                 var s: string = ""this is a string"";
 
@@ -22,9 +24,11 @@ public class StringTests
             .Be("this is a string");
     }
 
-    [Fact]
+    [SkippableFact]
     public void string_variable_can_be_reassigned()
     {
+        Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
         string source = @"
                 var s: string = ""this is a string"";
                 s = ""this is another string"";
@@ -38,9 +42,16 @@ public class StringTests
             .Be("this is another string");
     }
 
-    [Fact]
+    [SkippableFact]
     public void ascii_string_inferred_variable_can_be_reassigned_with_non_ascii_value()
     {
+        // The code below is incredibly hard to support in compiled mode, because: an AsciiString cannot be assigned to a
+        // String variable in C++ (because the latter is an abstract class; I believe the C++ compiler will try to make a
+        // copy of it). `const perlang::string& s = ...` works, but then the problem is that the variable can obviously
+        // not be reassigned on the second line... because it is constant. We'll have to think through how to solve this
+        // properly.
+        Skip.If(PerlangMode.ExperimentalCompilation, "Not yet supported in compiled mode");
+
         string source = @"
                 var s: string = ""this is a string"";
                 s = ""this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ"";

--- a/src/Perlang.Tests.Integration/Typing/TypingTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/TypingTests.cs
@@ -14,9 +14,11 @@ namespace Perlang.Tests.Integration.Typing
     /// </summary>
     public class TypingTests
     {
-        [Fact]
+        [SkippableFact]
         public void var_declaration_can_provide_a_type()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s: String = ""Hello World"";
             ";
@@ -190,9 +192,11 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Matches("Cannot assign null to an implicitly typed local variable", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void var_declaration_with_initializer_emits_warning_on_null_usage()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s: string = null;
 
@@ -239,9 +243,12 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Matches("Cannot assign 'AsciiString' to 'int' variable", exception!.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void var_declaration_supports_reassignment_to_null_for_reference_type()
         {
+            // ...because nullptr is not implicitly assignable to AsciiString. :-)
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s = ""foo"";
                 s = null;
@@ -254,9 +261,12 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Equal("null", result.OutputAsString);
         }
 
-        [Fact]
+        [SkippableFact]
         public void var_declaration_emits_warning_on_reassignment_to_null_for_reference_type()
         {
+            // ...because nullptr is not implicitly assignable to AsciiString. :-)
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s = ""foo"";
                 s = null;
@@ -290,9 +300,11 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Matches("Cannot assign null to 'int' variable", exception!.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void function_parameter_can_provide_a_type()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(s: String): void {
                     print(s);
@@ -324,9 +336,12 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Matches("Cannot pass int argument as parameter 's: string'", exception!.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void function_parameter_allows_null_argument_for_reference_type_parameter()
         {
+            // ...because nullptr is not implicitly assignable to AsciiString. :-)
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(s: String): void {
                     print(s);
@@ -340,9 +355,11 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Equal("null", result.OutputAsString);
         }
 
-        [Fact]
+        [SkippableFact]
         public void function_parameter_emits_warning_when_null_passed_for_reference_type_parameter()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(s: String): void {
                     print(s);
@@ -378,9 +395,11 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Matches("Cannot pass null argument as parameter 'i: int'", exception!.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         public void function_return_type_can_specify_explicit_type()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(): String {
                     return ""typed return value"";
@@ -394,9 +413,11 @@ namespace Perlang.Tests.Integration.Typing
             Assert.Equal("typed return value", output);
         }
 
-        [Fact]
+        [SkippableFact]
         public void function_return_value_can_be_assigned_to_variable_of_same_type()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 fun foo(): string {
                     return ""typed return value"";

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.0)
 project(stdlib VERSION 0.1.0)
 
 set(headers
+        src/ascii_string.h
         src/bigint.hpp
+        src/perlang_string.h
         src/stdlib.hpp
+        src/utf8_string.h
         src/double-conversion/utils.h
 )
 
@@ -13,11 +16,13 @@ set(libtommath_headers
 
 add_library(
         stdlib
+        src/ascii_string.cc
         src/bigint.cpp
         src/bigint_mod.cpp
         src/bigint_pow.cpp
         src/Base64.cpp
         src/print.cpp
+        src/utf8_string.cc
         src/libtommath/bn_cutoffs.c
         src/libtommath/bn_mp_add.c
         src/libtommath/bn_mp_clamp.c

--- a/src/stdlib/src/Base64.cpp
+++ b/src/stdlib/src/Base64.cpp
@@ -2,9 +2,9 @@
 
 namespace perlang::stdlib
 {
-    const char *Base64::to_string()
+    ASCIIString Base64::to_string()
     {
         // Poor-man's FQCN. :-)
-        return "Perlang.Stdlib.Base64";
+        return ASCIIString::from_static_string("Perlang.Stdlib.Base64");
     }
 }

--- a/src/stdlib/src/ascii_string.cc
+++ b/src/stdlib/src/ascii_string.cc
@@ -1,0 +1,53 @@
+#include <cstring>
+#include <stdexcept>
+#include <string> // needed for std::to_string() on macOS
+
+#include "ascii_string.h"
+
+namespace perlang
+{
+    ASCIIString ASCIIString::from_static_string(const char* s)
+    {
+        if (s == nullptr) {
+            throw std::invalid_argument("string argument cannot be null");
+        }
+
+        auto result = ASCIIString();
+        result.bytes_ = s;
+        result.length_ = strlen(s);
+
+        return result;
+    }
+
+    ASCIIString::ASCIIString()
+    {
+        // Set these to ensure we have predictable defaults. Note that this constructor must ONLY be used from factory
+        // methods, which set these fields to their appropriate values.
+        bytes_ = nullptr;
+        length_ = -1;
+    }
+
+    const char* ASCIIString::bytes() const
+    {
+        return bytes_;
+    }
+    bool ASCIIString::operator==(const ASCIIString& rhs) const
+    {
+        return bytes_ == rhs.bytes_ &&
+               length_ == rhs.length_;
+    }
+    bool ASCIIString::operator!=(const ASCIIString& rhs) const
+    {
+        return !(rhs == *this);
+    }
+
+    char ASCIIString::operator[](size_t index) const
+    {
+        if (index < length_) {
+            return bytes_[index];
+        }
+        else {
+            throw std::out_of_range("Index " + std::to_string(index) + " is out-of-bounds for a string with length " + std::to_string(this->length_));
+        }
+    }
+}

--- a/src/stdlib/src/ascii_string.h
+++ b/src/stdlib/src/ascii_string.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+
+#include "perlang_string.h"
+
+namespace perlang
+{
+    class ASCIIString : public String
+    {
+     public:
+        // Creates a new ASCIIString from a "static string", like a string constant. The static string is guaranteed to
+        // have "static lifetime" (in Rust terms); in other words, that it exists during the remaining lifetime of the
+        // running program. We also extend this to presume that the content of the string remains the same during this
+        // whole lifetime.
+        //
+        // Because of the above assumptions, we know that we can make the new ASCIIString constructed from the `s`
+        // parameter "borrow" the actual bytes_ used by the string. Since no deallocation will take place, and no
+        // mutation, copying the string at this point would just waste CPU cycles for no added benefit.
+        static ASCIIString from_static_string(const char* s);
+
+        // Returns the backing byte array for this ASCIIString. This method is generally to be avoided; it is safer to
+        // use the ASCIIString throughout the code and only call this when you really must.
+        [[nodiscard]]
+        const char* bytes() const override;
+
+        // Compares the equality of two `ASCIIString`s, returning `true` if they point to the same backing byte array
+        // and have the same length. Note that this method does *not* compare referential equality; two different
+        // `ASCIIString` instances pointing at the same backing byte array are considered equal in Perlang. For all
+        // practical matters, they can be considered interchangeable because strings are guaranteed to be immutable for
+        // the whole lifetime of the program.
+        bool operator==(const ASCIIString& rhs) const;
+
+        // Compares the equality of two `ASCIIString`s, returning `true` if they are non-equal. See the `operator==`
+        // documentation for more semantic details about the implementation.
+        bool operator!=(const ASCIIString& rhs) const;
+
+        // Indexes the string, returning the character at the given position. Note that this method performs bounds
+        // checking; attempting to read outside the string will result in an exception.
+        char operator[](size_t index) const;
+
+     private:
+        // Private constructor for creating a `null` string, not yet initialized with any sensible content.
+        ASCIIString();
+
+        // The backing byte array for this string. This is to be considered immutable and MUST NOT be modified at any
+        // point. There might be multiple ASCIIString objects pointing to the same `bytes_`, so modifying one of them
+        // would unintentionally spread the modifications to these other objects too.
+        const char* bytes_;
+
+        // The length of the string in bytes, excluding the terminating `NUL` character.
+        size_t length_;
+    };
+}

--- a/src/stdlib/src/perlang_string.h
+++ b/src/stdlib/src/perlang_string.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace perlang
+{
+    // Abstract base class for all String types in Perlang
+    class String
+    {
+     public:
+        // Returns the backing byte array for this String. This method is generally to be avoided; it is safer to use
+        // the String throughout the code and only call this when you really must.
+        [[nodiscard]]
+        virtual const char* bytes() const = 0;
+    };
+}

--- a/src/stdlib/src/print.cpp
+++ b/src/stdlib/src/print.cpp
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 
 // fmt is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.
@@ -6,19 +5,22 @@
 #define FMT_HEADER_ONLY
 #include "fmt/format.h"
 
+#include "ascii_string.h"
 #include "bigint.hpp"
 
 namespace perlang
 {
-    void print(const char* str)
+    void print(const String& str)
     {
-        if (str == nullptr) {
+        const char* bytes = str.bytes();
+
+        if (bytes == nullptr) {
             puts("null");
         }
         else {
             // For plain strings, there's no need to use the overhead which `printf` induces. `puts` can potentially be a
             // tiny bit faster.
-            puts(str);
+            puts(bytes);
         }
     }
 

--- a/src/stdlib/src/stdlib.hpp
+++ b/src/stdlib/src/stdlib.hpp
@@ -2,7 +2,10 @@
 
 #include <stdint.h>
 
+#include "ascii_string.h"
 #include "bigint.hpp"
+#include "perlang_string.h"
+#include "utf8_string.h"
 
 namespace perlang
 {
@@ -11,11 +14,11 @@ namespace perlang
         class Base64
         {
          public:
-            static const char* to_string();
+            static ASCIIString to_string();
         };
     }
 
-    void print(const char* str);
+    void print(const String& str);
     void print(bool b);
     void print(char c);
     void print(int32_t i);

--- a/src/stdlib/src/utf8_string.cc
+++ b/src/stdlib/src/utf8_string.cc
@@ -1,0 +1,42 @@
+#include <cstring>
+#include <stdexcept>
+
+#include "utf8_string.h"
+
+namespace perlang
+{
+    UTF8String UTF8String::from_static_string(const char* s)
+    {
+        if (s == nullptr) {
+            throw std::invalid_argument("string argument cannot be null");
+        }
+
+        auto result = UTF8String();
+        result.bytes_ = s;
+        result.length_ = strlen(s);
+
+        return result;
+    }
+
+    UTF8String::UTF8String()
+    {
+        // Set these to ensure we have predictable defaults. Note that this constructor must ONLY be used from factory
+        // methods, which set these fields to their appropriate values.
+        bytes_ = nullptr;
+        length_ = -1;
+    }
+
+    const char* UTF8String::bytes() const
+    {
+        return bytes_;
+    }
+    bool UTF8String::operator==(const UTF8String& rhs) const
+    {
+        return bytes_ == rhs.bytes_ &&
+               length_ == rhs.length_;
+    }
+    bool UTF8String::operator!=(const UTF8String& rhs) const
+    {
+        return !(rhs == *this);
+    }
+}

--- a/src/stdlib/src/utf8_string.h
+++ b/src/stdlib/src/utf8_string.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+
+#include "perlang_string.h"
+
+namespace perlang
+{
+    class UTF8String : public String
+    {
+     public:
+        // Creates a new UTF8String from a "static string", like a string constant. The static string is guaranteed to
+        // have "static lifetime" (in Rust terms); in other words, that it exists during the remaining lifetime of the
+        // running program. We also extend this to presume that the content of the string remains the same during this
+        // whole lifetime.
+        //
+        // Because of the above assumptions, we know that we can make the new UTF8String constructed from the `s`
+        // parameter "borrow" the actual bytes_ used by the string. Since no deallocation will take place, and no
+        // mutation, copying the string at this point would just waste CPU cycles for no added benefit.
+        static UTF8String from_static_string(const char* s);
+
+        // Returns the backing byte array for this UTF8String. This method is generally to be avoided; it is safer to
+        // use the UTF8String throughout the code and only call this when you really must.
+        [[nodiscard]]
+        const char* bytes() const override;
+
+        // Compares the equality of two `UTF8String`s, returning `true` if they point to the same backing byte array
+        // and have the same length. Note that this method does *not* compare referential equality; two different
+        // `UTF8String` instances pointing at the same backing byte array are considered equal in Perlang. For all
+        // practical matters, they can be considered interchangeable because strings are guaranteed to be immutable for
+        // the whole lifetime of the program.
+        bool operator==(const UTF8String& rhs) const;
+
+        // Compares the equality of two `UTF8String`s, returning `true` if they are non-equal. See the `operator==`
+        // documentation for more semantic details about the implementation.
+        bool operator!=(const UTF8String& rhs) const;
+
+     private:
+        // Private constructor for creating a `null` string, not yet initialized with any sensible content.
+        UTF8String();
+
+        // The backing byte array for this string. This is to be considered immutable and MUST NOT be modified at any
+        // point. There might be multiple UTF8String objects pointing to the same `bytes_`, so modifying one of them
+        // would unintentionally spread the modifications to these other objects too.
+        const char* bytes_;
+
+        // The length of the string in bytes, excluding the terminating `NUL` character.
+        size_t length_;
+    };
+}


### PR DESCRIPTION
"Native" as in "C++", being possible to access from C++ code targetting native machines.