### PR TITLE
(parser) Fix bug in C++ preprocessor parsing

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -27,6 +27,7 @@
 - Support `string`+float/double and float/double+`string` concatenation [[#477][477]]
 - Enable string bounds checking test [[#478][478]]
 - Support `ASCIIString+string` and `UTF8String+string` concatenation [[#480][480]]
+- Fix bug in C++ preprocessor parsing [[#481][481]]
 
 ### Changed
 #### Data types
@@ -73,3 +74,4 @@
 [478]: https://github.com/perlang-org/perlang/pull/478
 [479]: https://github.com/perlang-org/perlang/pull/479
 [480]: https://github.com/perlang-org/perlang/pull/480
+[481]: https://github.com/perlang-org/perlang/pull/481

--- a/src/Perlang.Parser/Scanner.cs
+++ b/src/Perlang.Parser/Scanner.cs
@@ -524,7 +524,7 @@ namespace Perlang.Parser
             switch (startDirective) {
                 case "c++-prototypes":
                 {
-                    while (Peek() != '#' && PeekNext() != '/' && !IsAtEnd()) {
+                    while (!(Peek() == '#' && PeekNext() == '/') && !IsAtEnd()) {
                         Advance();
                     }
 
@@ -557,7 +557,7 @@ namespace Perlang.Parser
 
                 case "c++-methods":
                 {
-                    while (Peek() != '#' && PeekNext() != '/' && !IsAtEnd()) {
+                    while (!(Peek() == '#' && PeekNext() == '/') && !IsAtEnd()) {
                         Advance();
                     }
 

--- a/src/Perlang.Tests.Integration/InlineCpp/InlineCppTests.cs
+++ b/src/Perlang.Tests.Integration/InlineCpp/InlineCppTests.cs
@@ -53,7 +53,7 @@ namespace Perlang.Tests.Integration.InlineCpp
             // TODO: `extern fun native_method(): void;`. This is probably the "easiest" way out of this. As a workaround
             // TODO: for now, we could skip this test and add another test method which just has a C++ `main` function
             // TODO: which prints a message as step 1. We can then fix `extern` in a separate PR.
-            string source = @"
+            string source = """
                 #c++-prototypes
                 static void cpp_method();
                 #/c++prototypes
@@ -71,12 +71,32 @@ namespace Perlang.Tests.Integration.InlineCpp
                     puts(""cpp_method output"");
                 }
                 #/c++methods
-            ";
+                """;
 
             var output = EvalReturningOutput(source);
 
             output.Should()
                 .Equal("cpp_method output");
+        }
+
+        [Fact(DisplayName = "C++ method can contain C++ comment")]
+        public void cpp_method_can_contain_cpp_comment()
+        {
+            string source = """
+                #c++-methods
+                void native_main(int argc, const char **argv)
+                {
+                    // TODO: range check
+                    const char* first_argument = argv[0];
+                }
+                #/c++-methods
+                """;
+
+            // The above code used to give a 'Expected '/c++-methods' but got '// TODO: range check'.' error.
+            var result = EvalWithParseErrorCatch(source);
+
+            result.Errors.Should()
+                .BeEmpty();
         }
     }
 }


### PR DESCRIPTION
There was a problem in parsing the end of the preprocessor directives, causing certain C++ constructs to fail.