### PR TITLE
(tests) Implement more `EvalHelper` methods for compiled mode

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -34,6 +34,7 @@
 
 ### Tests
 - Add `AsciiString_indexed_outside_string` test [[#449][449]]
+- Implement more `EvalHelper` methods for compiled mode [[#463][463]]
 
 [446]: https://github.com/perlang-org/perlang/pull/446
 [447]: https://github.com/perlang-org/perlang/pull/447
@@ -46,4 +47,5 @@
 [458]: https://github.com/perlang-org/perlang/pull/458
 [459]: https://github.com/perlang-org/perlang/pull/459
 [462]: https://github.com/perlang-org/perlang/pull/462
+[463]: https://github.com/perlang-org/perlang/pull/463
 [464]: https://github.com/perlang-org/perlang/pull/464

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -644,6 +644,13 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                     // Enable warnings on e.g. narrowing conversion from `long long` to `unsigned long long`.
                     "-Wconversion",
 
+                    // This could be added, but the problem is that division by zero has undefined behavior in C++. :/ I
+                    // think the long-term goal for Perlang in this regard is to use proper hardware exceptions for this
+                    // (which is natively supported on x86 and amd64, at least), and propagate it as a Perlang exception.
+                    // For platforms without hardware support, we might have to emulate this in software for a coherent
+                    // dev experience. For now, let Clang warn about it when dividing with a zero constant.
+                    //"-Wno-division-by-zero",
+
                     // ...but do not warn on implicit conversion from `int` to `float` or `double`. For now, we are
                     // aiming at mimicking the C# semantics in this.
                     "-Wno-implicit-int-float-conversion",

--- a/src/Perlang.Tests.Integration/EvalHelper.cs
+++ b/src/Perlang.Tests.Integration/EvalHelper.cs
@@ -71,23 +71,61 @@ namespace Perlang.Tests.Integration
         /// will be set to `null`.</returns>
         internal static EvalResult<RuntimeError> EvalWithRuntimeErrorCatch(string source, params string[] arguments)
         {
-            var result = new EvalResult<RuntimeError>();
+            if (PerlangMode.ExperimentalCompilation)
+            {
+                var result = new EvalResult<RuntimeError>();
 
-            var interpreter = new PerlangInterpreter(
-                result.ErrorHandler, result.OutputHandler, null, arguments
-            );
+                var compiler = new PerlangCompiler(
+                    result.ErrorHandler, result.OutputHandler, null, arguments
+                );
 
-            result.Value = interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                AssertFailParseErrorHandler,
-                AssertFailNameResolutionErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler,
-                result.WarningHandler
-            );
+                try
+                {
+                    result.Value = compiler.CompileAndRun(
+                        source,
+                        CreateTemporaryPath(source),
+                        CompilerFlags.None,
+                        AssertFailScanErrorHandler,
+                        AssertFailParseErrorHandler,
+                        AssertFailNameResolutionErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        result.WarningHandler
+                    );
+                }
+                catch (NotImplementedInCompiledModeException e)
+                {
+                    // This exception is thrown to make it possible for integration tests to skip tests for code which
+                    // is known to not yet work.
+                    throw new SkipException(e.Message, e);
+                }
 
-            return result;
+                // Return something else than `null` to make it reasonable for callers to distinguish that compiled mode
+                // (with no native "result") is being used, if needed.
+                result.Value = VoidObject.Void;
+
+                return result;
+            }
+            else
+            {
+                var result = new EvalResult<RuntimeError>();
+
+                var interpreter = new PerlangInterpreter(
+                    result.ErrorHandler, result.OutputHandler, null, arguments
+                );
+
+                result.Value = interpreter.Eval(
+                    source,
+                    AssertFailScanErrorHandler,
+                    AssertFailParseErrorHandler,
+                    AssertFailNameResolutionErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    result.WarningHandler
+                );
+
+                return result;
+            }
         }
 
         /// <summary>
@@ -108,20 +146,55 @@ namespace Perlang.Tests.Integration
         /// will be set to `null`.</returns>
         internal static EvalResult<ScanError> EvalWithScanErrorCatch(string source)
         {
-            var result = new EvalResult<ScanError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+            if (PerlangMode.ExperimentalCompilation)
+            {
+                var result = new EvalResult<ScanError>();
 
-            result.Value = interpreter.Eval(
-                source,
-                result.ErrorHandler,
-                AssertFailParseErrorHandler,
-                AssertFailNameResolutionErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler,
-                result.WarningHandler
-            );
+                var compiler = new PerlangCompiler(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
-            return result;
+                try
+                {
+                    result.Value = compiler.CompileAndRun(
+                        source,
+                        CreateTemporaryPath(source),
+                        CompilerFlags.None,
+                        result.ErrorHandler,
+                        AssertFailParseErrorHandler,
+                        AssertFailNameResolutionErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        result.WarningHandler
+                    );
+                }
+                catch (NotImplementedInCompiledModeException e)
+                {
+                    // This exception is thrown to make it possible for integration tests to skip tests for code which
+                    // is known to not yet work.
+                    throw new SkipException(e.Message, e);
+                }
+
+                // Return something else than `null` to make it reasonable for callers to distinguish that compiled mode
+                // (with no native "result") is being used, if needed.
+                result.Value = VoidObject.Void;
+
+                return result;
+            }
+            else {
+                var result = new EvalResult<ScanError>();
+                var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+
+                result.Value = interpreter.Eval(
+                    source,
+                    result.ErrorHandler,
+                    AssertFailParseErrorHandler,
+                    AssertFailNameResolutionErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    result.WarningHandler
+                );
+
+                return result;
+            }
         }
 
         /// <summary>
@@ -142,20 +215,52 @@ namespace Perlang.Tests.Integration
         /// will be set to `null`.</returns>
         internal static EvalResult<ParseError> EvalWithParseErrorCatch(string source)
         {
-            var result = new EvalResult<ParseError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+            if (PerlangMode.ExperimentalCompilation) {
+                var result = new EvalResult<ParseError>();
 
-            result.Value = interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                result.ErrorHandler,
-                AssertFailNameResolutionErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler,
-                result.WarningHandler
-            );
+                var compiler = new PerlangCompiler(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
-            return result;
+                try {
+                    result.Value = compiler.CompileAndRun(
+                        source,
+                        CreateTemporaryPath(source),
+                        CompilerFlags.None,
+                        AssertFailScanErrorHandler,
+                        result.ErrorHandler,
+                        AssertFailNameResolutionErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        result.WarningHandler
+                    );
+                }
+                catch (NotImplementedInCompiledModeException e) {
+                    // This exception is thrown to make it possible for integration tests to skip tests for code which
+                    // is known to not yet work.
+                    throw new SkipException(e.Message, e);
+                }
+
+                // Return something else than `null` to make it reasonable for callers to distinguish that compiled mode
+                // (with no native "result") is being used, if needed.
+                result.Value = VoidObject.Void;
+
+                return result;
+            }
+            else {
+                var result = new EvalResult<ParseError>();
+                var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+
+                result.Value = interpreter.Eval(
+                    source,
+                    AssertFailScanErrorHandler,
+                    result.ErrorHandler,
+                    AssertFailNameResolutionErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    result.WarningHandler
+                );
+
+                return result;
+            }
         }
 
         /// <summary>
@@ -176,20 +281,52 @@ namespace Perlang.Tests.Integration
         /// will be set to `null`.</returns>
         internal static EvalResult<NameResolutionError> EvalWithNameResolutionErrorCatch(string source)
         {
-            var result = new EvalResult<NameResolutionError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+            if (PerlangMode.ExperimentalCompilation) {
+                var result = new EvalResult<NameResolutionError>();
 
-            result.Value = interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                AssertFailParseErrorHandler,
-                result.ErrorHandler,
-                AssertFailValidationErrorHandler,
-                AssertFailValidationErrorHandler,
-                result.WarningHandler
-            );
+                var compiler = new PerlangCompiler(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
-            return result;
+                try {
+                    result.Value = compiler.CompileAndRun(
+                        source,
+                        CreateTemporaryPath(source),
+                        CompilerFlags.None,
+                        AssertFailScanErrorHandler,
+                        AssertFailParseErrorHandler,
+                        result.ErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        AssertFailValidationErrorHandler,
+                        result.WarningHandler
+                    );
+                }
+                catch (NotImplementedInCompiledModeException e) {
+                    // This exception is thrown to make it possible for integration tests to skip tests for code which
+                    // is known to not yet work.
+                    throw new SkipException(e.Message, e);
+                }
+
+                // Return something else than `null` to make it reasonable for callers to distinguish that compiled mode
+                // (with no native "result") is being used, if needed.
+                result.Value = VoidObject.Void;
+
+                return result;
+            }
+            else {
+                var result = new EvalResult<NameResolutionError>();
+                var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+
+                result.Value = interpreter.Eval(
+                    source,
+                    AssertFailScanErrorHandler,
+                    AssertFailParseErrorHandler,
+                    result.ErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    AssertFailValidationErrorHandler,
+                    result.WarningHandler
+                );
+
+                return result;
+            }
         }
 
         /// <summary>
@@ -210,20 +347,52 @@ namespace Perlang.Tests.Integration
         /// will be set to `null`.</returns>
         internal static EvalResult<ValidationError> EvalWithValidationErrorCatch(string source)
         {
-            var result = new EvalResult<ValidationError>();
-            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+            if (PerlangMode.ExperimentalCompilation) {
+                var result = new EvalResult<ValidationError>();
 
-            result.Value = interpreter.Eval(
-                source,
-                AssertFailScanErrorHandler,
-                AssertFailParseErrorHandler,
-                AssertFailNameResolutionErrorHandler,
-                result.ErrorHandler,
-                result.ErrorHandler,
-                result.WarningHandler
-            );
+                var compiler = new PerlangCompiler(AssertFailRuntimeErrorHandler, result.OutputHandler);
 
-            return result;
+                try {
+                    result.Value = compiler.CompileAndRun(
+                        source,
+                        CreateTemporaryPath(source),
+                        CompilerFlags.None,
+                        AssertFailScanErrorHandler,
+                        AssertFailParseErrorHandler,
+                        AssertFailNameResolutionErrorHandler,
+                        result.ErrorHandler,
+                        result.ErrorHandler,
+                        result.WarningHandler
+                    );
+                }
+                catch (NotImplementedInCompiledModeException e) {
+                    // This exception is thrown to make it possible for integration tests to skip tests for code which
+                    // is known to not yet work.
+                    throw new SkipException(e.Message, e);
+                }
+
+                // Return something else than `null` to make it reasonable for callers to distinguish that compiled mode
+                // (with no native "result") is being used, if needed.
+                result.Value = VoidObject.Void;
+
+                return result;
+            }
+            else {
+                var result = new EvalResult<ValidationError>();
+                var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, result.OutputHandler);
+
+                result.Value = interpreter.Eval(
+                    source,
+                    AssertFailScanErrorHandler,
+                    AssertFailParseErrorHandler,
+                    AssertFailNameResolutionErrorHandler,
+                    result.ErrorHandler,
+                    result.ErrorHandler,
+                    result.WarningHandler
+                );
+
+                return result;
+            }
         }
 
         /// <summary>

--- a/src/Perlang.Tests.Integration/IndexOperator/DictionaryIndexing.cs
+++ b/src/Perlang.Tests.Integration/IndexOperator/DictionaryIndexing.cs
@@ -51,9 +51,11 @@ public class DictionaryIndexing
 #endif
     }
 
-    [Fact]
+    [SkippableFact]
     public void dictionary_with_string_key_throws_expected_error_when_indexed_by_not_present_key()
     {
+        Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
         string source = @"
             var env = Libc.environ();
             print env[""NOT_PRESENT_DICTIONARY_KEY""];

--- a/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixDecrement.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Perlang.Compiler;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -114,11 +117,19 @@ namespace Perlang.Tests.Integration.Operator
                 s--;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.First();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("can only be used to decrement numbers, not null", exception.Message);
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*cannot decrement value of type*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.First();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("can only be used to decrement numbers, not null", exception.Message);
+            }
         }
 
         [Fact]
@@ -129,11 +140,19 @@ namespace Perlang.Tests.Integration.Operator
                 s--;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.First();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("can only be used to decrement numbers, not AsciiString", exception.Message);
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*cannot decrement value of type*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.First();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("can only be used to decrement numbers, not AsciiString", exception.Message);
+            }
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
+++ b/src/Perlang.Tests.Integration/Operator/PostfixIncrement.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Perlang.Compiler;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -121,11 +124,19 @@ namespace Perlang.Tests.Integration.Operator
                 s++;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.First();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("can only be used to increment numbers, not null", exception.Message);
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*cannot increment value of type*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.First();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("can only be used to increment numbers, not null", exception.Message);
+            }
         }
 
         [Fact]
@@ -136,11 +147,19 @@ namespace Perlang.Tests.Integration.Operator
                 i++;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.First();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("can only be used to increment numbers, not AsciiString", exception.Message);
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*cannot increment value of type*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.First();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("can only be used to increment numbers, not AsciiString", exception.Message);
+            }
         }
     }
 }

--- a/src/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
+++ b/src/Perlang.Tests.Integration/Stdlib/ArgvTests.cs
@@ -20,9 +20,11 @@ namespace Perlang.Tests.Integration.Stdlib
             Assert.IsAssignableFrom<TargetAndMethodContainer>(Eval("ARGV.pop"));
         }
 
-        [Fact]
+        [SkippableFact]
         public void ARGV_pop_with_no_arguments_throws_the_expected_exception()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             var result = EvalWithRuntimeErrorCatch("ARGV.pop()");
             var exception = result.Errors.FirstOrDefault();
 
@@ -52,9 +54,11 @@ namespace Perlang.Tests.Integration.Stdlib
             Assert.Equal("arg2", result);
         }
 
-        [Fact]
+        [SkippableFact]
         public void ARGV_pop_too_many_times_throws_the_expected_exception()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             var result = EvalWithRuntimeErrorCatch("ARGV.pop(); ARGV.pop();", "arg1");
             var exception = result.Errors.FirstOrDefault();
 

--- a/src/Perlang.Tests.Integration/Var/VarTests.cs
+++ b/src/Perlang.Tests.Integration/Var/VarTests.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Linq;
+using FluentAssertions;
+using Perlang.Compiler;
 using Xunit;
 using static Perlang.Tests.Integration.EvalHelper;
 
@@ -176,11 +179,20 @@ namespace Perlang.Tests.Integration.Var
                 print a;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+                // This is horribly hardwired for (a particular version of) CLang, but it will have to do for now.
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*redefinition of 'a'*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.FirstOrDefault();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+            }
         }
 
         [Fact]
@@ -192,11 +204,20 @@ namespace Perlang.Tests.Integration.Var
                 print a;
             ";
 
-            var result = EvalWithRuntimeErrorCatch(source);
-            var exception = result.Errors.FirstOrDefault();
+            if (PerlangMode.ExperimentalCompilation) {
+                Action action = () => EvalReturningOutput(source);
 
-            Assert.Single(result.Errors);
-            Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+                // This is horribly hardwired for (a particular version of) CLang, but it will have to do for now.
+                action.Should().Throw<PerlangCompilerException>()
+                    .WithMessage("*redefinition of 'a'*");
+            }
+            else {
+                var result = EvalWithRuntimeErrorCatch(source);
+                var exception = result.Errors.FirstOrDefault();
+
+                Assert.Single(result.Errors);
+                Assert.Matches("Variable with this name already declared in this scope.", exception.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This is a preparation for removing interpreted mode completely, expected to follow shortly.