### PR TITLE
(common) Make Initializer property be nullable

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -40,6 +40,7 @@
 - Remove custom `IConsole` implementations [[#456][456]]
 - Use `VisitorBase` everywhere applicable [[#459][459]]
 - Minor stdlib cleanups [[#476][476]]
+- Make `Initializer` property be nullable [[#490][490]]
 
 #### Maintenance
 - Remove unused methods [[#491][491]]
@@ -82,4 +83,5 @@
 [482]: https://github.com/perlang-org/perlang/pull/482
 [486]: https://github.com/perlang-org/perlang/pull/486
 [488]: https://github.com/perlang-org/perlang/pull/488
+[490]: https://github.com/perlang-org/perlang/pull/490
 [491]: https://github.com/perlang-org/perlang/pull/491

--- a/src/Perlang.Common/Stmt.cs
+++ b/src/Perlang.Common/Stmt.cs
@@ -150,12 +150,10 @@ namespace Perlang
         public class Var : Stmt
         {
             public Token Name { get; }
-            public Expr Initializer { get; }
+            public Expr? Initializer { get; }
             public ITypeReference TypeReference { get; }
 
-            public bool HasInitializer => Initializer != null;
-
-            public Var(Token name, Expr initializer, TypeReference typeReference)
+            public Var(Token name, Expr? initializer, TypeReference typeReference)
             {
                 Name = name;
                 Initializer = initializer;

--- a/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
+++ b/src/Perlang.Interpreter/Compiler/PerlangCompiler.cs
@@ -1542,7 +1542,7 @@ public class PerlangCompiler : Expr.IVisitor<object?>, Stmt.IVisitor<VoidObject>
 
         currentMethod.Append($"{Indent(indentationLevel)}{stmt.TypeReference.PossiblyWrappedCppType} {variableName}");
 
-        if (stmt.HasInitializer)
+        if (stmt.Initializer != null)
         {
             currentMethod.AppendLine($" = {stmt.Initializer.Accept(this)};");
         }

--- a/src/Perlang.Interpreter/Internals/AstPrinter.cs
+++ b/src/Perlang.Interpreter/Internals/AstPrinter.cs
@@ -196,7 +196,7 @@ namespace Perlang.Interpreter.Internals
 
         public string VisitVarStmt(Stmt.Var stmt)
         {
-            if (!stmt.HasInitializer)
+            if (stmt.Initializer == null)
             {
                 return Parenthesize2("var", stmt.Name);
             }

--- a/src/Perlang.Interpreter/Typing/TypeResolver.cs
+++ b/src/Perlang.Interpreter/Typing/TypeResolver.cs
@@ -777,7 +777,7 @@ namespace Perlang.Interpreter.Typing
 
             if (!stmt.TypeReference.IsResolved &&
                 !stmt.TypeReference.ExplicitTypeSpecified &&
-                stmt.HasInitializer)
+                stmt.Initializer != null)
             {
                 // An explicit type has not been provided. Try inferring it from the type of value provided.
                 stmt.TypeReference.ClrType = stmt.Initializer.TypeReference.ClrType;


### PR DESCRIPTION
It was already nullable in practice. This change adjusts the code to take this into account.