### PR TITLE
(compiler) Detect method being redefined

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -17,6 +17,7 @@
 - Add `-c` flag for "compile and assemble only" [[#455][455]]
 - Remove `using namespace` in generated C++ code [[#458][458]]
 - Add partial inline C++ support [[#462][462]]
+- Detect method being redefined [[#464][464]]
 
 ### Changed
 #### Data types
@@ -45,3 +46,4 @@
 [458]: https://github.com/perlang-org/perlang/pull/458
 [459]: https://github.com/perlang-org/perlang/pull/459
 [462]: https://github.com/perlang-org/perlang/pull/462
+[464]: https://github.com/perlang-org/perlang/pull/464

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -1415,6 +1415,11 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 
         currentMethod = new StringBuilder();
 
+        if (methods.ContainsKey(functionStmt.Name.Lexeme))
+        {
+            throw new PerlangCompilerException($"Function '{functionStmt.Name.Lexeme}' is already defined");
+        }
+
         methods[functionStmt.Name.Lexeme] = new Method(
             functionStmt.Name.Lexeme,
             functionStmt.Parameters,


### PR DESCRIPTION
This has been an oversight while working on the experimental Perlang compiler (https://github.com/perlang-org/perlang/issues/406). The bug was discovered when implementing the changes in https://github.com/perlang-org/perlang/pull/463; when we started running one of those tests, no error was emitted even though the code was redefining a top-level function. It turned out that the compiler would silently overwrite a function if you defined it twice.