### PR TITLE
(interpreter) Use `VisitorBase` everywhere applicable

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -17,6 +17,7 @@
 - Remove REPL code [[#446][446]]
 - Remove `-e <script>` option [[#447][447]]
 - Remove custom `IConsole` implementations [[#456][456]]
+- Use `VisitorBase` everywhere applicable [[#459][459]]
 
 #### Maintenance
 
@@ -34,3 +35,4 @@
 [455]: https://github.com/perlang-org/perlang/pull/455
 [456]: https://github.com/perlang-org/perlang/pull/456
 [458]: https://github.com/perlang-org/perlang/pull/458
+[459]: https://github.com/perlang-org/perlang/pull/459

--- a/src/Perlang.Common/VisitorBase.cs
+++ b/src/Perlang.Common/VisitorBase.cs
@@ -151,7 +151,7 @@ namespace Perlang
             return VoidObject.Void;
         }
 
-        public VoidObject VisitClassStmt(Stmt.Class stmt)
+        public virtual VoidObject VisitClassStmt(Stmt.Class stmt)
         {
             // TODO: visit fields also, once we have implemented support for them.
 

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -51,6 +51,9 @@ namespace Perlang.Interpreter.Compiler;
 /// This is not the case for this simple implementation; it simply knows the level of indentation at each stage in the
 /// processing and does its best to try to produce something which is "not garbage", but not necessarily perfectly
 /// aesthetically pleasing.
+/// <remarks>Note: must **NOT** be a <see cref="VisitorBase"/>, because we use different return types than the base class'
+/// methods. Using the `new` keyword for these overloads will not work, since the base class will then not call the
+/// methods in this class as expected.</remarks>
 /// </summary>
 public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 {
@@ -723,12 +726,13 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
         globalClasses[name] = perlangClass;
     }
 
-    public object? VisitEmptyExpr(Expr.Empty expr)
+    public object VisitEmptyExpr(Expr.Empty expr)
     {
-        throw new NotImplementedException();
+        // No need to emit anything in the generated C++ code for an empty expression.
+        return VoidObject.Void;
     }
 
-    public object? VisitAssignExpr(Expr.Assign expr)
+    public object VisitAssignExpr(Expr.Assign expr)
     {
         currentMethod.Append($"{expr.Identifier.Name.Lexeme} = {expr.Value.Accept(this)}");
         return VoidObject.Void;

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -32,6 +32,9 @@ namespace Perlang.Interpreter
     ///
     /// Instances of this class are not thread safe; calling <see cref="Eval"/> on multiple threads simultaneously can
     /// lead to race conditions and is not supported.
+    /// <remarks>Note: must **NOT** be a <see cref="VisitorBase"/>, because we use different return types than the base class'
+    /// methods. Using the `new` keyword for these overloads will not work, since the base class will then not call the
+    /// methods in this class as expected.</remarks>
     /// </summary>
     public class PerlangInterpreter : IInterpreter, Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
     {


### PR DESCRIPTION
This is a preparation for other changes coming, where we add a new `IVisitor<Stmt>` method. Doing this is easier if `VisitorBase` is used everywhere possible, since it means we only have to add the implementation to the base class.