### PR TITLE
(ci) Fix two bugs in package building

### DIFF
--- a/.github/workflows/publish-snapshot-packages.yml
+++ b/.github/workflows/publish-snapshot-packages.yml
@@ -50,8 +50,16 @@ jobs:
       - name: Build host-compatible release
         run: dotnet build
 
+      # This is needed to be able to run `perlang -v` a few commands below
+      - name: Build Perlang CLI shared library and copy to debug directory
+        run: make perlang_cli_install_debug
+
       - name: Build ${{ matrix.arch }} release
         run: dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r ${{ matrix.arch }} --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
+
+      # We need perlang_cli.so to be present in the published snapshot
+      - name: Build Perlang CLI shared library and copy to release directory
+        run: make perlang_cli_install_release ARCH=${{ matrix.arch }}
 
       - name: Rebuild stdlib
         run: make stdlib && cp -rv lib src/Perlang.ConsoleApp/bin/Release/net7.0/${{ matrix.arch }}/publish

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@
 
 .PRECIOUS: %.cc
 
+# This gets overridden in CI when building for another architecture
+ARCH=linux-x64
+
 DEBUG_PERLANG_DIRECTORY=src/Perlang.ConsoleApp/bin/Debug/net7.0
 DEBUG_PERLANG=$(DEBUG_PERLANG_DIRECTORY)/perlang
 
-RELEASE_PERLANG_DIRECTORY=src/Perlang.ConsoleApp/bin/Release/net7.0/linux-x64/publish
+RELEASE_PERLANG_DIRECTORY=src/Perlang.ConsoleApp/bin/Release/net7.0/$(ARCH)/publish
 RELEASE_PERLANG=$(RELEASE_PERLANG_DIRECTORY)/perlang
 
 # Enable fail-fast in case of errors
@@ -24,7 +27,7 @@ all: auto-generated perlang_cli
 	dotnet build
 
 release:
-	dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$$(pwd)/
+	dotnet publish src/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r $(ARCH) --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$$(pwd)/
 
 auto-generated: src/Perlang.Common/CommonConstants.Generated.cs
 


### PR DESCRIPTION
- The first bug was critical. The fact that `perlang_cli.so` wasn't being built meant that `perlang -v` would subsequently fail, failing the whole snapshot building and publishing.

- Equally important but more subtle in nature, the `perlang_cli.so` was also not properly included in the generated `tar.gz` files. This meant that the binaries would not work properly, even if `.tar.gz` files would have been generated.