### PR TITLE
(test) Enable string bounds checking test

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -25,6 +25,7 @@
 - Fix ASCIIString+ASCIIString concatenation to return ASCIIString [[#474][474]]
 - Support string+bigint and bigint+string concatenation [[#475][475]]
 - Support string+float/double and float/double+string concatenation [[#477][477]]
+- Enable string bounds checking test [[#478][478]]
 
 ### Changed
 #### Data types
@@ -67,3 +68,4 @@
 [475]: https://github.com/perlang-org/perlang/pull/475
 [476]: https://github.com/perlang-org/perlang/pull/476
 [477]: https://github.com/perlang-org/perlang/pull/477
+[478]: https://github.com/perlang-org/perlang/pull/478

--- a/src/Perlang.Common/RuntimeError.cs
+++ b/src/Perlang.Common/RuntimeError.cs
@@ -15,11 +15,5 @@ namespace Perlang
         {
             Token = token;
         }
-
-        public RuntimeError(Token? token, string message, Exception innerException)
-            : base(message, innerException)
-        {
-            Token = token;
-        }
     }
 }

--- a/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
+++ b/src/Perlang.Tests.Integration/IndexOperator/StringIndexing.cs
@@ -7,44 +7,61 @@ namespace Perlang.Tests.Integration.IndexOperator;
 public class StringIndexing
 {
     [Fact]
-    public void AsciiString_can_be_indexed_by_integer()
+    public void ASCIIString_can_be_indexed_by_integer()
     {
-        string source = @"
-            print ""foobar""[0];
-        ";
+        string source = """
+            print "foobar"[0];
+            """;
 
         var output = EvalReturningOutputString(source);
 
         output.Should().Be("f");
     }
 
-    [SkippableFact]
-    public void AsciiString_indexed_outside_string_returns_expected_error()
+    [Fact]
+    public void ASCIIString_indexed_outside_string_returns_expected_error()
     {
-        // -Warray-bounds is not enough to catch this, since the Perlang code is approximately
-        // perlang::ASCIIString::from_static_string("foobar")->char_at(10). We need to implement this on the Perlang side.
-        Skip.If(PerlangMode.ExperimentalCompilation, "String bounds checking is not yet supported in compiled mode");
-
-        string source = @"
-            print ""foobar""[10];
-        ";
+        string source = """
+            print "foobar"[10];
+            """;
 
         var result = EvalWithRuntimeErrorCatch(source);
 
         result.Errors.Should()
             .ContainSingle()
             .Which
-            .Message.Should().Contain("Index was outside the bounds of the array");
+            .Message.Should().Contain("exited with exit code 134");
+
+        result.OutputAsString.Should()
+            .Contain("Index 10 is out-of-bounds for a string with length 6");
+    }
+
+    [Fact(Skip = "Not yet supported for UTF8String")]
+    public void UTF8String_indexed_outside_string_returns_expected_error()
+    {
+        string source = """
+            print "åäöÅÄÖéèüÜÿŸïÏすし"[10];
+            """;
+
+        var result = EvalWithRuntimeErrorCatch(source);
+
+        result.Errors.Should()
+            .ContainSingle()
+            .Which
+            .Message.Should().Contain("exited with exit code 134");
+
+        result.OutputAsString.Should()
+            .Contain("Index 10 is out-of-bounds for a string with length 6");
     }
 
     [SkippableFact]
-    public void AsciiString_indexed_by_integer_returns_char_object()
+    public void ASCIIString_indexed_by_integer_returns_char_object()
     {
         Skip.If(PerlangMode.ExperimentalCompilation, "get_type() is not yet supported in compiled mode");
 
-        string source = @"
-            print ""foobar""[0].get_type();
-        ";
+        string source = """
+            print "foobar"[0].get_type();
+            """;
 
         var output = EvalReturningOutputString(source);
 
@@ -54,12 +71,12 @@ public class StringIndexing
     }
 
     [Fact]
-    public void AsciiString_indexed_by_integer_assigned_to_other_type_variable_throws_expected_error()
+    public void ASCIIString_indexed_by_integer_assigned_to_other_type_variable_throws_expected_error()
     {
-        // This is expected to fail, since an individual element of an AsciiString is `byte`
-        string source = @"
-            var s: string = ""foobar""[0];
-        ";
+        // This is expected to fail, since an individual element of an AsciiString is `char`
+        string source = """
+            var s: string = "foobar"[0];
+            """;
 
         var result = EvalWithValidationErrorCatch(source);
 
@@ -69,11 +86,11 @@ public class StringIndexing
     }
 
     [Fact]
-    public void string_indexed_by_string_throws_expected_error()
+    public void ASCIIString_indexed_by_string_throws_expected_error()
     {
-        string source = @"
-            print ""foobar""[""baz""];
-        ";
+        string source = """
+            print "foobar"["baz"];
+            """;
 
         var result = EvalWithValidationErrorCatch(source);
 


### PR DESCRIPTION
The code already seemeed to be there since
https://github.com/perlang-org/perlang/pull/451, so let's reap the full benefit of it now and adjust the code accordingly. Also added a similar `UTF8String` test for completeness.