### PR TITLE
(compiler) Add `--idempotent` flag

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -29,6 +29,7 @@
 - Support `ASCIIString+string` and `UTF8String+string` concatenation [[#480][480]]
 - Fix bug in C++ preprocessor parsing [[#481][481]]
 - Add `-o` flag for overriding the compiled output path [[#482][482]]
+- Add `--idempotent` flag [[#486][486]]
 
 ### Changed
 #### Data types
@@ -77,3 +78,4 @@
 [480]: https://github.com/perlang-org/perlang/pull/480
 [481]: https://github.com/perlang-org/perlang/pull/481
 [482]: https://github.com/perlang-org/perlang/pull/482
+[486]: https://github.com/perlang-org/perlang/pull/486

--- a/src/Perlang.Common/Compiler/CompilerFlags.cs
+++ b/src/Perlang.Common/Compiler/CompilerFlags.cs
@@ -18,8 +18,14 @@ public enum CompilerFlags
     CacheDisabled = 1,
 
     /// <summary>
-    /// This flag which makes the compiler remove the `main` method if it is empty. This
-    /// can be useful e.g. when the `main` method is implemented in C++.
+    /// This flag which makes the compiler remove the `main` method if it is empty. This can be useful e.g. when the
+    /// `main` method is implemented in C++.
     /// </summary>
-    RemoveEmptyMainMethod = 2
+    RemoveEmptyMainMethod = 2,
+
+    /// <summary>
+    /// This flag makes the compiler avoid writing timestamps and the Perlang compiler version to generated C++ files.
+    /// This is useful when these files are committed to version control, to avoid redundant diffs.
+    /// </summary>
+    Idempotent = 4
 }

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -527,11 +527,19 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
             // The AST traverser writes its output to the transpiledSource field.
             Compile(statements);
 
-            using (StreamWriter streamWriter = File.CreateText(targetCppFile))
-            {
+            using (StreamWriter streamWriter = File.CreateText(targetCppFile)) {
+                string headerLine;
+
+                if (compilerFlags.HasFlag(CompilerFlags.Idempotent)) {
+                    headerLine = "Automatically generated code by Perlang";
+                }
+                else {
+                    headerLine = $"Automatically generated code by Perlang {CommonConstants.InformationalVersion} at {DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)}";
+                }
+
                 // Write standard file header, which includes everything our transpiled code might expect.
                 streamWriter.Write($"""
-// Automatically generated code by Perlang {CommonConstants.InformationalVersion} at {DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)}
+// {headerLine}
 // Do not modify. Changes to this file might be overwritten the next time the Perlang compiler is executed.
 
 #include <math.h> // fmod()


### PR DESCRIPTION
This is useful when committing the generated C++ files to version control, which we will soon start doing ourselves. :slightly_smiling_face: 