### PR TITLE
(many) Fix `ASCIIString+ASCIIString` concatenation to return `ASCIIString`

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -22,6 +22,7 @@
 - Support string concatenation in compiled mode [[#470][470]]
 - Support string+integer concatenation in compiled mode [[#472][472]]
 - Support more types in string+int and int+string concatenation [[#473][473]]
+- Fix ASCIIString+ASCIIString concatenation to return ASCIIString [[#474][474]]
 
 ### Changed
 #### Data types
@@ -59,3 +60,4 @@
 [470]: https://github.com/perlang-org/perlang/pull/470
 [472]: https://github.com/perlang-org/perlang/pull/472
 [473]: https://github.com/perlang-org/perlang/pull/473
+[474]: https://github.com/perlang-org/perlang/pull/474

--- a/src/Perlang.Common/TypeReference.cs
+++ b/src/Perlang.Common/TypeReference.cs
@@ -85,9 +85,9 @@ namespace Perlang
 
                 // These are wrapped in std::shared_ptr<>, as a simple way to deal with ownership for now. For the
                 // long-term solution, see https://github.com/perlang-org/perlang/issues/378.
-                // TODO: Handle UTF-8 strings here too
                 var t when t.FullName == "Perlang.Lang.AsciiString" => "std::shared_ptr<const perlang::ASCIIString>",
                 var t when t.FullName == "Perlang.Lang.String" => "std::shared_ptr<const perlang::String>",
+                var t when t.FullName == "Perlang.Lang.Utf8String" => "std::shared_ptr<const perlang::UTF8String>",
 
                 _ => throw new NotImplementedInCompiledModeException($"Internal error: C++ type for {clrType} not defined")
             };

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -171,7 +171,7 @@ namespace Perlang.Interpreter.Typing
                              (leftTypeReference.ClrType == typeof(AsciiString) &&
                               rightTypeReference.ClrType == typeof(AsciiString))) {
                         // "string" + "string"
-                        expr.TypeReference.ClrType = typeof(Utf8String);
+                        expr.TypeReference.ClrType = typeof(AsciiString);
                     }
                     else if (expr.Operator.Type == TokenType.PLUS &&
                              (leftTypeReference.ClrType == typeof(Utf8String) &&

--- a/src/Perlang.Tests.Integration/Var/VarTests.cs
+++ b/src/Perlang.Tests.Integration/Var/VarTests.cs
@@ -103,11 +103,9 @@ namespace Perlang.Tests.Integration.Var
             }, output);
         }
 
-        [SkippableFact]
+        [Fact]
         public void in_middle_of_block()
         {
-            Skip.If(PerlangMode.ExperimentalCompilation, "C++ type for Perlang.Lang.Utf8String not defined, and compilation errors if we fix that");
-
             string source = @"
                 {
                     var a = ""a"";

--- a/src/stdlib/src/ascii_string.cc
+++ b/src/stdlib/src/ascii_string.cc
@@ -80,6 +80,21 @@ namespace perlang
         size_t length = this->length_ + rhs.length();
         char *bytes = new char[length + 1];
 
+        // TODO: This won't work once we bring in UTF16String into the picture.
+        memcpy((void*)bytes, this->bytes_, this->length_);
+        memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
+        bytes[length] = '\0';
+
+        return from_owned_string(bytes, length);
+    }
+
+    std::shared_ptr<const ASCIIString> ASCIIString::operator+(const ASCIIString& rhs) const
+    {
+        // The alternative to copy-paste here would be to use a bunch of casting.
+
+        size_t length = this->length_ + rhs.length();
+        char *bytes = new char[length + 1];
+
         memcpy((void*)bytes, this->bytes_, this->length_);
         memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
         bytes[length] = '\0';

--- a/src/stdlib/src/ascii_string.h
+++ b/src/stdlib/src/ascii_string.h
@@ -64,6 +64,10 @@ namespace perlang
         [[nodiscard]]
         std::shared_ptr<const String> operator+(const String& rhs) const override;
 
+        // Concatenates this string with another string. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        std::shared_ptr<const ASCIIString> operator+(const ASCIIString& rhs) const;
+
         // Concatenates this string with an int32. The memory for the new string is allocated from the heap.
         [[nodiscard]]
         inline std::shared_ptr<const String> operator+(int32_t rhs) const override

--- a/src/stdlib/src/utf8_string.cc
+++ b/src/stdlib/src/utf8_string.cc
@@ -68,6 +68,19 @@ namespace perlang
         size_t length = this->length_ + rhs.length();
         char *bytes = new char[length_ + 1];
 
+        // TODO: This won't work once we bring in UTF16String into the picture.
+        memcpy((void*)bytes, this->bytes_, this->length_);
+        memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
+        bytes[length] = '\0';
+
+        return from_owned_string(bytes, length);
+    }
+
+    std::shared_ptr<const UTF8String> UTF8String::operator+(const UTF8String& rhs) const
+    {
+        size_t length = this->length_ + rhs.length();
+        char *bytes = new char[length_ + 1];
+
         memcpy((void*)bytes, this->bytes_, this->length_);
         memcpy((void*)(bytes + this->length_), rhs.bytes(), rhs.length());
         bytes[length] = '\0';

--- a/src/stdlib/src/utf8_string.h
+++ b/src/stdlib/src/utf8_string.h
@@ -58,6 +58,10 @@ namespace perlang
         [[nodiscard]]
         std::shared_ptr<const String> operator+(const String& rhs) const override;
 
+        // Concatenates this string with another string. The memory for the new string is allocated from the heap.
+        [[nodiscard]]
+        std::shared_ptr<const UTF8String> operator+(const UTF8String& rhs) const;
+
         // Concatenates this string with an int or long. The memory for the new string is allocated from the heap.
         [[nodiscard]]
         std::shared_ptr<const String> operator+(int64_t rhs) const override;


### PR DESCRIPTION
The problem with letting it return `String` (as was the case before this fix) is that the result couldn't be assigned to an `ASCIIString` variable, but the `TypeResolver` would still believe the result of such an operation would be a pointer to `ASCIIString`. The end result would be that we would emit uncompilable C++ code.