### PR TITLE
(compiler) Add `-c` flag for "compile and assemble only"

### DIFF
--- a/Perlang.sln
+++ b/Perlang.sln
@@ -29,7 +29,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Tests.Architecture"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Compiler", "src\Perlang.Compiler\Perlang.Compiler.csproj", "{7E7CF7BF-F792-49C9-BB16-67FE856D8D51}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{47B4A37F-6999-4510-9815-418E03D7B39E}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{47B4A37F-6999-4510-9815-418E03D7B39E}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection

--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -7,6 +7,7 @@
 - `BigInt::pow`: Detect negative exponents and throw an exception [[#450][450]]
 - Implement initial native `ASCIIString` class [[#451][451]]
 - Wrap `ASCIIString` in `std::shared_ptr<T>` [[#453][453]]
+- Add `-c` flag for "compile and assemble only" [[#455][455]]
 
 ### Changed
 #### Data types
@@ -27,3 +28,5 @@
 [449]: https://github.com/perlang-org/perlang/pull/449
 [450]: https://github.com/perlang-org/perlang/pull/450
 [451]: https://github.com/perlang-org/perlang/pull/451
+[453]: https://github.com/perlang-org/perlang/pull/453
+[455]: https://github.com/perlang-org/perlang/pull/455


### PR DESCRIPTION
This commit is a small step towards #454. By adding this flag, it's possible to "use Perlang as a transpiler" only. Okay, a _little_ more than a transpiler, since it also emits ELF object files. :) But still, it helps us towards a state where we can gradually, incrementally rewrite parts of the Perlang compiler in Perlang. Oh, the joy! Oh, the glory!