### PR TITLE
(many) Support string+integer concatenation in compiled mode

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -24,6 +24,7 @@
 - Support ASCII-to-UTF8 string reassignment in compiled mode [[#466][466]]
 - Minor test improvements [[#467][467]]
 - Support string concatenation in compiled mode [[#470][470]]
+- Support string+integer concatenation in compiled mode [[#472][472]]
 
 ### Changed
 #### Data types
@@ -59,3 +60,4 @@
 [466]: https://github.com/perlang-org/perlang/pull/466
 [467]: https://github.com/perlang-org/perlang/pull/467
 [470]: https://github.com/perlang-org/perlang/pull/470
+[472]: https://github.com/perlang-org/perlang/pull/472

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -924,15 +924,18 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
                 else if (expr.Left.TypeReference.IsStringType() && expr.Right.TypeReference.IsStringType())
                 {
                     // The dereference operator (*) must be used to dereference the std::shared_ptr instances
+                    // Parentheses required to workaround "indirection requires pointer operand" errors in the C++ compilation
                     currentMethod.Append($"(*{leftCast}{expr.Left.Accept(this)} + *{rightCast}{expr.Right.Accept(this)})");
-                }
-                else if (expr.Left.TypeReference.IsValidNumberType && expr.Right.TypeReference.IsStringType())
-                {
-                    throw new NotImplementedInCompiledModeException($"Concatenation between {expr.Left.TypeReference.ClrType.ToTypeKeyword()} and {expr.Right.TypeReference.ClrType.ToTypeKeyword()} is not yet implemented");
                 }
                 else if (expr.Left.TypeReference.IsStringType() && expr.Right.TypeReference.IsValidNumberType)
                 {
-                    throw new NotImplementedInCompiledModeException($"Concatenation between {expr.Left.TypeReference.ClrType.ToTypeKeyword()} and {expr.Right.TypeReference.ClrType.ToTypeKeyword()} is not yet implemented");
+                    // The dereference operator (*) must be used to dereference the std::shared_ptr instance
+                    currentMethod.Append($"(*{leftCast}{expr.Left.Accept(this)} + {rightCast}{expr.Right.Accept(this)})");
+                }
+                else if (expr.Left.TypeReference.IsValidNumberType && expr.Right.TypeReference.IsStringType())
+                {
+                    // The dereference operator (*) must be used to dereference the std::shared_ptr instance
+                    currentMethod.Append($"({leftCast}{expr.Left.Accept(this)} + *{rightCast}{expr.Right.Accept(this)})");
                 }
                 else
                 {

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -132,6 +132,36 @@ namespace Perlang.Interpreter.Typing
                         expr.TypeReference.ClrType = typeof(Lang.String);
                     }
                     else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(AsciiString) &&
+                              rightTypeReference.ClrType == typeof(int))) {
+                        // "string" + 42
+                        expr.TypeReference.ClrType = typeof(AsciiString);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(Utf8String) &&
+                              rightTypeReference.ClrType == typeof(int))) {
+                        // "åäö string" + 42
+                        expr.TypeReference.ClrType = typeof(Utf8String);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(int) &&
+                              rightTypeReference.ClrType == typeof(Lang.String))) {
+                        // 42 + "string"
+                        expr.TypeReference.ClrType = typeof(Lang.String);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(int) &&
+                              rightTypeReference.ClrType == typeof(AsciiString))) {
+                        // 42 + "string" + 42
+                        expr.TypeReference.ClrType = typeof(AsciiString);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(int) &&
+                              rightTypeReference.ClrType == typeof(Utf8String))) {
+                        // 42 + "åäö string"
+                        expr.TypeReference.ClrType = typeof(Utf8String);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
                              (leftTypeReference.ClrType == typeof(Lang.String) &&
                               rightTypeReference.ClrType == typeof(double))) {
                         // "string" + 123.45

--- a/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
+++ b/src/Perlang.Tests.Integration/Operator/Binary/AdditionTests.cs
@@ -76,7 +76,10 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Message.Should().Match(expectedResult);
         }
 
-        [SkippableFact]
+        // TODO: There's a clear overlap between these tests and the ones in StringTests.cs. We could consider
+        // TODO: removing some of them at some point. OTOH, the tests in StringTests test more complex
+
+        [Fact]
         void addition_of_strings_performs_concatenation()
         {
             string source = @"
@@ -92,11 +95,9 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("foobar");
         }
 
-        [SkippableFact]
+        [Fact]
         void addition_of_integer_and_string_coerces_number_to_string()
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
-
             // Some interesting notes on how other languages deal with this:
             //
             // Ruby 2.6: Not supported. TypeError (no implicit conversion of Integer into String)
@@ -121,7 +122,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_bigint_and_string_coerces_number_to_string()
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+            Skip.If(PerlangMode.ExperimentalCompilation, "bigint+string is not yet supported in compiled mode");
 
             string source = @"
                 var i = 18446744073709551616;
@@ -136,11 +137,9 @@ namespace Perlang.Tests.Integration.Operator.Binary
                 .Be("18446744073709551616xyz");
         }
 
-        [SkippableFact]
+        [Fact]
         void addition_of_string_and_integer_coerces_number_to_string()
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
-
             string source = @"
                 var s = ""abc"";
                 var i = 123;
@@ -157,7 +156,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [SkippableFact]
         void addition_of_string_and_bigint_coerces_number_to_string()
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+            Skip.If(PerlangMode.ExperimentalCompilation, "string+bigint is not yet supported in compiled mode");
 
             string source = @"
                 var s = ""abc"";
@@ -176,7 +175,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [ClassData(typeof(TestCultures))]
         async Task addition_of_float_and_string_coerces_number_to_string(CultureInfo cultureInfo)
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+            Skip.If(PerlangMode.ExperimentalCompilation, "float+string is not yet supported in compiled mode");
 
             CultureInfo.CurrentCulture = cultureInfo;
 
@@ -197,7 +196,7 @@ namespace Perlang.Tests.Integration.Operator.Binary
         [ClassData(typeof(TestCultures))]
         async Task addition_of_string_and_float_coerces_number_to_string(CultureInfo cultureInfo)
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "Not supported in compiled mode");
+            Skip.If(PerlangMode.ExperimentalCompilation, "string+float is not yet supported in compiled mode");
 
             CultureInfo.CurrentCulture = cultureInfo;
 

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -171,7 +171,7 @@ public class StringTests
             .Be("this is s1 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし and this is s2");
     }
 
-    [SkippableFact]
+    [Fact]
     public void ascii_string_can_be_concatenated_with_int_and_ascii_string()
     {
         string source = """
@@ -192,6 +192,8 @@ public class StringTests
     [SkippableFact]
     public void ascii_string_can_be_concatenated_with_double_and_string()
     {
+        Skip.If(PerlangMode.ExperimentalCompilation, "string+double is not yet supported in compiled mode");
+
         string source = """
                 var s1: string = "temperature is ";
                 var i: double = 85.2;
@@ -210,6 +212,8 @@ public class StringTests
     [SkippableFact]
     public void utf8_string_can_be_concatenated_with_double_and_ascii_string()
     {
+        Skip.If(PerlangMode.ExperimentalCompilation, "string+double is not yet supported in compiled mode");
+
         string source = """
                 var s1: string = "Den årliga medeltemperaturen i Vasa är ";
                 var d: double = 3.4;
@@ -225,7 +229,7 @@ public class StringTests
             .Be("Den årliga medeltemperaturen i Vasa är 3.4 grader Celsius");
     }
 
-    [SkippableFact]
+    [Fact]
     public void utf8_string_can_be_concatenated_with_int()
     {
         string source = """

--- a/src/stdlib/src/ascii_string.cc
+++ b/src/stdlib/src/ascii_string.cc
@@ -87,11 +87,38 @@ namespace perlang
         return from_owned_string(bytes, length);
     }
 
+    std::shared_ptr<const String> ASCIIString::operator+(long rhs) const
+    {
+        std::string str = std::to_string(rhs);
+
+        size_t length = str.length() + this->length_;
+        char *bytes = new char[length + 1];
+
+        memcpy((void*)bytes, this->bytes_, this->length_);
+        memcpy((void*)(bytes + this->length_), str.c_str(), str.length());
+        bytes[length] = '\0';
+
+        return from_owned_string(bytes, length);
+    }
+
     char ASCIIString::char_at(int index) const
     {
         // The reason this method exists is that the construct below would be slightly more awkward to generate from
         // PerlangCompiler.cs. It's easier to just add an extra char_at() method call when it visits the Expr.Index
         // expression.
         return (*this)[index];
+    }
+
+    std::shared_ptr<const ASCIIString> operator+(const long lhs, const ASCIIString& rhs)
+    {
+        std::string str = std::to_string(lhs);
+        size_t length = str.length() + rhs.length();
+        char *bytes = new char[length + 1];
+
+        memcpy((void*)bytes, str.c_str(), str.length());
+        memcpy((void*)(bytes + str.length()), rhs.bytes(), rhs.length());
+        bytes[length] = '\0';
+
+        return ASCIIString::from_owned_string(bytes, length);
     }
 }

--- a/src/stdlib/src/ascii_string.h
+++ b/src/stdlib/src/ascii_string.h
@@ -24,6 +24,7 @@ namespace perlang
         // Creates a new ASCIIString from an "owned string", like a string that has been allocated on the heap. The
         // ownership of the memory is transferred to the ASCIIString, which is then responsible for deallocating the
         // memory when it is no longer needed (i.e. when no references to it remains).
+        [[nodiscard]]
         static std::shared_ptr<const ASCIIString> from_owned_string(const char* s, size_t length);
 
      private:
@@ -63,6 +64,10 @@ namespace perlang
         [[nodiscard]]
         std::shared_ptr<const String> operator+(const String& rhs) const override;
 
+        // Concatenates this string with an int or long. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        std::shared_ptr<const String> operator+(long rhs) const override;
+
         // Alias for [], which is easier to use from Perlang-generated C++ code in a pointer context.
         [[nodiscard]]
         char char_at(int index) const;
@@ -81,4 +86,9 @@ namespace perlang
         // memory from somewhere else, and should not deallocate it.
         bool owned_;
     };
+
+    // Concatenate an int/long+ASCIIString. The memory for the new string is allocated from the heap. This is a free
+    // function, since the left-hand side is not an ASCIIString.
+    [[nodiscard]]
+    std::shared_ptr<const ASCIIString> operator+(long lhs, const ASCIIString& rhs);
 }

--- a/src/stdlib/src/perlang_string.h
+++ b/src/stdlib/src/perlang_string.h
@@ -18,5 +18,9 @@ namespace perlang
         // Concatenate this string with another string. The memory for the new string is allocated from the heap.
         [[nodiscard]]
         virtual std::shared_ptr<const String> operator+(const String& rhs) const = 0;
+
+        // Concatenates this string with an int or long. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        virtual std::shared_ptr<const String> operator+(long rhs) const = 0;
     };
 }

--- a/src/stdlib/src/utf8_string.cc
+++ b/src/stdlib/src/utf8_string.cc
@@ -66,12 +66,39 @@ namespace perlang
     std::shared_ptr<const String> UTF8String::operator+(const String& rhs) const
     {
         size_t length = this->length_ + rhs.length();
-        char *bytes = new char[length + 1];
+        char *bytes = new char[length_ + 1];
 
         memcpy((void*)bytes, this->bytes_, this->length_);
         memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
         bytes[length] = '\0';
 
         return from_owned_string(bytes, length);
+    }
+
+    std::shared_ptr<const String> UTF8String::operator+(long rhs) const
+    {
+        std::string str = std::to_string(rhs);
+
+        size_t length = str.length() + this->length_;
+        char *bytes = new char[length + 1];
+
+        memcpy((void*)bytes, this->bytes_, this->length_);
+        memcpy((void*)(bytes + this->length_), str.c_str(), str.length());
+        bytes[length] = '\0';
+
+        return from_owned_string(bytes, length);
+    }
+
+    std::shared_ptr<const UTF8String> operator+(const long lhs, const UTF8String& rhs)
+    {
+        std::string str = std::to_string(lhs);
+        size_t length = str.length() + rhs.length();
+        char *bytes = new char[length + 1];
+
+        memcpy((void*)bytes, str.c_str(), str.length());
+        memcpy((void*)(bytes + str.length()), rhs.bytes(), rhs.length());
+        bytes[length] = '\0';
+
+        return UTF8String::from_owned_string(bytes, length);
     }
 }

--- a/src/stdlib/src/utf8_string.h
+++ b/src/stdlib/src/utf8_string.h
@@ -23,6 +23,7 @@ namespace perlang
         // Creates a new ASCIIString from an "owned string", like a string that has been allocated on the heap. The
         // ownership of the memory is transferred to the ASCIIString, which is then responsible for deallocating the
         // memory when it is no longer needed (i.e. when no references to it remains).
+        [[nodiscard]]
         static std::shared_ptr<const UTF8String> from_owned_string(const char* s, size_t length);
 
         // Private constructor for creating a new UTF8String from a C-style string. The `owned` parameter indicates
@@ -57,6 +58,10 @@ namespace perlang
         [[nodiscard]]
         std::shared_ptr<const String> operator+(const String& rhs) const override;
 
+        // Concatenates this string with an int or long. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        std::shared_ptr<const String> operator+(long rhs) const override;
+
      private:
         // The backing byte array for this string. This is to be considered immutable and MUST NOT be modified at any
         // point. There might be multiple UTF8String objects pointing to the same `bytes_`, so modifying one of them
@@ -71,4 +76,9 @@ namespace perlang
         // memory from somewhere else, and should not deallocate it.
         bool owned_;
     };
+
+    // Concatenate an int/long+UTF8String. The memory for the new string is allocated from the heap. This is a free
+    // function, since the left-hand side is not a UTF8String.
+    [[nodiscard]]
+    std::shared_ptr<const UTF8String> operator+(long lhs, const UTF8String& rhs);
 }


### PR DESCRIPTION
`int` and `long` are supported on the left-hand and right-hand sides. Other integer types (unsigned integers, bigint) could be added similarly as needed.