### PR TITLE
(ci) Upgrade to `macos-13` CI runner image

### DIFF
--- a/.github/workflows/perlang-install.yml
+++ b/.github/workflows/perlang-install.yml
@@ -10,7 +10,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-11
+          - macos-13
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
macOS 11 support has been dropped in the GitHub-hosted CI runners: https://github.com/actions/runner-images/issues/9255. This has the unpleasant effect of breaking all our CI until this gets merged.