### PR TITLE
(compiler) Remove `using namespace` in generated C++ code

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -8,6 +8,7 @@
 - Implement initial native `ASCIIString` class [[#451][451]]
 - Wrap `ASCIIString` in `std::shared_ptr<T>` [[#453][453]]
 - Add `-c` flag for "compile and assemble only" [[#455][455]]
+- Remove `using namespace` in generated C++ code [[#458][458]]
 
 ### Changed
 #### Data types
@@ -32,3 +33,4 @@
 [453]: https://github.com/perlang-org/perlang/pull/453
 [455]: https://github.com/perlang-org/perlang/pull/455
 [456]: https://github.com/perlang-org/perlang/pull/456
+[458]: https://github.com/perlang-org/perlang/pull/458

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -62,8 +62,8 @@ namespace Perlang
                 null => throw new InvalidOperationException("Internal error: ClrType was unexpectedly null"),
 
                 // TODO: Handle UTF-8 strings here too
-                var t when t.FullName == "Perlang.Lang.AsciiString" => "ASCIIString",
-                var t when t.FullName == "Perlang.Lang.String" => "String",
+                var t when t.FullName == "Perlang.Lang.AsciiString" => "perlang::ASCIIString",
+                var t when t.FullName == "Perlang.Lang.String" => "perlang::String",
 
                 _ => throw new NotImplementedInCompiledModeException($"Internal error: C++ type for {clrType} not defined")
             };
@@ -86,8 +86,8 @@ namespace Perlang
                 // These are wrapped in std::shared_ptr<>, as a simple way to deal with ownership for now. For the
                 // long-term solution, see https://github.com/perlang-org/perlang/issues/378.
                 // TODO: Handle UTF-8 strings here too
-                var t when t.FullName == "Perlang.Lang.AsciiString" => "std::shared_ptr<const ASCIIString>",
-                var t when t.FullName == "Perlang.Lang.String" => "std::shared_ptr<const String>",
+                var t when t.FullName == "Perlang.Lang.AsciiString" => "std::shared_ptr<const perlang::ASCIIString>",
+                var t when t.FullName == "Perlang.Lang.String" => "std::shared_ptr<const perlang::String>",
 
                 _ => throw new NotImplementedInCompiledModeException($"Internal error: C++ type for {clrType} not defined")
             };

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -520,8 +520,6 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 #include ""bigint.hpp"" // BigInt
 #include ""stdlib.hpp""
 
-using namespace perlang;
-
 ");
 
                 streamWriter.WriteLine("//");
@@ -1146,7 +1144,7 @@ using namespace perlang;
             // on the C++ side. (The "static string" is the important part here; because we know that it's a literal, we
             // can assume "shared" ownership of it and assume that it will never be deallocated for the whole lifetime of
             // the program.)
-            currentMethod.Append("ASCIIString::from_static_string(\"");
+            currentMethod.Append("perlang::ASCIIString::from_static_string(\"");
             currentMethod.Append(expr);
             currentMethod.Append("\")");
         }
@@ -1156,7 +1154,7 @@ using namespace perlang;
             // on the C++ side. (The "static string" is the important part here; because we know that it's a literal, we
             // can assume "shared" ownership of it and assume that it will never be deallocated for the whole lifetime of
             // the program.)
-            currentMethod.Append("UTF8String::from_static_string(\"");
+            currentMethod.Append("perlang::UTF8String::from_static_string(\"");
             currentMethod.Append(expr);
             currentMethod.Append("\")");
         }


### PR DESCRIPTION
This has turned out to be a bad idea. Including this makes it slightly harder to copy fragments of the generated C++ code into e.g. a test program, which is something I do from time to time (when e.g. debugging generated C++ code that doesn't work or doesn't compile).