### PR TITLE
(compiler) Add partial inline C++ support

### DIFF
--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -2,9 +2,10 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/PARENTHESES_REDUNDANCY_STYLE/@EntryValue">Remove</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_DECLARED_IN/@EntryValue">BaseClass</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Property, Event, Method</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Property, Event</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_BEFORE_BLOCK_STATEMENTS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">False</s:Boolean>
@@ -33,6 +34,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Titleized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=toupper/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trippable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ucrtbase/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werror/@EntryIndexedValue">True</s:Boolean>

--- a/global.ruleset
+++ b/global.ruleset
@@ -27,6 +27,8 @@
         <Rule Id="SA1204" Action="None"/>       <!-- Static elements should appear before instance elements -->
 
         <Rule Id="SA1413" Action="None"/>       <!-- Use trailing comma in multi-line initializers -->
+
+        <Rule Id="SA1500" Action="None"/>       <!-- Braces for multi-line statements should not share line -->
         <Rule Id="SA1512" Action="None"/>       <!-- Single-line comments should not be followed by blank line -->
         <Rule Id="SA1516" Action="None"/>       <!-- Elements should be separated by blank line -->
 

--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -9,6 +9,7 @@
 - Wrap `ASCIIString` in `std::shared_ptr<T>` [[#453][453]]
 - Add `-c` flag for "compile and assemble only" [[#455][455]]
 - Remove `using namespace` in generated C++ code [[#458][458]]
+- Add partial inline C++ support [[#462][462]]
 
 ### Changed
 #### Data types
@@ -36,3 +37,4 @@
 [456]: https://github.com/perlang-org/perlang/pull/456
 [458]: https://github.com/perlang-org/perlang/pull/458
 [459]: https://github.com/perlang-org/perlang/pull/459
+[462]: https://github.com/perlang-org/perlang/pull/462

--- a/src/Perlang.Common/Compiler/CompilerFlags.cs
+++ b/src/Perlang.Common/Compiler/CompilerFlags.cs
@@ -15,5 +15,11 @@ public enum CompilerFlags
     /// This flag disables all caching of compiled Perlang code, to ensure that all parts of the compilation is being
     /// used.
     /// </summary>
-    CacheDisabled = 1
+    CacheDisabled = 1,
+
+    /// <summary>
+    /// This flag which makes the compiler remove the `main` method if it is empty. This
+    /// can be useful e.g. when the `main` method is implemented in C++.
+    /// </summary>
+    RemoveEmptyMainMethod = 2
 }

--- a/src/Perlang.Common/Token.cs
+++ b/src/Perlang.Common/Token.cs
@@ -21,12 +21,10 @@ namespace Perlang
 
         public override string ToString()
         {
-            if (Literal != null)
-            {
+            if (Literal != null) {
                 return $"{Type} {Lexeme} {Literal}";
             }
-            else
-            {
+            else {
                 return $"{Type} {Lexeme}";
             }
         }

--- a/src/Perlang.Common/TokenType.cs
+++ b/src/Perlang.Common/TokenType.cs
@@ -50,6 +50,11 @@ namespace Perlang
         STRING,
         NUMBER,
 
+        // #-directives, used for enabling special features in the compiler. These are not part of the language itself,
+        // and each directive has a token type of its own.
+        PREPROCESSOR_DIRECTIVE_CPP_PROTOTYPES,
+        PREPROCESSOR_DIRECTIVE_CPP_METHODS,
+
         // Keywords.
         ELSE,
         FALSE,

--- a/src/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/src/Perlang.Interpreter/PerlangInterpreter.cs
@@ -199,6 +199,11 @@ namespace Perlang.Interpreter
                 return null;
             }
 
+            if (result.CppPrototypes.Count > 0 || result.CppMethods.Count > 0)
+            {
+                throw new PerlangInterpreterException("C++ code is not supported in interpreted mode");
+            }
+
             if (result.HasStatements)
             {
                 var previousAndNewStatements = previousStatements.Concat(result.Statements!).ToImmutableList();
@@ -490,13 +495,18 @@ namespace Perlang.Interpreter
                 allowSemicolonElision: replMode
             );
 
-            object syntax = parser.ParseExpressionOrStatements();
+            (object syntax, List<Token> cppPrototypes, List<Token> cppMethods) = parser.ParseExpressionOrStatements();
 
             if (hasParseErrors)
             {
                 // One or more parse errors were encountered. They have been reported upstream, so we just abort
                 // the evaluation at this stage.
                 return null;
+            }
+
+            if (cppPrototypes.Count > 0 || cppMethods.Count > 0)
+            {
+                throw new IllegalStateException("C++ code is not supported in interpreted mode");
             }
 
             if (syntax is List<Stmt> statements)

--- a/src/Perlang.Parser/ScanAndParseResult.cs
+++ b/src/Perlang.Parser/ScanAndParseResult.cs
@@ -1,4 +1,5 @@
 #nullable enable
+#pragma warning disable SA1128
 using System.Collections.Generic;
 
 namespace Perlang.Parser;
@@ -13,22 +14,28 @@ public class ScanAndParseResult
 
     public Expr? Expr { get; }
     public List<Stmt>? Statements { get; }
+    public List<Token> CppMethods { get; set; }
+    public List<Token> CppPrototypes { get; set; }
 
     public bool HasExpr => Expr != null;
     public bool HasStatements => Statements != null;
 
     private ScanAndParseResult()
     {
+        CppMethods = new List<Token>();
+        CppPrototypes = new List<Token>();
     }
 
-    private ScanAndParseResult(Expr expr)
+    private ScanAndParseResult(Expr expr) : this()
     {
         Expr = expr;
     }
 
-    private ScanAndParseResult(List<Stmt> statements)
+    private ScanAndParseResult(List<Stmt> statements, List<Token> cppPrototypes, List<Token> cppMethods)
     {
         Statements = statements;
+        CppPrototypes = cppPrototypes;
+        CppMethods = cppMethods;
     }
 
     public static ScanAndParseResult OfExpr(Expr expr)
@@ -36,8 +43,8 @@ public class ScanAndParseResult
         return new ScanAndParseResult(expr);
     }
 
-    public static ScanAndParseResult OfStmts(List<Stmt> stmts)
+    public static ScanAndParseResult OfStmts(List<Stmt> stmts, List<Token> cppPrototypes, List<Token> cppMethods)
     {
-        return new ScanAndParseResult(stmts);
+        return new ScanAndParseResult(stmts, cppPrototypes, cppMethods);
     }
 }

--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -21,7 +21,8 @@ namespace Perlang.Tests.Integration
         /// first will be thrown.
         ///
         /// Output printed to the standard output stream will be silently discarded by this method. For tests which need
-        /// to make assertions based on the output printed, see e.g. the <see cref="EvalReturningOutput"/> method.
+        /// to make assertions based on the output printed, see e.g. the
+        /// <see cref="EvalReturningOutput(string, string[])"/> method.
         ///
         /// Note that compiler warnings will be propagated as exceptions to the caller; in other words, this resembles
         /// the `-Werror` flag being enabled.
@@ -347,7 +348,23 @@ namespace Perlang.Tests.Integration
         /// <returns>The output from the provided expression/statements.</returns>
         internal static IEnumerable<string> EvalReturningOutput(string source, params string[] arguments)
         {
-            var result = EvalWithResult(source, arguments);
+            return EvalReturningOutput(source, CompilerFlags.None, arguments);
+        }
+
+        /// <summary>
+        /// Evaluates the provided expression or list of statements. If the expression or statements prints to the
+        /// standard output, the content will be returned as a collection of strings (one string per line printed).
+        ///
+        /// This method will propagate all errors to the caller. Note that compiler warnings will also be propagated as
+        /// exceptions to the caller; in other words, this resembles the `-Werror` flag being enabled.
+        /// </summary>
+        /// <param name="source">A valid Perlang program.</param>
+        /// <param name="compilerFlags">The <see cref="CompilerFlags"/> to use when performing the compilation.</param>
+        /// <param name="arguments">Zero or more arguments to be passed to the program.</param>
+        /// <returns>The output from the provided expression/statements.</returns>
+        internal static IEnumerable<string> EvalReturningOutput(string source, CompilerFlags compilerFlags, params string[] arguments)
+        {
+            var result = EvalWithResult(source, compilerFlags, arguments);
 
             if (result.CompilerWarnings.Count > 0)
             {

--- a/src/Perlang.Tests.Integration/InlineCpp/InlineCppTests.cs
+++ b/src/Perlang.Tests.Integration/InlineCpp/InlineCppTests.cs
@@ -1,0 +1,82 @@
+using System;
+using FluentAssertions;
+using Perlang.Compiler;
+using Perlang.Interpreter;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration.InlineCpp
+{
+    /// <summary>
+    /// Inline C++ tests.
+    /// </summary>
+    public class InlineCppTests
+    {
+        [Fact(DisplayName = "C++ can be used to implement the `main` method")]
+        public void cpp_can_be_used_to_implement_the_main_method()
+        {
+            string source = """
+                #c++-prototypes
+                int main();
+                #/c++-prototypes
+
+                #c++-methods
+                int main()
+                {
+                    puts("main method implemented in C++");
+                    return 0;
+                }
+                #/c++-methods
+                """;
+
+            if (PerlangMode.ExperimentalCompilation) {
+                var output = EvalReturningOutput(source, CompilerFlags.RemoveEmptyMainMethod);
+
+                output.Should()
+                    .Equal("main method implemented in C++");
+            }
+            else {
+                Action action = () => EvalWithRuntimeErrorCatch(source);
+
+                action.Should()
+                    .Throw<PerlangInterpreterException>()
+                    .WithMessage("C++ code is not supported in interpreted mode");
+            }
+        }
+
+        [Fact(DisplayName = "C++ method can be called from Perlang code", Skip = "Needs `extern` keyword")]
+        public void cpp_method_can_be_called_from_perlang_code()
+        {
+            // TODO: Even if/when we can get the parser to consume the "raw" C++ code and handle it correctly, there's
+            // TODO: still a challenge here. The Perlang code doesn't know anything about this method. How could we change
+            // TODO: this? We would need something like an `extern` keyword or so, so you can write
+            // TODO: `extern fun native_method(): void;`. This is probably the "easiest" way out of this. As a workaround
+            // TODO: for now, we could skip this test and add another test method which just has a C++ `main` function
+            // TODO: which prints a message as step 1. We can then fix `extern` in a separate PR.
+            string source = @"
+                #c++-prototypes
+                static void cpp_method();
+                #/c++prototypes
+
+                extern fun cpp_method(): void;
+
+                fun main(): void
+                {
+                    cpp_method();
+                }
+
+                #c++-methods
+                void cpp_method()
+                {
+                    puts(""cpp_method output"");
+                }
+                #/c++methods
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            output.Should()
+                .Equal("cpp_method output");
+        }
+    }
+}

--- a/src/Perlang.Tests.Integration/Shebang.cs
+++ b/src/Perlang.Tests.Integration/Shebang.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -29,10 +30,12 @@ namespace Perlang.Tests.Integration
             ".Trim();
 
             var result = EvalWithScanErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Unexpected character #", exception.Message);
+            // This doesn't get treated as a shebang, but as preprocessor directive, which is why the error message
+            // doesn't contain the hash sign.
+            result.Errors.Should()
+                .ContainSingle().Which
+                .Message.Should().Match("Unknown preprocessor directive !/usr/bin/env perlang.");
         }
     }
 }


### PR DESCRIPTION
This change adds support for writing entire methods in C++. It lets you declare the prototype(s), using a special preprocessor directive, and similarly for the actual method implemention.

What we don't support is something like:

```
cpp {
  // C++ code here inside a Perlang function
}
```

...and this is also something we don't see a strong need for right now. Will leave this as-is, and might consider implementing the above at some point if the need arises.

### Related issue

* #457 