### PR TITLE
(compiler) Support `ASCIIString+string` and `UTF8String+string` concatenation

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -21,11 +21,12 @@
 - Minor test improvements [[#467][467]]
 - Support string concatenation in compiled mode [[#470][470]]
 - Support string+integer concatenation in compiled mode [[#472][472]]
-- Support more types in string+int and int+string concatenation [[#473][473]]
-- Fix ASCIIString+ASCIIString concatenation to return ASCIIString [[#474][474]]
-- Support string+bigint and bigint+string concatenation [[#475][475]]
-- Support string+float/double and float/double+string concatenation [[#477][477]]
+- Support more types in `string+int` and `int+string` concatenation [[#473][473]]
+- Fix `ASCIIString`+`ASCIIString` concatenation to return `ASCIIString` [[#474][474]]
+- Support `string+bigint` and `bigint+string` concatenation [[#475][475]]
+- Support `string`+float/double and float/double+`string` concatenation [[#477][477]]
 - Enable string bounds checking test [[#478][478]]
+- Support `ASCIIString+string` and `UTF8String+string` concatenation [[#480][480]]
 
 ### Changed
 #### Data types
@@ -71,3 +72,4 @@
 [477]: https://github.com/perlang-org/perlang/pull/477
 [478]: https://github.com/perlang-org/perlang/pull/478
 [479]: https://github.com/perlang-org/perlang/pull/479
+[480]: https://github.com/perlang-org/perlang/pull/480

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -126,6 +126,18 @@ namespace Perlang.Interpreter.Typing
                         expr.TypeReference.ClrType = typeof(Lang.String);
                     }
                     else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(AsciiString) &&
+                              rightTypeReference.ClrType == typeof(Lang.String))) {
+                        // "string" literal + string_variable
+                        expr.TypeReference.ClrType = typeof(Lang.String);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
+                             (leftTypeReference.ClrType == typeof(Utf8String) &&
+                              rightTypeReference.ClrType == typeof(Lang.String))) {
+                        // "åäö string" literal + string_variable
+                        expr.TypeReference.ClrType = typeof(Lang.String);
+                    }
+                    else if (expr.Operator.Type == TokenType.PLUS &&
                              (leftTypeReference.ClrType == typeof(Lang.String) &&
                               new[] { typeof(int), typeof(long), typeof(uint), typeof(ulong), typeof(BigInteger), typeof(float), typeof(double) }.Contains(rightTypeReference.ClrType))) {
                         // "string" + 42

--- a/src/Perlang.Tests.Integration/Typing/StringTests.cs
+++ b/src/Perlang.Tests.Integration/Typing/StringTests.cs
@@ -109,7 +109,7 @@ public class StringTests
     public void ascii_string_and_utf8_string_variable_can_be_concatenated()
     {
         string source = """
-                var s1: string = "s1";
+                var s1: string = "this is s1";
                 var s2: string = " and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし";
                 var s3: string = s1 + s2;
 
@@ -119,7 +119,7 @@ public class StringTests
         var output = EvalReturningOutputString(source);
 
         output.Should()
-            .Be("s1 and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
+            .Be("this is s1 and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
     }
 
     [Fact]
@@ -136,6 +136,70 @@ public class StringTests
 
         output.Should()
             .Be("this is s1 and this is s2 with non-ASCII characters: åäöÅÄÖéèüÜÿŸïÏすし");
+    }
+
+    [Fact]
+    public void ascii_string_literal_and_string_variable_can_be_concatenated()
+    {
+        string source = """
+                var s2: string = "s2";
+                var s3 = "s1 and " + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("s1 and s2");
+    }
+
+    [Fact]
+    public void string_variable_and_ascii_string_literal_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "s1";
+                var s3 = s1 + " and s2";
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("s1 and s2");
+    }
+
+    [Fact]
+    public void utf8_string_literal_and_string_variable_can_be_concatenated()
+    {
+        string source = """
+                var s2: string = "ASCII string";
+                var s3 = "åäöÅÄÖéèüÜÿŸïÏすし and " + s2;
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("åäöÅÄÖéèüÜÿŸïÏすし and ASCII string");
+    }
+
+    [Fact]
+    public void string_variable_and_utf8_string_literal_can_be_concatenated()
+    {
+        string source = """
+                var s1: string = "ASCII string";
+                var s3 = s1 + " and åäöÅÄÖéèüÜÿŸïÏすし";
+
+                print(s3);
+                """;
+
+        var output = EvalReturningOutputString(source);
+
+        output.Should()
+            .Be("ASCII string and åäöÅÄÖéèüÜÿŸïÏすし");
     }
 
     [Fact]


### PR DESCRIPTION
This was already supported in the C++-based stdlib; it was just the compiler that didn't allow these type combinations through.