### PR TITLE
(many) Remove `char_at()` kludge

### DIFF
--- a/release-notes/v0.5.0.md
+++ b/release-notes/v0.5.0.md
@@ -30,6 +30,7 @@
 - Fix bug in C++ preprocessor parsing [[#481][481]]
 - Add `-o` flag for overriding the compiled output path [[#482][482]]
 - Add `--idempotent` flag [[#486][486]]
+- Remove char_at kludge [[#493][493]]
 
 ### Changed
 #### Data types
@@ -89,3 +90,4 @@
 [490]: https://github.com/perlang-org/perlang/pull/490
 [491]: https://github.com/perlang-org/perlang/pull/491
 [492]: https://github.com/perlang-org/perlang/pull/492
+[493]: https://github.com/perlang-org/perlang/pull/493

--- a/src/stdlib/src/ascii_string.cc
+++ b/src/stdlib/src/ascii_string.cc
@@ -194,14 +194,6 @@ namespace perlang
         return from_owned_string(bytes, length);
     }
 
-    char ASCIIString::char_at(int index) const
-    {
-        // The reason this method exists is that the construct below would be slightly more awkward to generate from
-        // PerlangCompiler.cs. It's easier to just add an extra char_at() method call when it visits the Expr.Index
-        // expression.
-        return (*this)[index];
-    }
-
     std::shared_ptr<const ASCIIString> operator+(const int64_t lhs, const ASCIIString& rhs)
     {
         std::string str = std::to_string(lhs);

--- a/src/stdlib/src/ascii_string.h
+++ b/src/stdlib/src/ascii_string.h
@@ -111,10 +111,6 @@ namespace perlang
         [[nodiscard]]
         std::shared_ptr<const String> operator+(const BigInt& rhs) const override;
 
-        // Alias for [], which is easier to use from Perlang-generated C++ code in a pointer context.
-        [[nodiscard]]
-        char char_at(int index) const;
-
      private:
         // The backing byte array for this string. This is to be considered immutable and MUST NOT be modified at any
         // point. There might be multiple ASCIIString objects pointing to the same `bytes_`, so modifying one of them


### PR DESCRIPTION
This was a workaround to the fact that unwrapping a `std::shared_ptr` seemed awkward at the time. However, doing it like this is actually quite straightforward and feels like a great cleanup. It also means we don't have to pollute the public API in `ASCIIString`, which is a great improvement.