### PR TITLE
(many) Support string concatenation in compiled mode

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -23,6 +23,7 @@
 - Make compiled mode be the default and drop interpreted mode [[#465][465]]
 - Support ASCII-to-UTF8 string reassignment in compiled mode [[#466][466]]
 - Minor test improvements [[#467][467]]
+- Support string concatenation in compiled mode [[#470][470]]
 
 ### Changed
 #### Data types
@@ -57,3 +58,4 @@
 [465]: https://github.com/perlang-org/perlang/pull/465
 [466]: https://github.com/perlang-org/perlang/pull/466
 [467]: https://github.com/perlang-org/perlang/pull/467
+[470]: https://github.com/perlang-org/perlang/pull/470

--- a/src/Perlang.Common/ITypeReference.cs
+++ b/src/Perlang.Common/ITypeReference.cs
@@ -79,6 +79,7 @@ namespace Perlang
 
                 // Cannot use typeof(AsciiString) since Perlang.Common cannot depend on Perlang.Stdlib
                 var t when t.FullName == "Perlang.Lang.AsciiString" => true,
+                var t when t.FullName == "Perlang.Lang.Utf8String" => true,
                 var t when t.FullName == "Perlang.Lang.String" => true,
 
                 _ => false

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
@@ -95,6 +95,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_integer_and_string_coerces_number_to_string()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             // Some interesting notes on how other languages deal with this:
             //
             // Ruby 2.6: Not supported. TypeError (no implicit conversion of Integer into String)
@@ -119,6 +121,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_bigint_and_string_coerces_number_to_string()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var i = 18446744073709551616;
                 var s = ""xyz"";
@@ -135,6 +139,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_string_and_integer_coerces_number_to_string()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s = ""abc"";
                 var i = 123;
@@ -151,6 +157,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_string_and_bigint_coerces_number_to_string()
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             string source = @"
                 var s = ""abc"";
                 var i = 18446744073709551616;
@@ -168,6 +176,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [ClassData(typeof(TestCultures))]
         async Task addition_of_float_and_string_coerces_number_to_string(CultureInfo cultureInfo)
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             CultureInfo.CurrentCulture = cultureInfo;
 
             string source = @"
@@ -187,6 +197,8 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [ClassData(typeof(TestCultures))]
         async Task addition_of_string_and_float_coerces_number_to_string(CultureInfo cultureInfo)
         {
+            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+
             CultureInfo.CurrentCulture = cultureInfo;
 
             string source = @"

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -10,11 +10,11 @@ public class StringTests
     [Fact]
     public void string_variable_can_be_printed()
     {
-        string source = @"
-                var s: string = ""this is a string"";
+        string source = """
+                var s: string = "this is a string";
 
                 print(s);
-            ";
+                """;
 
         var output = EvalReturningOutputString(source);
 
@@ -25,12 +25,12 @@ public class StringTests
     [Fact]
     public void string_variable_can_be_reassigned()
     {
-        string source = @"
-                var s: string = ""this is a string"";
-                s = ""this is another string"";
+        string source = """
+                var s: string = "this is a string";
+                s = "this is another string";
 
                 print(s);
-            ";
+                """;
 
         var output = EvalReturningOutputString(source);
 
@@ -41,29 +41,29 @@ public class StringTests
     [Fact]
     public void ascii_string_inferred_variable_can_be_reassigned_with_non_ascii_value()
     {
-        string source = @"
-                var s: string = ""this is a string"";
-                s = ""this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ"";
+        string source = """
+                var s: string = "this is a string";
+                s = "this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
 
                 print(s);
-            ";
+                """;
 
         var output = EvalReturningOutputString(source);
 
         output.Should()
-            .Be("this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ");
+            .Be("this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
     }
 
     [Fact]
     public void non_ascii_string_inferred_variable_can_be_reassigned_with_ascii_value()
     {
         // Same as the ASCIIString to UTF8String above, but the other way around
-        string source = @"
-                var s: string = ""this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏ"";
-                s = ""this is a string"";
+        string source = """
+                var s: string = "this is a string with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
+                s = "this is a string";
 
                 print(s);
-            ";
+                """;
 
         var output = EvalReturningOutputString(source);
 
@@ -71,14 +71,185 @@ public class StringTests
             .Be("this is a string");
     }
 
+    [Fact]
+    public void ascii_string_and_ascii_string_variable_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "this is s1";
+                var s2: string = " and this is s2";
+                var s3: string = s1 + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is s1 and this is s2");
+    }
+
+    [Fact]
+    public void ascii_string_and_ascii_string_literal_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "this is s1";
+                var s2: string = "and this is s2";
+                var s3: string = s1 + " " + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is s1 and this is s2");
+    }
+
+    [Fact]
+    public void ascii_string_and_utf8_string_variable_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "s1";
+                var s2: string = " and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
+                var s3: string = s1 + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("s1 and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
+    }
+
+    [Fact]
+    public void ascii_string_and_utf8_string_literal_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "this is s1";
+                var s3: string = s1 + " and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is s1 and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
+    }
+
+    [Fact]
+    public void utf8_string_and_ascii_string_variable_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "this is s1 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
+                var s2: string = " and this is s2";
+                var s3: string = s1 + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is s1 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし and this is s2");
+    }
+
+    [Fact]
+    public void utf8_string_and_ascii_string_literal_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "this is s1 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
+                var s3: string = s1 + " and this is s2";
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("this is s1 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし and this is s2");
+    }
+
+    [SkippableFact]
+    public void ascii_string_can_be_concatenated_with_int_and_ascii_string()
+    {
+        string source = """
+                var s1: string = "temperature is ";
+                var i: int = 85;
+                var s2: string = " degrees fahrenheit";
+                var s3: string = s1 + i + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("temperature is 85 degrees fahrenheit");
+    }
+
+    [SkippableFact]
+    public void ascii_string_can_be_concatenated_with_double_and_string()
+    {
+        string source = """
+                var s1: string = "temperature is ";
+                var i: double = 85.2;
+                var s2: string = " degrees fahrenheit";
+                var s3: string = s1 + i + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("temperature is 85.2 degrees fahrenheit");
+    }
+
+    [SkippableFact]
+    public void utf8_string_can_be_concatenated_with_double_and_ascii_string()
+    {
+        string source = """
+                var s1: string = "Den årliga medeltemperaturen i Vasa är ";
+                var d: double = 3.4;
+                var s2: string = " grader Celsius";
+                var s3: string = s1 + d + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("Den årliga medeltemperaturen i Vasa är 3.4 grader Celsius");
+    }
+
+    [SkippableFact]
+    public void utf8_string_can_be_concatenated_with_int()
+    {
+        string source = """
+                var s1: string = "Årets varmaste temperatur (Celsius): ";
+                var i: int = 32;
+                var s2: string = s1 + i;
+
+                print(s2);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("Årets varmaste temperatur (Celsius): 32");
+    }
+
     [SkippableFact]
     public void ascii_string_variable_has_expected_type()
     {
-        string source = @"
-                var s: string = ""this is an ASCII string"";
+        string source = """
+                var s: string = "this is an ASCII string";
 
                 print(s.get_type());
-            ";
+                """;
 
         var output = EvalReturningOutputString(source);
 

--- a/src/stdlib/src/ascii_string.cc
+++ b/src/stdlib/src/ascii_string.cc
@@ -13,25 +13,44 @@ namespace perlang
             throw std::invalid_argument("string argument cannot be null");
         }
 
-        // TODO: Mark this string as "static" in some way, to ensure the destructor doesn't try to delete `bytes_`.
-        auto result = ASCIIString();
-        result.bytes_ = s;
-        result.length_ = strlen(s);
+        auto result = new ASCIIString(s, strlen(s), false);
 
-        return std::make_shared<ASCIIString>(result);
+        return std::shared_ptr<ASCIIString>(result);
     }
 
-    ASCIIString::ASCIIString()
+    std::shared_ptr<const ASCIIString> ASCIIString::from_owned_string(const char* s, size_t length)
     {
-        // Set these to ensure we have predictable defaults. Note that this constructor must ONLY be used from factory
-        // methods, which set these fields to their appropriate values.
-        bytes_ = nullptr;
-        length_ = -1;
+        if (s == nullptr) {
+            throw std::invalid_argument("string argument cannot be null");
+        }
+
+        auto result = new ASCIIString(s, length, true);
+
+        return std::shared_ptr<ASCIIString>(result);
+    }
+
+    ASCIIString::ASCIIString(const char* string, size_t length, bool owned)
+    {
+        bytes_ = string;
+        length_ = length;
+        owned_ = owned;
+    }
+
+    ASCIIString::~ASCIIString()
+    {
+        if (owned_) {
+            delete[] bytes_;
+        }
     }
 
     const char* ASCIIString::bytes() const
     {
         return bytes_;
+    }
+
+    size_t ASCIIString::length() const
+    {
+        return length_;
     }
 
     bool ASCIIString::operator==(const ASCIIString& rhs) const
@@ -54,6 +73,18 @@ namespace perlang
         else {
             throw std::out_of_range("Index " + std::to_string(index) + " is out-of-bounds for a string with length " + std::to_string(this->length_));
         }
+    }
+
+    std::shared_ptr<const String> ASCIIString::operator+(const String& rhs) const
+    {
+        size_t length = this->length_ + rhs.length();
+        char *bytes = new char[length + 1];
+
+        memcpy((void*)bytes, this->bytes_, this->length_);
+        memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
+        bytes[length] = '\0';
+
+        return from_owned_string(bytes, length);
     }
 
     char ASCIIString::char_at(int index) const

--- a/src/stdlib/src/perlang_string.h
+++ b/src/stdlib/src/perlang_string.h
@@ -10,5 +10,13 @@ namespace perlang
         // the String throughout the code and only call this when you really must.
         [[nodiscard]]
         virtual const char* bytes() const = 0;
+
+        // The length of the string in bytes, excluding the terminating `NUL` character.
+        [[nodiscard]]
+        virtual size_t length() const = 0;
+
+        // Concatenate this string with another string. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        virtual std::shared_ptr<const String> operator+(const String& rhs) const = 0;
     };
 }

--- a/src/stdlib/src/utf8_string.h
+++ b/src/stdlib/src/utf8_string.h
@@ -20,10 +20,27 @@ namespace perlang
         [[nodiscard]]
         static std::shared_ptr<const UTF8String> from_static_string(const char* s);
 
+        // Creates a new ASCIIString from an "owned string", like a string that has been allocated on the heap. The
+        // ownership of the memory is transferred to the ASCIIString, which is then responsible for deallocating the
+        // memory when it is no longer needed (i.e. when no references to it remains).
+        static std::shared_ptr<const UTF8String> from_owned_string(const char* s, size_t length);
+
+        // Private constructor for creating a new UTF8String from a C-style string. The `owned` parameter indicates
+        // whether the UTF8String should take ownership of the memory it points to, and thus be responsible for
+        // deallocating it when it is no longer needed.
+        UTF8String(const char* string, size_t length, bool owned);
+
+     public:
+        virtual ~UTF8String();
+
         // Returns the backing byte array for this UTF8String. This method is generally to be avoided; it is safer to
         // use the UTF8String throughout the code and only call this when you really must.
         [[nodiscard]]
         const char* bytes() const override;
+
+        // The length of the string in bytes, excluding the terminating `NUL` character.
+        [[nodiscard]]
+        size_t length() const override;
 
         // Compares the equality of two `UTF8String`s, returning `true` if they point to the same backing byte array
         // and have the same length. Note that this method does *not* compare referential equality; two different
@@ -36,12 +53,9 @@ namespace perlang
         // documentation for more semantic details about the implementation.
         bool operator!=(const UTF8String& rhs) const;
 
-     private:
-        // Private constructor for creating a `null` string, not yet initialized with any sensible content.
-        UTF8String();
-
-     public:
-        virtual ~UTF8String();
+        // Concatenate this string with another string. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        std::shared_ptr<const String> operator+(const String& rhs) const override;
 
      private:
         // The backing byte array for this string. This is to be considered immutable and MUST NOT be modified at any
@@ -51,5 +65,10 @@ namespace perlang
 
         // The length of the string in bytes, excluding the terminating `NUL` character.
         size_t length_;
+
+        // A flag indicating whether this string owns the memory it points to. If this is true, the string is
+        // responsible for deallocating the memory when it is no longer needed. If false, the string is borrowing the
+        // memory from somewhere else, and should not deallocate it.
+        bool owned_;
     };
 }


### PR DESCRIPTION
Because we now have an idea around how to allocate Perlang strings dynamically (#453), we can also implement the `+` operator now which fixes one of the remaining "not supported in compiled mode" features.